### PR TITLE
ata validation check for reduce_scatter and comms replay

### DIFF
--- a/train/comms/pt/comms.py
+++ b/train/comms/pt/comms.py
@@ -27,6 +27,7 @@ supportedCollectives = [
     "all_gather",
     "broadcast",
     "reduce_scatter",
+    "reduce_scatter_base",
     "all_gather_base",
     "incast",
     "multicast",

--- a/train/comms/pt/commsTraceReplay.py
+++ b/train/comms/pt/commsTraceReplay.py
@@ -521,6 +521,12 @@ class commsTraceReplayBench(paramCommsBench):
                     coll_in_batch_num = 0
                     self.batchLat.append(batch_latency)
 
+            # perfom data validation check on the final opTensor
+            if self.is_blocking and commsParams.dcheck == 1 and collName not in ("wait","barrier"):
+                commsParams.collective = collName
+                commsParams.srcOrDst = curComm["root"] if "root" in curComm else 0
+                self.dcheck(commsParams, curComm["out_msg_size"], self.collectiveArgs.opTensor)
+
             self.collLat[collName].append(latency)
 
             curComm["seqnum"] = cnt

--- a/train/comms/pt/comms_utils.py
+++ b/train/comms/pt/comms_utils.py
@@ -278,7 +278,9 @@ def paramToCommName(name, supported_comms=None):
         new_name = name
 
     if supported_comms is not None and new_name not in supported_comms:
-        gracefulExit(f"{name} is not a supported communication in PARAM! Supported comms: {supported_comms}")
+        gracefulExit(
+            f"{name} is not a supported communication in PARAM! Supported comms: {supported_comms}"
+        )
 
     return new_name
 
@@ -347,7 +349,7 @@ class backendFunctions(ABC):
             "all_gather_base": self.all_gather_base,
             "reduce": self.reduce,
             "reduce_scatter": self.reduce_scatter,
-            "reduce_scatter_base": self.reduce_scatter,
+            "reduce_scatter_base": self.reduce_scatter_base,
             "barrier": self.barrier,
             "incast": self.incast,
             "multicast": self.multicast,
@@ -368,6 +370,7 @@ class backendFunctions(ABC):
             "all_to_allv",
             "all_gather",
             "reduce_scatter",
+            "reduce_scatter_base",
             "all_gather_base",
         ):
             if collectiveArgs.world_size != 0:
@@ -648,7 +651,10 @@ class paramCommsBench(ABC):
 
     def dcheck(self, commsParams, curSize, tensor):
         expRes = self.initVal
-        if (commsParams.collective == "all_reduce") or (
+        if (
+            commsParams.collective
+            in ("all_reduce", "reduce_scatter", "reduce_scatter_base")
+        ) or (
             self.backendFuncs.get_global_rank() == commsParams.srcOrDst
             and commsParams.collective == "reduce"
         ):
@@ -695,7 +701,7 @@ class paramCommsBench(ABC):
                 else newVal
             )
         elif isinstance(tensor, list):
-            # could be a list of tensor, for all_gather/gather
+            # could be a list of tensor, for all_gather, gather, reduce_scatter
             for t in tensor:
                 t[:] = newVal
         else:
@@ -712,7 +718,8 @@ class paramCommsBench(ABC):
             return ([], [])
 
         numElementsIn = curComm["in_msg_size"]
-        numElementsOut = curComm["out_msg_size"] # only meaningful for out-of-place collectives and pt2pt
+        # numElementsOut is only meaningful for out-of-place collectives and pt2pt
+        numElementsOut = curComm["out_msg_size"]
         world_size = self.collectiveArgs.world_size
         dtype = commsParams.dtype
         curDevice = commsParams.device
@@ -769,11 +776,36 @@ class paramCommsBench(ABC):
         elif commOp == "reduce_scatter":
             opTensor = ipTensor
             ipTensor = []
-            for _ in range(world_size):
-                ipTensor.append(
-                    self.backendFuncs.alloc_random(
-                        [numElementsOut], curDevice, dtype, scaleFactor
+            if commsParams.dcheck == 1:
+                for _ in range(world_size):
+                    ipTensor.append(
+                        self.backendFuncs.alloc_ones(
+                            [numElementsOut], curDevice, commsParams.dtype, self.initVal
+                        )
                     )
+            else:
+                for _ in range(world_size):
+                    ipTensor.append(
+                        self.backendFuncs.alloc_random(
+                            [numElementsOut], curDevice, commsParams.dtype, scaleFactor
+                        )
+                    )
+        elif commOp == "reduce_scatter_base":
+            opTensor = ipTensor
+            ipTensor = []
+            if commsParams.dcheck == 1:
+                ipTensor = self.backendFuncs.alloc_ones(
+                    numElementsOut * world_size,
+                    curDevice,
+                    commsParams.dtype,
+                    self.initVal,
+                )
+            else:
+                ipTensor = self.backendFuncs.alloc_random(
+                    numElementsOut * world_size,
+                    curDevice,
+                    commsParams.dtype,
+                    scaleFactor,
                 )
         elif commOp in ("all_to_all", "pt2pt"):
             # pt2pt or out-of-place collectives

--- a/train/comms/pt/pytorch_dist_backend.py
+++ b/train/comms/pt/pytorch_dist_backend.py
@@ -252,6 +252,20 @@ class PyTorchDistBackend(backendFunctions):
         if retFlag:
             return retObj
 
+    def reduce_scatter_base(self, collectiveArgs, retFlag=False, pair=False):
+        retObj = dist._reduce_scatter_base(
+            output=collectiveArgs.opTensor,
+            input=collectiveArgs.ipTensor,
+            group=collectiveArgs.group,
+            async_op=collectiveArgs.asyncOp,
+        )  # synchronicity is maintained in runColl
+
+        if collectiveArgs.asyncOp:
+            collectiveArgs.waitObj.append(retObj)
+
+        if retFlag:
+            return retObj
+
     def all_gather_base(self, collectiveArgs, retFlag=False, pair=False):
         retObj = dist._all_gather_base(
             output_tensor=collectiveArgs.opTensor,


### PR DESCRIPTION
Summary: 
- add validation check for commsTraceReplay
- add validation check for reduce_scatter and reduce_scatter_base
- support for reduce_scatter_base (i.e., reduce_scatter w/ flatten tensors)
  - pass `--collective reduce_scatter_base` to use it

Differential Revision: D30920209

