### PR TITLE
Support benchmarking UCC backend through PyTorch in PARAM-Comms

### DIFF
--- a/train/comms/pt/comms.py
+++ b/train/comms/pt/comms.py
@@ -47,10 +47,6 @@ class commsCollBench(paramCommsBench):
         )  # number of iterations
         # experiment related parameters
         parser.add_argument(
-            "--backend", type=str, default=("nccl" if self.isCudaAvail() else "mpi"),
-            help="The backend to be used in PyTorch distributed process group"
-        )  # alternative is DLRM mode.
-        parser.add_argument(
             "--mode", type=str, default="comms",
             help="benchmark mode"
         )  # alternative is DLRM mode or comm-compute mode
@@ -469,10 +465,9 @@ class commsCollBench(paramCommsBench):
     def runBench(self, comms_world_info, commsParams):
         # Init the desired backend
         if commsParams.nw_stack == "pytorch-nccl":
-            from pytorch_nccl_backend import PyTorchNCCLBackend
-            #from param_bench.train.comms.pt.fb.pytorch_nccl_backend import PyTorchNCCLBackend
+            from pytorch_dist_backend import PyTorchDistBackend
 
-            backendObj = PyTorchNCCLBackend(comms_world_info, commsParams)
+            backendObj = PyTorchDistBackend(comms_world_info, commsParams)
         elif commsParams.nw_stack == "pytorch-xla-tpu":
             from tpu_backend import PyTorchTPUBackend
 

--- a/train/comms/pt/comms_utils.py
+++ b/train/comms/pt/comms_utils.py
@@ -391,6 +391,11 @@ class paramCommsBench(ABC):
             "--num-tpu-cores", type=int, default=1,
             help="number of TPU cores to be used"
         )  # number of TPU cores
+        parser.add_argument(
+            "--backend", type=str, default=("nccl" if self.isCudaAvail() else "mpi"),
+            help="The backend to be used in PyTorch distributed process group",
+            choices=["nccl","gloo","mpi","ucc"]
+        )  #  backend used for the network stack
         pass
 
     @abstractmethod

--- a/train/comms/pt/dlrm.py
+++ b/train/comms/pt/dlrm.py
@@ -21,7 +21,7 @@ import json
 import subprocess
 
 import dlrm_data as dd
-from pytorch_nccl_backend import PyTorchNCCLBackend
+from pytorch_dist_backend import PyTorchDistBackend
 import comms_utils as comms_utils
 from comms_utils import paramCommsBench
 
@@ -1039,7 +1039,7 @@ class commsDLRMBench(paramCommsBench):
         if(self.expt_config['nw_stack'] == "pytorch-nccl"):
             # WARNING: expt_config is different from commsParams but using it as a placeholder here!
             # FIXME: can we make it common
-            self.backendFuncs = PyTorchNCCLBackend(comms_world_info, self.expt_config)
+            self.backendFuncs = PyTorchDistBackend(comms_world_info, self.expt_config)
             self.backendFuncs.initialize_backend(comms_world_info.master_ip, comms_world_info.master_port, backend="nccl")
         else:
             print("\t Input backend: %s not supported! " % (self.expt_config['nw_stack']))

--- a/train/comms/pt/pytorch_dist_backend.py
+++ b/train/comms/pt/pytorch_dist_backend.py
@@ -39,7 +39,7 @@ def _dequantize(obj):
         return [obj.value()[0].to(torch.float32)]
 
 
-class PyTorchNCCLBackend(backendFunctions):
+class PyTorchDistBackend(backendFunctions):
     def sayHello(self):
         myhost = os.uname()[1]
         global_rank = self.get_global_rank()


### PR DESCRIPTION
Summary:
Update `--backend` argument to accept `ucc` as a valid option
  - utilize `PyTorchNCCLBackend` for calling collectives UCC PG
  - move `--backend` option to a common option for all comms benchs
  - use generic name `PyTorchDistBackend` instead of `PyTorchNCCLBackend` to support NCCL, UCC, MPI, and Gloo backends

Differential Revision: D24433491

