### PR TITLE
Improve compute benchmark framework test coverage

### DIFF
--- a/train/compute/python/test/test_benchmark_load.py
+++ b/train/compute/python/test/test_benchmark_load.py
@@ -1,0 +1,32 @@
+import os
+import unittest
+
+from ..lib.config import BenchmarkConfig
+from ..lib.pytorch.benchmark import Benchmark, make_default_benchmark
+from ..lib.pytorch.config_util import get_benchmark_options
+
+CURR_DIR = os.path.dirname(os.path.realpath(__file__))
+
+
+class TestBenchmarkLoad(unittest.TestCase):
+
+    def setUp(self):
+        self.config_path = os.path.join(
+            CURR_DIR,
+            "pytorch",
+            "configs",
+            "test_native_basic_ops.json"
+            )
+
+    def test_json_load_benchmark(self):
+        run_options = get_benchmark_options()
+        bench_config = BenchmarkConfig(run_options)
+        bench_config.load_json_file(self.config_path)
+        benchmark = make_default_benchmark(bench_config)
+        self.assertTrue(isinstance(benchmark, Benchmark))
+        self.assertTrue(len(benchmark.run_options)>0)
+        self.assertTrue(len(benchmark.bench_config.bench_config)>0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Summary:
Add a new test for a simple benchmark object creation by json
 - get default benchmark options
 - load json into benchmark config
 - init a Benchmark object
 - assert a Benchmark object is created, run_options is not empty in the object, bench_config.bench_config of the benchmark object is not empty

This test try to improve test coverage involve config.py, config_util.py, benchmark.py

Reviewed By: louisfeng

Differential Revision: D37490539

