### PR TITLE
fix collective overlap test

### DIFF
--- a/train/comms/pt/comms.py
+++ b/train/comms/pt/comms.py
@@ -1045,11 +1045,11 @@ class commsCollBench(paramCommsBench):
                     if (commsParams.collective_pair == "all_to_all") or (
                         commsParams.collective_pair == "all_to_allv"
                     ):
-                        results[curSize]["num_elements"] = int(
+                        results[curSize]["num_elements_pair"] = int(
                             numElements // world_size
                         )
                     else:
-                        results[curSize]["num_elements"] = int(numElements)
+                        results[curSize]["num_elements_pair"] = int(numElements)
                         results[curSize]["x_pair"] = x_pair
             else:
                 (


### PR DESCRIPTION
Fixing
Traceback (most recent call last):
  File param/train/comms/pt/comms.py", line 1050, in <module>
    main()
  File "param/train/comms/pt/comms.py", line 1046, in main
    collBenchObj.runBench(comms_world_info, commsParams)
  File "param/train/comms/pt/comms.py", line 998, in runBench
    backendObj.benchmark_comms()
  File "param/train/comms/pt/pytorch_dist_backend.py", line 520, in benchmark_comms
    self.commsParams.benchTime(index, self.commsParams, self)
  File "param/train/comms/pt/comms.py", line 965, in benchTime
    commsParams, allSizes, tensorList, results
  File "param/train/comms/pt/comms.py", line 714, in reportBenchTime
    str("%d" % (results[curSize]["num_elements_pair"])),
KeyError: 'num_elements_pair'
