### PR TITLE
Improve benchmark runtime with data check

### DIFF
--- a/train/comms/pt/comms_utils.py
+++ b/train/comms/pt/comms_utils.py
@@ -678,17 +678,19 @@ class paramCommsBench(ABC):
         if isinstance(tensor, list):
             # for allgather and incast, it's a list of tensors:
             for (rank, t) in enumerate(tensor):
-                for (index, val) in enumerate(t):
+                if not torch.all(torch.eq(t, expRes)):
+                    for (index, val) in enumerate(t):
+                        if val != expRes:
+                            raise ValueError(
+                                f"[{curSize}-bytes {commsParams.collective}] Wrong value at [{rank}][{index}] = {t[index]}, expected {expRes}\n {tensor}"
+                            )
+        else:
+            if not torch.all(torch.eq(tensor, expRes)):
+                for (index, val) in enumerate(tensor):
                     if val != expRes:
                         raise ValueError(
-                            f"[{curSize}-bytes {commsParams.collective}] Wrong value at [{rank}][{index}] = {tensor[index]}, expected {expRes}\n {tensor}"
+                            f"[{curSize}-bytes {commsParams.collective}] Wrong value at [{index}] = {tensor[index]}, expected {expRes}\n {tensor}"
                         )
-        else:
-            for (index, val) in enumerate(tensor):
-                if val != expRes:
-                    raise ValueError(
-                        f"[{curSize}-bytes {commsParams.collective}] Wrong value at [{index}] = {tensor[index]}, expected {expRes}\n {tensor}"
-                    )
 
     def setTensorVal(self, tensor, useRandVal=True):
         newVal = random.random() if useRandVal else self.initVal


### PR DESCRIPTION
Add fast path to data check to see if tensors are different first.
Allgather 8 Ranks with data check without optimization
CPU --b 1K --e 1M: 52.046s
GPU --b 1K --e 2M: 8m 29.476s

Allgather 8 Ranks with data check with optimization
CPU --b 1K --e 1M: 7.730s
GPU --b 1K --e 2M: 8.375s

Also fixes "IndexError: list index out of range" for collectives with list of tensors when tensors are not equal
