### PR TITLE
add ucc plugin to comms

### DIFF
--- a/train/comms/pt/comms_utils.py
+++ b/train/comms/pt/comms_utils.py
@@ -277,6 +277,7 @@ class commsParamsHolder:
         self.dst = args.root
 
         self.backend = args.backend
+        self.enable_ucc_plugin = args.enable_ucc_plugin
         self.numWarmupIters = args.w
         self.numIters = args.n
         self.collective = args.collective
@@ -427,6 +428,12 @@ class paramCommsBench(ABC):
             help="The backend to be used in PyTorch distributed process group",
             choices=["nccl", "gloo", "mpi", "ucc", "xla"],
         )  #  backend used for the network stack
+        parser.add_argument(
+            "--enable-ucc-plugin",
+            action="store_true",
+            default=False,
+            help="If backend is plugin based, ignored for non-ucc backends",
+        )  # does backend use plugin
         pass
 
     @abstractmethod


### PR DESCRIPTION
Summary:
add a mechanism to load torch-ucc plugin into comms when the following flags
are used [for fb builds only]
  --backend ucc --enable-ucc-plugin
It should have no effect on the old behavior when just
  --backend ucc
is used. ucc support is expected to be delivered as
torch_ucc module or as part of runtime in c10d

Differential Revision: D25507910

