### PR TITLE
GPU memory utilization, operator execution modes

### DIFF
--- a/train/compute/python/examples/pytorch/configs/simple_mm.json
+++ b/train/compute/python/examples/pytorch/configs/simple_mm.json
@@ -1,0 +1,31 @@
+{
+  "torch.mm": {
+    "input_data_generator": "PyTorch:DefaultDataGenerator",
+    "config": [
+      {
+        "input": [
+          {
+            "args": [
+              {
+                "dtype": "float",
+                "shape": [
+                  1024,
+                  1024
+                ],
+                "type": "tensor"
+              },
+              {
+                "dtype": "float",
+                "shape": [
+                  1024,
+                  1024
+                ],
+                "type": "tensor"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/train/compute/python/examples/pytorch/run_op.py
+++ b/train/compute/python/examples/pytorch/run_op.py
@@ -5,7 +5,7 @@ from ...lib.config import make_op_config
 from ...lib.init_helper import load_modules
 from ...lib.pytorch.config_util import (
     create_bench_config,
-    create_data,
+    create_type,
     create_op_args,
     ExecutionPass,
     get_benchmark_options,
@@ -28,9 +28,9 @@ def main():
 
     op_name = "torch.mm"
     bench_config = create_bench_config(op_name)
-    tensor_1 = create_data("tensor")
+    tensor_1 = create_type("tensor")
     tensor_1["shape"] = [128, 128]
-    tensor_2 = create_data("tensor")
+    tensor_2 = create_type("tensor")
     tensor_2["shape"] = [128, 128]
 
     op_info = bench_config[op_name]

--- a/train/compute/python/examples/pytorch/run_op_split_table_batched_embeddings.py
+++ b/train/compute/python/examples/pytorch/run_op_split_table_batched_embeddings.py
@@ -62,7 +62,7 @@ def main():
             {"type": "int", "name": "rows", "value": rows},
             {"type": "int", "name": "dim", "value": dim},
             {"type": "int", "name": "batch_size", "value": batch_size},
-            {"name": "pooling_factor", "type": "int", "value": pooling_factor},
+            {"type": "int", "name": "pooling_factor", "value": pooling_factor},
             {"type": "bool", "name": "weighted", "value": weighted},
             {"type": "str", "name": "weights_precision", "value": weights_precision},
         ],

--- a/train/compute/python/lib/pytorch/build_executor.py
+++ b/train/compute/python/lib/pytorch/build_executor.py
@@ -180,9 +180,7 @@ class OpBuildExecutor(BuildExecutor):
         start_input_id = self.input_config_queue[0]["id"]
         out_file_prefix = self.run_options["out_file_prefix"]
         timestamp = int(datetime.timestamp(datetime.now()))
-        ncu_log_file = (
-            f"{out_file_prefix}_{os.getpid()}_{timestamp}_ncu.log"
-        )
+        ncu_log_file = f"{out_file_prefix}_{os.getpid()}_{timestamp}_ncu.log"
         ncu_log_file = ncu_log_file.replace(":", "-")
         ncu_extra_args = self.run_options["ncu_args"]
         ncu_options = (
@@ -207,6 +205,7 @@ class OpBuildExecutor(BuildExecutor):
         run_options = get_benchmark_options()
         run_options["device"] = self.run_options["device"]
         run_options["pass_type"] = self.run_options["pass_type"].value
+        run_options["op_exec_mode"] = self.run_options["op_exec_mode"].value
         run_options["warmup"] = 1
         run_options["iteration"] = 1
         config = {
@@ -247,7 +246,7 @@ class OpBuildExecutor(BuildExecutor):
                     print(line, end="")
         shm.close()
         shm.unlink()
-        end_input_id = self.input_config_queue[-1]['id']
+        end_input_id = self.input_config_queue[-1]["id"]
         print(
             json.dumps(
                 {
@@ -357,12 +356,22 @@ def output_stats(
     for pass_name, metric in metrics.items():
         logger.info(f"pass: {pass_name}")
         for metric_name, records in metric.items():
-            total = sum(records)
-            avg = total / len(records)
-            logger.info(
-                f"metric: {metric_name}, average: {avg:.3f} ms, total: {total:.3f} ms"
-            )
-            logger.info(f"{format_float_val_list(records, 3)}")
+            total = 0
+            avg = 0
+            if records:
+                total = sum(records)
+                avg = total / len(records)
+            if metric_name.endswith(".time"):
+                logger.info(
+                    f"metric: {metric_name}, average: {avg:.3f} ms, total: {total:.3f} ms"
+                )
+                logger.info(f"{format_float_val_list(records, 3)}")
+            elif metric_name.endswith(".memory"):
+                logger.info(
+                    f"metric: {metric_name}, average: {avg:.3f} MB, total: {total:.3f} MB"
+                )
+                logger.info(f"{format_float_val_list(records, 3)}")
+
     stats = {
         "op_name": name,
         "id": run_id,

--- a/train/compute/python/lib/pytorch/config_util.py
+++ b/train/compute/python/lib/pytorch/config_util.py
@@ -19,8 +19,21 @@ from ...lib import __version__ as param_bench_version
 class ExecutionPass(enum.Enum):
     # Forward pass will always run (also required for backward pass).
     FORWARD = "forward"
+
     # Run backward pass in addition to forward pass.
     BACKWARD = "backward"
+
+
+@enum.unique
+class OpExecutionMode(enum.Enum):
+    # Run operator seprately and clear cache between each call.
+    DISCRETE = "discrete"
+
+    # Run operator back to back without clear cache, etc.
+    CONTINUOUS = "continuous"
+
+    # Run operator back to back but record indivisual events.
+    CONTINUOUS_EVENTS = "continuous_events"
 
 
 def get_op_run_id(op_name: str, run_id: str) -> str:
@@ -33,6 +46,7 @@ def get_benchmark_options() -> Dict[str, Any]:
         "pass_type": ExecutionPass.FORWARD,
         "warmup": 1,
         "iteration": 1,
+        "op_exec_mode": OpExecutionMode.DISCRETE,
         "time_unit": "millisecond",
         "out_file_prefix": None,
         "out_stream": None,
@@ -63,7 +77,7 @@ def create_op_args(args: List[Any], kwargs: Dict[str, Any]) -> Dict[str, Any]:
     return {"args": args, "kwargs": kwargs}
 
 
-_pytorch_data: Dict[str, Any] = {
+_pytorch_type: Dict[str, Any] = {
     "int": {"type": "int", "value": None},
     "int_range": {"type": "int", "value_range": None},
     "long": {"type": "long", "value": None},
@@ -81,8 +95,8 @@ _pytorch_data: Dict[str, Any] = {
 }
 
 
-def create_data(type) -> Dict[str, Any]:
-    return copy.deepcopy(_pytorch_data[type])
+def create_type(type) -> Dict[str, Any]:
+    return copy.deepcopy(_pytorch_type[type])
 
 
 def get_sys_info():

--- a/train/compute/python/lib/pytorch/op_executor.py
+++ b/train/compute/python/lib/pytorch/op_executor.py
@@ -12,7 +12,7 @@ import torch
 from torch.autograd.profiler import record_function
 
 from ..operator import OperatorInterface
-from .config_util import ExecutionPass
+from .config_util import ExecutionPass, OpExecutionMode
 from .timer import Timer
 
 
@@ -52,6 +52,12 @@ class OpExecutor:
         self.iteration = run_options["iteration"]
         self.warmup = run_options["warmup"]
         self.pass_type = run_options["pass_type"]
+        self.exec_mode = run_options["op_exec_mode"]
+        self.benchmark_func = {
+            OpExecutionMode.DISCRETE: self._benchmark_discrete,
+            OpExecutionMode.CONTINUOUS: self._benchmark_continuous,
+            OpExecutionMode.CONTINUOUS_EVENTS: self._benchmark_continuous,
+        }
 
     def run(
         self, input_args: List, input_kwargs: Dict[str, Any], op_run_id: str
@@ -74,43 +80,264 @@ class OpExecutor:
 
     def _benchmark_op(
         self, op: Callable, args: List, kwargs: Dict[str, Any], tag: str, op_run_id: str
-    ) -> float:
+    ) -> Tuple[float, float]:
         logger.debug(f"benchmarking {self.name} {tag} {op_run_id}")
+        gpu_memory = 0
         # flush cache
         if self.device.startswith("cuda"):
             _clear_cache()
+            # Reset to measure peak memory usage
+            torch.cuda.reset_peak_memory_stats()
             if USE_NVTX:
-                tag_rng = nvtx.start_range(domain="param_bench", message=tag)
-                op_run_id_rng = nvtx.start_range(domain=self.name, message=op_run_id)
+                tag_range = nvtx.start_range(domain="param_bench", message=tag)
+                op_run_id_range = nvtx.start_range(domain=self.name, message=op_run_id)
 
+        timer = Timer(self.device)
         with record_function("__param_bench__:_benchmark_op"):
-            with Timer(self.device) as timer:
-                op(*args, **kwargs)
+            timer.start()
+            op(*args, **kwargs)
+            timer.stop()
 
         if self.device.startswith("cuda") and USE_NVTX:
-            nvtx.end_range(op_run_id_rng)
-            nvtx.end_range(tag_rng)
+            nvtx.end_range(op_run_id_range)
+            nvtx.end_range(tag_range)
+            # Memory size in MB
+            gpu_memory = torch.cuda.max_memory_allocated() / (1048576)
 
         # Return result in milliseconds.
-        return timer.elapsed_time()
+        return timer.elapsed_time_ms(), gpu_memory
 
-    def _benchmark_loop(
+    def _benchmark_discrete(
         self, count: int, args: List, kwargs: Dict[str, Any], tag: str, op_run_id: str
-    ) -> Tuple[List[float], List[float]]:
+    ) -> Tuple[List[float], List[float], List[float], List[float]]:
         fw_time_records = []
         bw_time_records = []
+        fw_gpu_mem_records = []
+        bw_gpu_mem_records = []
         for _ in range(count):
             op_run_pass = f"{op_run_id}:{ExecutionPass.FORWARD.value}"
-            latency = self._benchmark_op(
+            latency, peak_memory = self._benchmark_op(
                 self.op.forward, args, kwargs, tag, op_run_pass
             )
             fw_time_records.append(latency)
+            fw_gpu_mem_records.append(peak_memory)
             if self.pass_type == ExecutionPass.BACKWARD:
                 self.op.create_grad()
                 op_run_pass = f"{op_run_id}:{ExecutionPass.BACKWARD.value}"
-                latency = self._benchmark_op(self.op.backward, [], {}, tag, op_run_pass)
+                latency, peak_memory = self._benchmark_op(
+                    self.op.backward, [], {}, tag, op_run_pass
+                )
                 bw_time_records.append(latency)
-        return (fw_time_records, bw_time_records)
+                bw_gpu_mem_records.append(peak_memory)
+        return (
+            fw_time_records,
+            fw_gpu_mem_records,
+            bw_time_records,
+            bw_gpu_mem_records,
+        )
+
+    def _benchmark_loop_cuda_events(
+        self,
+        count: int,
+        args: List,
+        kwargs: Dict[str, Any],
+        tag: str,
+        op_run_id: str,
+    ) -> float:
+        """
+        Using CUDA events to record is making the assumptions that we are running single stream.
+        In this mode, we do not flush cache, assuming benefit from data in warmup.
+        """
+
+        def create_cuda_start_stop_events(count: int):
+            return [
+                (
+                    torch.cuda.Event(enable_timing=True),
+                    torch.cuda.Event(enable_timing=True),
+                )
+                for i in range(count)
+            ]
+
+        def compute_cuda_event_delta(events: List[Tuple[Any]]):
+            deltas = []
+            for event_pair in events:
+                deltas.append(event_pair[0].elapsed_time(event_pair[1]))
+
+            return deltas
+
+        fw_time_records = []
+        bw_time_records = []
+        fw_gpu_mem_records = []
+        bw_gpu_mem_records = []
+
+        if USE_NVTX:
+            tag_range = nvtx.start_range(domain="param_bench", message=tag)
+
+        with record_function("__param_bench__:_benchmark_op"):
+            fw_events = create_cuda_start_stop_events(count)
+            torch.cuda.reset_peak_memory_stats()
+            if USE_NVTX:
+                op_run_id_range = nvtx.start_range(
+                    domain=self.name,
+                    message=f"{op_run_id}:{ExecutionPass.FORWARD.value}",
+                )
+            for i in range(count):
+                fw_events[i][0].record()
+                self.op.forward(*args, **kwargs)
+                fw_events[i][1].record()
+
+            torch.cuda.synchronize()
+            if USE_NVTX:
+                nvtx.end_range(op_run_id_range)
+            fw_time_records = compute_cuda_event_delta(fw_events)
+            fw_gpu_mem_records.append(torch.cuda.max_memory_allocated() / (1048576))
+
+            if self.pass_type == ExecutionPass.BACKWARD:
+                self.op.create_grad()
+
+                bw_events = create_cuda_start_stop_events(count)
+                torch.cuda.reset_peak_memory_stats()
+                if USE_NVTX:
+                    op_run_id_range = nvtx.start_range(
+                        domain=self.name,
+                        message=f"{op_run_id}:{ExecutionPass.FORWARD.value}_{ExecutionPass.BACKWARD.value}",
+                    )
+                for i in range(count):
+                    self.op.forward(*args, **kwargs)
+                    bw_events[i][0].record()
+                    self.op.backward()
+                    bw_events[i][1].record()
+
+                torch.cuda.synchronize()
+                if USE_NVTX:
+                    nvtx.end_range(op_run_id_range)
+                bw_time_records = compute_cuda_event_delta(bw_events)
+                bw_gpu_mem_records.append(torch.cuda.max_memory_allocated() / (1048576))
+
+        if USE_NVTX:
+            nvtx.end_range(tag_range)
+
+        # Return result in milliseconds.
+        return fw_time_records, fw_gpu_mem_records, bw_time_records, bw_gpu_mem_records
+
+    def _benchmark_loop_cuda(
+        self,
+        count: int,
+        args: List,
+        kwargs: Dict[str, Any],
+        tag: str,
+        op_run_id: str,
+    ) -> float:
+        fw_time_records = []
+        bw_time_records = []
+        fw_gpu_mem_records = []
+        bw_gpu_mem_records = []
+        logger.debug(f"benchmarking {self.name} {tag} {op_run_id}")
+        if USE_NVTX:
+            tag_range = nvtx.start_range(domain="param_bench", message=tag)
+
+        with record_function("__param_bench__:_benchmark_op"):
+            fw_time = 0
+            bw_time = 0
+            if USE_NVTX:
+                op_run_id_range = nvtx.start_range(
+                    domain=self.name,
+                    message=f"{op_run_id}:{ExecutionPass.FORWARD.value}",
+                )
+
+            # Always run forward.
+            torch.cuda.reset_peak_memory_stats()
+            timer = Timer(self.device)
+            timer.start()
+            for i in range(count):
+                self.op.forward(*args, **kwargs)
+            timer.stop()
+            fw_time = timer.elapsed_time_ms() / count
+
+            if USE_NVTX:
+                nvtx.end_range(op_run_id_range)
+
+            fw_gpu_mem_records.append(torch.cuda.max_memory_allocated() / (1048576))
+
+            if self.pass_type == ExecutionPass.BACKWARD:
+                self.op.create_grad()
+                torch.cuda.reset_peak_memory_stats()
+                if USE_NVTX:
+                    op_run_id_range = nvtx.start_range(
+                        domain=self.name,
+                        message=f"{op_run_id}:{ExecutionPass.FORWARD.value}_{ExecutionPass.BACKWARD.value}",
+                    )
+                timer.start()
+                for i in range(count):
+                    self.op.forward(*args, **kwargs)
+                    self.op.backward()
+                timer.stop()
+
+                # Subtract forward time to get backward time.
+                bw_time = timer.elapsed_time_ms() / count - fw_time
+
+                if USE_NVTX:
+                    nvtx.end_range(op_run_id_range)
+
+                bw_gpu_mem_records.append(torch.cuda.max_memory_allocated() / (1048576))
+
+        if USE_NVTX:
+            nvtx.end_range(tag_range)
+
+        fw_time_records.append(fw_time)
+        bw_time_records.append(bw_time)
+
+        # Return result in milliseconds.
+        return fw_time_records, fw_gpu_mem_records, bw_time_records, bw_gpu_mem_records
+
+    def _benchmark_loop_cpu(
+        self,
+        count: int,
+        args: List,
+        kwargs: Dict[str, Any],
+        tag: str,
+        op_run_id: str,
+    ) -> float:
+        logger.debug(f"benchmarking {self.name} {tag} {op_run_id}")
+
+        fw_time_records = []
+        fw_gpu_mem_records = []
+        bw_time_records = []
+        bw_gpu_mem_records = []
+        timer = Timer(self.device)
+        with record_function("__param_bench__:_benchmark_op"):
+            if self.pass_type == ExecutionPass.FORWARD:
+                for i in range(count):
+                    timer.start()
+                    self.op.forward(*args, **kwargs)
+                    timer.stop()
+                    fw_time_records.append(timer.elapsed_time_ms())
+
+            elif self.pass_type == ExecutionPass.BACKWARD:
+                for i in range(count):
+                    self.op.forward(*args, **kwargs)
+                    self.op.create_grad()
+                    timer.start()
+                    self.op.backward()
+                    timer.stop()
+                    bw_time_records.append(timer.elapsed_time_ms())
+
+        # Return result in milliseconds.
+        return fw_time_records, fw_gpu_mem_records, bw_time_records, bw_gpu_mem_records
+
+    def _benchmark_continuous(
+        self, count: int, args: List, kwargs: Dict[str, Any], tag: str, op_run_id: str
+    ) -> Tuple[List[float], List[float], List[float], List[float]]:
+        if self.device.startswith("cpu"):
+            return self._benchmark_loop_cpu(count, args, kwargs, tag, op_run_id)
+        elif self.device.startswith("cuda"):
+            if self.exec_mode == OpExecutionMode.CONTINUOUS:
+                return self._benchmark_loop_cuda(count, args, kwargs, tag, op_run_id)
+            elif self.exec_mode == OpExecutionMode.CONTINUOUS_EVENTS:
+                return self._benchmark_loop_cuda_events(
+                    count, args, kwargs, tag, op_run_id
+                )
+        return [], [], [], []
 
     def _measure(
         self,
@@ -123,9 +350,12 @@ class OpExecutor:
     ) -> Dict[str, Any]:
         logger.info(f"running [{op_run_id}] for {iteration} {tag} iteration")
 
-        (fw_time_records, bw_time_records) = self._benchmark_loop(
-            iteration, args, kwargs, tag, op_run_id
-        )
+        (
+            fw_time_records,
+            fw_mem_records,
+            bw_time_records,
+            bw_mem_records,
+        ) = self.benchmark_func[self.exec_mode](iteration, args, kwargs, tag, op_run_id)
 
         metric_name = tag + ".time"
         pass_name = ExecutionPass.FORWARD.value
@@ -133,3 +363,10 @@ class OpExecutor:
         if self.pass_type == ExecutionPass.BACKWARD:
             pass_name = ExecutionPass.BACKWARD.value
             result[pass_name][metric_name] = bw_time_records
+
+        metric_name = tag + ".gpu.memory"
+        pass_name = ExecutionPass.FORWARD.value
+        result[pass_name][metric_name] = fw_mem_records
+        if self.pass_type == ExecutionPass.BACKWARD:
+            pass_name = ExecutionPass.BACKWARD.value
+            result[pass_name][metric_name] = bw_mem_records

--- a/train/compute/python/lib/pytorch/timer.py
+++ b/train/compute/python/lib/pytorch/timer.py
@@ -2,24 +2,26 @@ import time
 
 import torch
 
-# Timer in seconds
+# Timer
 class Timer:
     def __init__(self, device: str):
         self.device: str = device
         self.start_time: float = 0
         self.end_time: float = 0
 
-    def __enter__(self):
+    def start(self):
         if self.device.startswith("cuda"):
             torch.cuda.synchronize()
         self.start_time = time.perf_counter()
-        return self
 
-    def __exit__(self, type, value, traceback):
+    def stop(self):
         if self.device.startswith("cuda"):
             torch.cuda.synchronize()
         self.end_time = time.perf_counter()
 
     # Return result in milliseconds.
-    def elapsed_time(self) -> float:
+    def elapsed_time_ms(self) -> float:
         return (self.end_time - self.start_time) * 1000.0
+
+    def elapsed_time_sec(self) -> float:
+        return (self.end_time - self.start_time)

--- a/train/compute/python/pytorch/run_batch.py
+++ b/train/compute/python/pytorch/run_batch.py
@@ -13,7 +13,7 @@ from multiprocessing import shared_memory, resource_tracker
 from ..lib import pytorch as lib_pytorch
 from ..lib.config import make_op_config
 from ..lib.pytorch.build_executor import MaterializedBuildExecutor
-from ..lib.pytorch.config_util import ExecutionPass
+from ..lib.pytorch.config_util import ExecutionPass, OpExecutionMode
 from ..workloads import pytorch as workloads_pytorch
 
 
@@ -74,6 +74,7 @@ def main():
     logger.debug(f"run_options: {run_options}")
 
     run_options["pass_type"] = ExecutionPass(run_options["pass_type"])
+    run_options["op_exec_mode"] = OpExecutionMode(run_options["op_exec_mode"])
 
     op_config = make_op_config(op_name, op_info, run_options["device"])
     build_input_config = op_info["config"][0]

--- a/train/compute/python/pytorch/run_benchmark.py
+++ b/train/compute/python/pytorch/run_benchmark.py
@@ -11,7 +11,12 @@ from ..lib import pytorch as lib_pytorch
 from ..lib.config import BenchmarkConfig
 from ..lib.init_helper import init_logging, load_modules
 from ..lib.pytorch.benchmark import make_default_benchmark
-from ..lib.pytorch.config_util import get_benchmark_options, ExecutionPass, get_sys_info
+from ..lib.pytorch.config_util import (
+    get_benchmark_options,
+    ExecutionPass,
+    get_sys_info,
+    OpExecutionMode,
+)
 from ..workloads import pytorch as workloads_pytorch
 
 
@@ -55,6 +60,13 @@ def main():
     parser.add_argument(
         "--ncu", action="store_true", help="Run NSight Compute to collect metrics."
     )
+    parser.add_argument(
+        "--exec-mode",
+        type=str,
+        default="continuous",
+        help="Set execution mode of the operators (discrete, continuous, continuous_events).",
+    )
+
     parser.add_argument(
         "--ncu-args-file",
         type=str,
@@ -103,6 +115,7 @@ def main():
     else:
         run_options["pass_type"] = ExecutionPass.FORWARD
 
+    run_options["op_exec_mode"] = OpExecutionMode(args.exec_mode)
     if args.ncu:
         run_options["run_ncu"] = True
 


### PR DESCRIPTION
Summary:
# New features:
* Collects GPU memory utilization in addition to latency. This done using PyTorch's own memory tracker.
* Added new modes of operator execution
  * DISCRETE: this is the original method. We time each operator execution individually. A synchronization point is inserted before and after each GPU operator launch. We also clear the cache between each execution. However this introduces various overhead that we may not observe when multiple operators execute sequentially. This is due to the async execution model of CUDA.
  * CONTINUOUS: In this mode, the operator is executed in a tight loop. We only time the overall loop time, then divide by the number of loop count to get the average operator execution time. The overheads are amortized over many iterations so it's closer to the actual kernel execution time.
  * CONTINUOUS_EVENTS: This is similar to CONTINUOUS mode, but we also insert before and after torch.cuda.Event in the loop. The operator time is calculated based on the delta of these events. This will give individual measurements, but may introduce minor overhead that's not observed in CONTINUOUS mode.

**Note that the continuous mode is the same way to measure in compute/pt/ benchmarks. As shown below (2nd run), they produce the same result.**

# A few to do items for the coming diffs:
* convert to use the new torch nvtx D33155244
* be consistent using buck build run_batch script
* nsys support

Differential Revision: D34071165

