### PR TITLE
remove num-batches from pytorch_linear

### DIFF
--- a/train/compute/pt/README.md
+++ b/train/compute/pt/README.md
@@ -85,8 +85,8 @@ invoked through --usexlabag
 Example: Measure the performance of a MLP with 18 hidden layer, layer size 1024
 ```bash
 python pytorch_linear.py --device gpu --layer-num 18  --batch-size 128 --input-size 1024 \
-       --hidden-size 1024  --output-size 1024 --num-batches 100 \
-       --data-type=float16 --optimizer-type=sgd
+       --hidden-size 1024  --output-size 1024 --steps 100 \
+       --dtype=float16 --optimizer-type=sgd
 ```
 
 ### Testing MLP Linear

--- a/train/compute/pt/pytorch_linear.py
+++ b/train/compute/pt/pytorch_linear.py
@@ -175,7 +175,6 @@ def run_single(args, layer_num, input_size, hidden_size, output_size, batch_size
     device = args.device
     optimizer_type = args.optimizer_type
     data_type = args.dtype
-    # num_batches = args.num_batches
 
     torch.manual_seed(1)
 
@@ -302,7 +301,6 @@ if __name__ == "__main__":
     parser.add_argument(
         "--output-size", type=int, default=1024, help="Output layer size"
     )
-    # parser.add_argument("--num-batches", type=int, default=100, help="Number of batches to train")
     parser.add_argument("--steps", type=int, default=100)
     parser.add_argument("--warmups", type=int, default=10)
 
@@ -312,7 +310,6 @@ if __name__ == "__main__":
     input_size = args.input_size
     hidden_size = args.hidden_size
     output_size = args.output_size
-    # num_batches = args.num_batches
 
     d = [(layer_num, input_size, hidden_size, output_size, batch_size)]
     run(args, d)


### PR DESCRIPTION
Summary: Change README.md to reflect num-batches option is no longer there

Differential Revision: D33317758

