### PR TITLE
reproduce UCC error at exit

### DIFF
--- a/train/comms/pt/comms.py
+++ b/train/comms/pt/comms.py
@@ -1225,11 +1225,11 @@ class commsCollBench(paramCommsBench):
                     if (commsParams.collective_pair == "all_to_all") or (
                         commsParams.collective_pair == "all_to_allv"
                     ):
-                        results[curSize]["num_elements"] = int(
+                        results[curSize]["num_elements_pair"] = int(
                             numElements // world_size
                         )
                     else:
-                        results[curSize]["num_elements"] = int(numElements)
+                        results[curSize]["num_elements_pair"] = int(numElements)
                         results[curSize]["x_pair"] = x_pair
             else:
                 (

--- a/train/comms/pt/pytorch_dist_backend.py
+++ b/train/comms/pt/pytorch_dist_backend.py
@@ -616,7 +616,7 @@ class PyTorchDistBackend(backendFunctions):
         self.commsParams.benchTime(index, self.commsParams, self)
         return
 
-    def __del__(self):
-        if dist.is_initialized():
-            dist.destroy_process_group()
-        pass
+    # def __del__(self):
+    #     if dist.is_initialized():
+    #         dist.destroy_process_group()
+    #     pass


### PR DESCRIPTION
Summary:
[This is for debug purpose, **DO NOT MERGE**]

Error happens when there are more than 2 PGs created and not destroying them explicitly/properly at exit

sample reproducer: `mpirun -np 16 <any MPI variables> python comms.py --backend ucc --device cuda --collective all_to_allv --e 1M --collective-pair all_to_allv --collective-pair-size 8K --overlap-pair-pgs 1 --pair 1`

Differential Revision: D31291835

