### PR TITLE
fix pt2pt support

### DIFF
--- a/train/comms/pt/comms.py
+++ b/train/comms/pt/comms.py
@@ -1177,12 +1177,13 @@ class commsCollBench(paramCommsBench):
                 # set corresponding function pointers
                 if commsParams.collective != "pt2pt":
                     collectiveFunc = backendFuncs.collectiveFunc[commsParams.collective]
-                    commsArgs = comms_utils.commsArgs()
-                    commsArgs.inMsgSize = numElements
-                    commsArgs.outMsgSize = numElements
-                    commsArgs.worldSize = world_size
-                    commsArgs.inSplit = commsParams.inSplit
-                    commsArgs.outSplit = commsParams.outSplit
+
+                commsArgs = comms_utils.commsArgs()
+                commsArgs.inMsgSize = numElements
+                commsArgs.outMsgSize = numElements
+                commsArgs.worldSize = world_size
+                commsArgs.inSplit = commsParams.inSplit
+                commsArgs.outSplit = commsParams.outSplit
 
                 (
                     self.collectiveArgs.ipTensor,


### PR DESCRIPTION
Summary: Previous code reports "local variable 'commsArgs' referenced before assignment" when running pt2pt test, due to incorrect code indent. This patch fixes it

Differential Revision: D38445883

