### PR TITLE
Fix issue of device option for DLRM bench in PARAM-Comms

### DIFF
--- a/train/comms/pt/comms.py
+++ b/train/comms/pt/comms.py
@@ -470,7 +470,6 @@ class commsCollBench(paramCommsBench):
         # Init the desired backend
         if commsParams.nw_stack == "pytorch-nccl":
             from pytorch_nccl_backend import PyTorchNCCLBackend
-            #from param_bench.train.comms.pt.fb.pytorch_nccl_backend import PyTorchNCCLBackend
 
             backendObj = PyTorchNCCLBackend(comms_world_info, commsParams)
         elif commsParams.nw_stack == "pytorch-xla-tpu":

--- a/train/comms/pt/dlrm.py
+++ b/train/comms/pt/dlrm.py
@@ -1103,6 +1103,7 @@ class commsDLRMBench(paramCommsBench):
         self.expt_config['nw_stack'] = args.nw_stack
         self.expt_config['collective'] = 'all_reduce'  # dummy params for now
         self.expt_config['warmup_batches'] = args.warmup_batches
+        self.expt_config['device'] = "cuda"
 
         if(mpi_env_params['global_rank'] == 0):
             print("\t expt_config: %s " % (self.expt_config))


### PR DESCRIPTION
Summary: Add a quick workaround of device selection for DLRM benchmark, which only support cuda now. Fix #12

Differential Revision: D24690816

