### PR TITLE
Add TF32 option explicitly to param_gemm and param_linear

### DIFF
--- a/train/compute/pt/pytorch_gemm.py
+++ b/train/compute/pt/pytorch_gemm.py
@@ -65,6 +65,9 @@ def run_single(args, m, n, k):
         dt = torch.float16
     elif (dtype == "bfloat16"):
         dt = torch.bfloat16
+    elif (dtype == "tf32"):
+        torch.backends.cudnn.allow_tf32 = True
+        torch.backends.cuda.matmul.allow_tf32 = True
 
     torch.manual_seed(0)
 

--- a/train/compute/pt/pytorch_linear.py
+++ b/train/compute/pt/pytorch_linear.py
@@ -59,6 +59,9 @@ def train_cpu(
 def train_gpu(
     model, device, optimizer, data_type, input_size, output_size, batch_size, args
 ):
+    if data_type == "tf32":
+        torch.backends.cudnn.allow_tf32 = True
+        torch.backends.cuda.matmul.allow_tf32 = True
     import apex
 
     loss_f = nn.CrossEntropyLoss().to(device)
@@ -310,7 +313,7 @@ if __name__ == "__main__":
         "--dtype",
         default="float",
         help="data type",
-        choices=["float", "float16", "bfloat16"],
+        choices=["float", "float16", "bfloat16", "tf32"],
     )
     parser.add_argument(
         "--layer-num", type=int, default=20, help="Number of Linear layers"


### PR DESCRIPTION
Summary: This change is required since pytorch 1.12 and later have TF32 set off unless turned on explicitly. Henceforth, we need to set data_type to "tf32" to enable this in the param_gemm and param_linear benchmarks.

Differential Revision: D37089606

