### PR TITLE
Change benchmark time unit to millisecond

### DIFF
--- a/train/compute/python/README.md
+++ b/train/compute/python/README.md
@@ -140,7 +140,7 @@ For each **`"build"`** and **`"input"`** configuration, the __`"args"`__ and __`
 ```json
 {
   "torch.baddbmm": {
-    "input_data_generator": "PyTorch::DefaultDataGenerator",
+    "input_data_generator": "PyTorch:DefaultDataGenerator",
     "config": [
       {
         "input": [

--- a/train/compute/python/development.md
+++ b/train/compute/python/development.md
@@ -158,7 +158,7 @@ In above example of a tensor argument, its shape's value at element index `0` (w
 The role of the data generator is given a configuration specification, it generates actual data (scalar, boolean, string, tensor, etc.) for building or executing an operator.
 
 In current implementations we provide a default data generator that supports PyTorch data types (see [PyTorch Data Types](#pyTorch-data-types)):
-* [`PyTorch::DefaultDataGenerator`](lib/pytorch/data_impl.py)
+* [`PyTorch:DefaultDataGenerator`](lib/pytorch/data_impl.py)
 
 If needed, it's possible to implement custom data generators based on the [`DataGenerator`](lib/data.py) interface. They can be registered using
 [`register_data_generator(name: str, data_gen_class: Type[DataGenerator])`](lib/data.py).

--- a/train/compute/python/examples/pytorch/configs/alex_net.json
+++ b/train/compute/python/examples/pytorch/configs/alex_net.json
@@ -1,24 +1,20 @@
 {
-  "torch.add": {
+  "pytorch.model.alex_net": {
+    "build_data_generator": "PyTorch:DefaultDataGenerator",
     "input_data_generator": "PyTorch:DefaultDataGenerator",
     "config": [
       {
+        "build": [],
         "input": [
           {
             "args": [
               {
                 "dtype": "float",
                 "shape": [
-                  256,
-                  256
-                ],
-                "type": "tensor"
-              },
-              {
-                "dtype": "float",
-                "shape": [
-                  256,
-                  256
+                  128,
+                  3,
+                  224,
+                  224
                 ],
                 "type": "tensor"
               }

--- a/train/compute/python/examples/pytorch/configs/batch_example.json
+++ b/train/compute/python/examples/pytorch/configs/batch_example.json
@@ -2,7 +2,7 @@
   "op_name": "torch.add",
   "build_id": "1:2",
   "op_info": {
-    "input_data_generator": "PyTorch::DefaultDataGenerator",
+    "input_data_generator": "PyTorch:DefaultDataGenerator",
     "config": [
       {
         "input": [

--- a/train/compute/python/examples/pytorch/configs/mm.json
+++ b/train/compute/python/examples/pytorch/configs/mm.json
@@ -1,6 +1,6 @@
 {
   "torch.baddbmm": {
-    "input_data_generator": "PyTorch::DefaultDataGenerator",
+    "input_data_generator": "PyTorch:DefaultDataGenerator",
     "config": [
       {
         "input": [
@@ -91,7 +91,7 @@
     ]
   },
   "torch.bmm": {
-    "input_data_generator": "PyTorch::DefaultDataGenerator",
+    "input_data_generator": "PyTorch:DefaultDataGenerator",
     "config": [
       {
         "input": [
@@ -210,7 +210,7 @@
     ]
   },
   "torch.mm": {
-    "input_data_generator": "PyTorch::DefaultDataGenerator",
+    "input_data_generator": "PyTorch:DefaultDataGenerator",
     "config": [
       {
         "input": [
@@ -219,16 +219,16 @@
               {
                 "dtype": "float",
                 "shape": [
-                  512,
-                  512
+                  1024,
+                  1024
                 ],
                 "type": "tensor"
               },
               {
                 "dtype": "float",
                 "shape": [
-                  512,
-                  3702
+                  1024,
+                  1024
                 ],
                 "type": "tensor"
               }

--- a/train/compute/python/examples/pytorch/configs/mm_range.json
+++ b/train/compute/python/examples/pytorch/configs/mm_range.json
@@ -1,7 +1,7 @@
 {
   "torch.baddbmm": {
     "input_iterator": "RangeConfigIterator",
-    "input_data_generator": "PyTorch::DefaultDataGenerator",
+    "input_data_generator": "PyTorch:DefaultDataGenerator",
     "config": [
       {
         "input": [
@@ -128,7 +128,7 @@
   },
   "torch.bmm": {
     "input_iterator": "RangeConfigIterator",
-    "input_data_generator": "PyTorch::DefaultDataGenerator",
+    "input_data_generator": "PyTorch:DefaultDataGenerator",
     "config": [
       {
         "input": [

--- a/train/compute/python/examples/pytorch/configs/simple_add_range.json
+++ b/train/compute/python/examples/pytorch/configs/simple_add_range.json
@@ -1,7 +1,7 @@
 {
   "torch.add": {
     "input_iterator": "RangeConfigIterator",
-    "input_data_generator": "PyTorch::DefaultDataGenerator",
+    "input_data_generator": "PyTorch:DefaultDataGenerator",
     "config": [
       {
         "input": [

--- a/train/compute/python/examples/pytorch/configs/simple_mm_range.json
+++ b/train/compute/python/examples/pytorch/configs/simple_mm_range.json
@@ -1,7 +1,7 @@
 {
   "torch.mm": {
     "input_iterator": "RangeConfigIterator",
-    "input_data_generator": "PyTorch::DefaultDataGenerator",
+    "input_data_generator": "PyTorch:DefaultDataGenerator",
     "config": [
       {
         "input": [

--- a/train/compute/python/examples/pytorch/configs/split_table_batched_embeddings_ops.json
+++ b/train/compute/python/examples/pytorch/configs/split_table_batched_embeddings_ops.json
@@ -2,7 +2,7 @@
   "SplitTableBatchedEmbeddingBagsCodegen": {
     "build_iterator": "RangeConfigIterator",
     "input_iterator": "SplitTableBatchedEmbeddingBagsCodegenInputIterator",
-    "build_data_generator": "PyTorch::DefaultDataGenerator",
+    "build_data_generator": "PyTorch:DefaultDataGenerator",
     "input_data_generator": "SplitTableBatchedEmbeddingBagsCodegenInputDataGenerator",
     "config": [
       {

--- a/train/compute/python/lib/iterator.py
+++ b/train/compute/python/lib/iterator.py
@@ -250,8 +250,7 @@ class DefaultConfigIterator(ConfigIterator):
         self.num_configs = len(self.configs)
 
     def __next__(self):
-        # check if this is in the op filter, skip if not
-        # loop through the different input variants
+        # loop through the different config variants
         if self.idx < self.num_configs:
             result = (self.idx, self.configs[self.idx])
             self.idx += 1

--- a/train/compute/python/lib/pytorch/config_util.py
+++ b/train/compute/python/lib/pytorch/config_util.py
@@ -1,8 +1,9 @@
 import copy
 import enum
+import os
 import platform
+import random
 import socket
-from datetime import datetime
 from typing import Any
 from typing import Dict
 from typing import List
@@ -32,6 +33,7 @@ def get_benchmark_options() -> Dict[str, Any]:
         "pass_type": ExecutionPass.FORWARD,
         "warmup": 1,
         "iteration": 1,
+        "time_unit": "millisecond",
         "out_file_prefix": None,
         "out_stream": None,
         "run_ncu": False,
@@ -52,7 +54,7 @@ def create_op_info() -> Dict[str, Any]:
         "build_iterator": None,
         "input_iterator": None,
         "build_data_generator": None,
-        "input_data_generator": "PyTorch::DefaultDataGenerator",
+        "input_data_generator": "PyTorch:DefaultDataGenerator",
         "config": [{"build": [], "input": []}],
     }
 
@@ -101,8 +103,9 @@ def get_sys_info():
         }
 
     return {
-        "timestamp": datetime.now().isoformat(timespec="seconds"),
         "hostname": socket.gethostname(),
+        "pid": os.getpid(),
+        "cwd": os.getcwd(),
         "python_version": platform.python_version(),
         "param_bench_version": param_bench_version,
         "cuda_available": cuda_available,
@@ -111,3 +114,12 @@ def get_sys_info():
         "pytorch_debug_build": torch.version.debug,
         "pytorch_build_config": torch._C._show_config(),
     }
+
+
+def init_pytorch(run_options: Dict[str, Any]):
+    # We don't want too many threads for stable benchmarks
+    torch.set_num_threads(1)
+
+    # Fix random number generator seeds.
+    torch.manual_seed(0)
+    random.seed(0)

--- a/train/compute/python/lib/pytorch/data_impl.py
+++ b/train/compute/python/lib/pytorch/data_impl.py
@@ -24,17 +24,18 @@ def materialize_arg(arg: Dict[str, Any], device: str) -> Any:
 
     def create_tensor(attr: Dict[str, Any]):
         shape = attr["shape"]
+        requires_grad = attr.get("requires_grad", True)
         if len(shape) > 0:
             if attr["dtype"] == "float" or attr["dtype"] == "double":
                 return torch.rand(
-                    *shape, requires_grad=True, device=torch.device(device)
+                    *shape, requires_grad=requires_grad, device=torch.device(device)
                 )
             elif attr["dtype"] == "int" or attr["dtype"] == "long":
                 return torch.randint(
                     -10,
                     10,
                     tuple(shape),
-                    requires_grad=True,
+                    requires_grad=requires_grad,
                     device=torch.device(device),
                 )
         # Single value
@@ -42,7 +43,7 @@ def materialize_arg(arg: Dict[str, Any], device: str) -> Any:
             return torch.tensor(
                 random.uniform(-10.0, 10.0),
                 dtype=pytorch_dtype_map[attr["dtype"]],
-                requires_grad=True,
+                requires_grad=requires_grad,
                 device=torch.device(device),
             )
 
@@ -155,7 +156,10 @@ class DefaultDataGenerator(DataGenerator):
                     self.op_kwargs[key] = materialize_arg(arg, device)
 
     def get_data(self, config: Dict[str, Any], device: str):
-        if self.cache:
+        if not config:
+            # No configs, just return empty args.
+            return (self.op_args, self.op_kwargs)
+        elif self.cache:
             # find the arg config that changed from previous iteration
             arg_updates, kwarg_updates = self._find_updates(config)
             # cache arg configs for next iteration to compare.
@@ -167,4 +171,4 @@ class DefaultDataGenerator(DataGenerator):
         return (self.op_args, self.op_kwargs)
 
 
-register_data_generator("PyTorch::DefaultDataGenerator", DefaultDataGenerator)
+register_data_generator("PyTorch:DefaultDataGenerator", DefaultDataGenerator)

--- a/train/compute/python/lib/pytorch/operator_impl.py
+++ b/train/compute/python/lib/pytorch/operator_impl.py
@@ -1,21 +1,27 @@
+import gc
 from typing import Callable
+
+from ..init_helper import get_logger
+
+logger = get_logger()
 
 import torch
 
 from ..operator import OperatorInterface
 
 
-class InPlaceOpByName(OperatorInterface):
+class UnaryOp(OperatorInterface):
     """
-    Inplace ops is called in the form of tensor.op(args), we convert it
-    to a regular function call with "getattr(tensor, op)(args)"
+    UnaryOp is called in the form of tensor_obj.op(args), we convert it
+    to a regular function call with "getattr(tensor_obj, op)(args)". So the
+    first arg is assumed to be the `tensor_obj`.
     """
 
     def __init__(
         self,
         func_name: str,
     ):
-        super(InPlaceOpByName, self).__init__()
+        super(UnaryOp, self).__init__()
         self.func_name: str = func_name
         self.fwd_out: torch.tensor = None
         self.grad_in: torch.tensor = None
@@ -23,13 +29,15 @@ class InPlaceOpByName(OperatorInterface):
     def forward(self, *args, **kwargs):
         # The first arg is assume to be the inplace value, pass on the rest of
         # the args to the callable.
-        self.fwd_out = getattr(args[0], self.func_name)(*args[1:], **kwargs)
+        # Unary op also does not support backward() because they are in-place.
+        with torch.no_grad():
+            getattr(args[0], self.func_name)(*args[1:], **kwargs)
 
     def create_grad(self):
-        self.grad_in = torch.ones_like(self.fwd_out, device=torch.device(self.device))
+        pass
 
     def backward(self):
-        self.fwd_out.backward(self.grad_in)
+        pass
 
 
 class CallableOp(OperatorInterface):
@@ -46,12 +54,65 @@ class CallableOp(OperatorInterface):
         self.fwd_out: torch.tensor = None
         self.grad_in = None
 
+    def cleanup(self):
+        self.fwd_out = None
+        self.grad_in = None
+        gc.collect()
+
     def forward(self, *args, **kwargs):
         self.fwd_out = self.func(*args, **kwargs)
         return self.fwd_out
 
     def create_grad(self):
-        self.grad_in = torch.ones_like(self.fwd_out, device=torch.device(self.device))
+        if not self.fwd_out.is_leaf:
+            self.grad_in = torch.ones_like(self.fwd_out)
+        else:
+            logger.debug(f"{self.constructor.__name__}: skipping create_grad() due to forward result is leaf tensor.")
 
     def backward(self):
-        self.fwd_out.backward(self.grad_in)
+        if not self.fwd_out.is_leaf:
+            self.fwd_out.backward(self.grad_in)
+        else:
+            logger.debug(f"{self.constructor.__name__}: skipping backward() due to forward result is leaf tensor.")
+
+
+class BuildableOp(OperatorInterface):
+    """
+    BuildableOp are ops needs to be constructed first, before running with inputs.
+    """
+
+    def __init__(
+        self,
+        constructor: Callable,
+    ):
+        super(BuildableOp, self).__init__()
+        self.constructor: Callable = constructor
+        self.func: Callable = None
+        self.fwd_out: torch.tensor = None
+        self.grad_in = None
+
+    # Construct and initialize the operator.
+    def build(self, *args, **kwargs):
+        # Use `to` to make sure weights are on device.
+        self.func = self.constructor(*args, **kwargs).to(torch.device(self.device))
+
+    def cleanup(self):
+        self.fwd_out = None
+        self.grad_in = None
+        gc.collect()
+
+    def forward(self, *args, **kwargs):
+        self.fwd_out = self.func(*args, **kwargs)
+        return self.fwd_out
+
+    def create_grad(self):
+        if not self.fwd_out.is_leaf:
+            self.grad_in = torch.ones_like(self.fwd_out)
+        else:
+            logger.debug(f"{self.constructor.__name__}: skipping create_grad() due to forward result is leaf tensor.")
+
+    def backward(self):
+        if not self.fwd_out.is_leaf:
+            self.fwd_out.backward(self.grad_in)
+        else:
+            logger.debug(f"{self.constructor.__name__}: skipping backward() due to forward result is leaf tensor.")

--- a/train/compute/python/lib/pytorch/timer.py
+++ b/train/compute/python/lib/pytorch/timer.py
@@ -8,28 +8,18 @@ class Timer:
         self.device: str = device
         self.start_time: float = 0
         self.end_time: float = 0
-        self.start_event = None
-        self.end_event = None
 
     def __enter__(self):
-        if self.device == "cpu":
-            self.start_time = time.perf_counter()
-        else:
+        if self.device.startswith("cuda"):
             torch.cuda.synchronize()
-            self.start_event = torch.cuda.Event(enable_timing=True)
-            self.end_event = torch.cuda.Event(enable_timing=True)
-            self.start_event.record()
-            self.start_time = 0
+        self.start_time = time.perf_counter()
         return self
 
     def __exit__(self, type, value, traceback):
-        if self.device == "cpu":
-            self.end_time = time.perf_counter()
-        else:
-            self.end_event.record()
+        if self.device.startswith("cuda"):
             torch.cuda.synchronize()
-            self.end_time = self.start_event.elapsed_time(self.end_event) * 1.0e-3
+        self.end_time = time.perf_counter()
 
-    # returns time in seconds
-    def elapsed_time(self):
-        return self.end_time - self.start_time
+    # Return result in milliseconds.
+    def elapsed_time(self) -> float:
+        return (self.end_time - self.start_time) * 1000.0

--- a/train/compute/python/pytorch/run_batch.py
+++ b/train/compute/python/pytorch/run_batch.py
@@ -64,12 +64,12 @@ def main():
         return
 
     op_name = config["op_name"]
-    build_id = config["build_id"]
+    config_build_id = config["config_build_id"]
     op_info = config["op_info"]
     run_options = config["run_options"]
 
     logger.debug(f"op_name: {op_name}")
-    logger.debug(f"build_id: {build_id}")
+    logger.debug(f"config_build_id: {config_build_id}")
     logger.debug(f"op_info: {op_info}")
     logger.debug(f"run_options: {run_options}")
 
@@ -82,7 +82,7 @@ def main():
     with open(os.devnull, "w") as out_stream:
         run_options["out_stream"] = out_stream
         build_exe = MaterializedBuildExecutor(run_options)
-        build_exe.run(op_config, build_input_config, build_id)
+        build_exe.run(op_config, build_input_config, config_build_id)
 
 
 if __name__ == "__main__":

--- a/train/compute/python/test/pytorch/configs/test_native_basic_ops.json
+++ b/train/compute/python/test/pytorch/configs/test_native_basic_ops.json
@@ -1,6 +1,64 @@
 {
+  "torch.add_": {
+    "input_data_generator": "PyTorch:DefaultDataGenerator",
+    "config": [
+      {
+        "input": [
+          {
+            "args": [
+              {
+                "dtype": "float",
+                "shape": [
+                  256,
+                  256
+                ],
+                "type": "tensor"
+              },
+              {
+                "dtype": "float",
+                "shape": [
+                  256,
+                  256
+                ],
+                "type": "tensor"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "torch.clamp_": {
+    "input_data_generator": "PyTorch:DefaultDataGenerator",
+    "config": [
+      {
+        "input": [
+          {
+            "args": [
+              {
+                "dtype": "float",
+                "shape": [
+                  256,
+                  256
+                ],
+                "type": "tensor"
+              },
+              {
+                "type": "int",
+                "value": 0
+              },
+              {
+                "type": "int",
+                "value": 10
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
   "torch.add": {
-    "input_data_generator": "PyTorch::DefaultDataGenerator",
+    "input_data_generator": "PyTorch:DefaultDataGenerator",
     "config": [
       {
         "input": [
@@ -29,7 +87,7 @@
     ]
   },
   "torch.baddbmm": {
-    "input_data_generator": "PyTorch::DefaultDataGenerator",
+    "input_data_generator": "PyTorch:DefaultDataGenerator",
     "config": [
       {
         "input": [
@@ -79,7 +137,7 @@
     ]
   },
   "torch.bmm": {
-    "input_data_generator": "PyTorch::DefaultDataGenerator",
+    "input_data_generator": "PyTorch:DefaultDataGenerator",
     "config": [
       {
         "input": [
@@ -110,7 +168,7 @@
     ]
   },
   "torch.cat": {
-    "input_data_generator": "PyTorch::DefaultDataGenerator",
+    "input_data_generator": "PyTorch:DefaultDataGenerator",
     "config": [
       {
         "input": [
@@ -147,7 +205,7 @@
     ]
   },
   "torch.matmul": {
-    "input_data_generator": "PyTorch::DefaultDataGenerator",
+    "input_data_generator": "PyTorch:DefaultDataGenerator",
     "config": [
       {
         "input": [
@@ -176,7 +234,7 @@
     ]
   },
   "torch.mean": {
-    "input_data_generator": "PyTorch::DefaultDataGenerator",
+    "input_data_generator": "PyTorch:DefaultDataGenerator",
     "config": [
       {
         "input": [
@@ -197,7 +255,7 @@
     ]
   },
   "torch.mm": {
-    "input_data_generator": "PyTorch::DefaultDataGenerator",
+    "input_data_generator": "PyTorch:DefaultDataGenerator",
     "config": [
       {
         "input": [
@@ -226,7 +284,7 @@
     ]
   },
   "torch.mul": {
-    "input_data_generator": "PyTorch::DefaultDataGenerator",
+    "input_data_generator": "PyTorch:DefaultDataGenerator",
     "config": [
       {
         "input": [
@@ -251,7 +309,7 @@
     ]
   },
   "torch.nn.functional.relu": {
-    "input_data_generator": "PyTorch::DefaultDataGenerator",
+    "input_data_generator": "PyTorch:DefaultDataGenerator",
     "config": [
       {
         "input": [
@@ -272,7 +330,7 @@
     ]
   },
   "torch.reshape": {
-    "input_data_generator": "PyTorch::DefaultDataGenerator",
+    "input_data_generator": "PyTorch:DefaultDataGenerator",
     "config": [
       {
         "input": [
@@ -298,6 +356,197 @@
                     "value": 512
                   }
                 ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "torch.nn.Conv2d": {
+    "build_data_generator": "PyTorch:DefaultDataGenerator",
+    "input_data_generator": "PyTorch:DefaultDataGenerator",
+    "config": [
+      {
+        "build": [
+          {
+            "args": [
+              {
+                "type": "int",
+                "value": 3
+              },
+              {
+                "type": "int",
+                "value": 64
+              }
+            ],
+            "kwargs": {
+              "kernel_size": {
+                "type": "int",
+                "value": 11
+              },
+              "stride": {
+                "type": "int",
+                "value": 4
+              },
+              "padding": {
+                "type": "int",
+                "value": 2
+              }
+            }
+          }
+        ],
+        "input": [
+          {
+            "args": [
+              {
+                "dtype": "float",
+                "shape": [
+                  1,
+                  3,
+                  64,
+                  64
+                ],
+                "type": "tensor"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "torch.nn.Dropout": {
+    "build_data_generator": "PyTorch:DefaultDataGenerator",
+    "input_data_generator": "PyTorch:DefaultDataGenerator",
+    "config": [
+      {
+        "build": [
+          {
+            "args": [
+              {
+                "type": "float",
+                "value": 0.5
+              }
+            ]
+          }
+        ],
+        "input": [
+          {
+            "args": [
+              {
+                "dtype": "float",
+                "shape": [
+                  64,
+                  64
+                ],
+                "type": "tensor"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "torch.nn.MaxPool2d": {
+    "build_data_generator": "PyTorch:DefaultDataGenerator",
+    "input_data_generator": "PyTorch:DefaultDataGenerator",
+    "config": [
+      {
+        "build": [
+          {
+            "args": [
+              {
+                "type": "int",
+                "value": 3
+              },
+              {
+                "type": "int",
+                "value": 2
+              }
+            ]
+          }
+        ],
+        "input": [
+          {
+            "args": [
+              {
+                "dtype": "float",
+                "shape": [
+                  1,
+                  3,
+                  64,
+                  64
+                ],
+                "type": "tensor"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "torch.nn.ReLU": {
+    "build_data_generator": "PyTorch:DefaultDataGenerator",
+    "input_data_generator": "PyTorch:DefaultDataGenerator",
+    "config": [
+      {
+        "build": [
+          {
+            "args": [
+              {
+                "type": "bool",
+                "value": true
+              }
+            ]
+          }
+        ],
+        "input": [
+          {
+            "args": [
+              {
+                "dtype": "float",
+                "shape": [
+                  64,
+                  64
+                ],
+                "type": "tensor",
+                "requires_grad": false
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "torch.nn.Linear": {
+    "build_data_generator": "PyTorch:DefaultDataGenerator",
+    "input_data_generator": "PyTorch:DefaultDataGenerator",
+    "config": [
+      {
+        "build": [
+          {
+            "args": [
+              {
+                "type": "int",
+                "value": 64
+              },
+              {
+                "type": "int",
+                "value": 8
+              }
+            ]
+          }
+        ],
+        "input": [
+          {
+            "args": [
+              {
+                "dtype": "float",
+                "shape": [
+                  64,
+                  64
+                ],
+                "type": "tensor"
               }
             ]
           }

--- a/train/compute/python/workloads/pytorch/alex_net.py
+++ b/train/compute/python/workloads/pytorch/alex_net.py
@@ -1,0 +1,49 @@
+import torch
+import torch.nn as nn
+
+from ...lib.operator import register_operator
+from ...lib.pytorch.operator_impl import BuildableOp
+
+
+class AlexNet(nn.Module):
+    """
+    Ref: https://pytorch.org/vision/master/_modules/torchvision/models/alexnet.html
+    """
+
+    def __init__(self, num_classes: int = 1000, dropout: float = 0.5) -> None:
+        super().__init__()
+        self.features = nn.Sequential(
+            nn.Conv2d(3, 64, kernel_size=11, stride=4, padding=2),
+            nn.ReLU(inplace=True),
+            nn.MaxPool2d(kernel_size=3, stride=2),
+            nn.Conv2d(64, 192, kernel_size=5, padding=2),
+            nn.ReLU(inplace=True),
+            nn.MaxPool2d(kernel_size=3, stride=2),
+            nn.Conv2d(192, 384, kernel_size=3, padding=1),
+            nn.ReLU(inplace=True),
+            nn.Conv2d(384, 256, kernel_size=3, padding=1),
+            nn.ReLU(inplace=True),
+            nn.Conv2d(256, 256, kernel_size=3, padding=1),
+            nn.ReLU(inplace=True),
+            nn.MaxPool2d(kernel_size=3, stride=2),
+        )
+        self.avgpool = nn.AdaptiveAvgPool2d((6, 6))
+        self.classifier = nn.Sequential(
+            nn.Dropout(p=dropout),
+            nn.Linear(256 * 6 * 6, 4096),
+            nn.ReLU(inplace=True),
+            nn.Dropout(p=dropout),
+            nn.Linear(4096, 4096),
+            nn.ReLU(inplace=True),
+            nn.Linear(4096, num_classes),
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = self.features(x)
+        x = self.avgpool(x)
+        x = torch.flatten(x, 1)
+        x = self.classifier(x)
+        return x
+
+
+register_operator("pytorch.model.alex_net", BuildableOp(AlexNet))

--- a/train/compute/python/workloads/pytorch/native_basic_ops.py
+++ b/train/compute/python/workloads/pytorch/native_basic_ops.py
@@ -6,13 +6,13 @@ from ...lib.operator import (
     OperatorInterface,
     register_operators,
 )
-from ...lib.pytorch.operator_impl import CallableOp, InPlaceOpByName
+from ...lib.pytorch.operator_impl import CallableOp, UnaryOp, BuildableOp
 
 
 # Unary
 unary_ops: Dict[str, OperatorInterface] = {
-    "torch.add_": InPlaceOpByName("add_"),
-    "torch.clamp_": InPlaceOpByName("clamp_"),
+    "torch.add_": UnaryOp("add_"),
+    "torch.clamp_": UnaryOp("clamp_"),
 }
 register_operators(unary_ops)
 
@@ -29,3 +29,14 @@ callable_ops: Dict[str, OperatorInterface] = {
     "torch.reshape": CallableOp(torch.reshape),
 }
 register_operators(callable_ops)
+
+
+buildable_ops: Dict[str, OperatorInterface] = {
+    "torch.nn.AdaptiveAvgPool2d": BuildableOp(torch.nn.AdaptiveAvgPool2d),
+    "torch.nn.Conv2d": BuildableOp(torch.nn.Conv2d),
+    "torch.nn.Dropout": BuildableOp(torch.nn.Dropout),
+    "torch.nn.MaxPool2d": BuildableOp(torch.nn.MaxPool2d),
+    "torch.nn.ReLU": BuildableOp(torch.nn.ReLU),
+    "torch.nn.Linear": BuildableOp(torch.nn.Linear),
+}
+register_operators(buildable_ops)

--- a/train/compute/python/workloads/pytorch/split_table_batched_embeddings_ops.py
+++ b/train/compute/python/workloads/pytorch/split_table_batched_embeddings_ops.py
@@ -305,8 +305,6 @@ class SplitTableBatchedEmbeddingBagsCodegenOp(OperatorInterface):
         self.grad_in = None
         self.fwd_out = None
         gc.collect()
-        if self.device.startswith("cuda"):
-            torch.cuda.empty_cache()
 
     def forward(self, *args, **kwargs):
         self.fwd_out = self.op.forward(args[0], args[1], args[2])


### PR DESCRIPTION
Summary:
The nature of the microbenchmarks are intented to measure short duration workloads where each iteration range from a few seconds to a few hundred micro seconds. Using milliseconds unit is a middle ground to improve readability and less prone to losing precision between data conversions.

Also simplified GPU timer. The previous method will measure mostly the kernel time (through cuda event records) rather than CPU time, may not include a small amount of overhead in the runtime or operator.

Differential Revision: D32533223

