### PR TITLE
Enable setting CPU events along with CUPTI Range profiler

### DIFF
--- a/train/compute/python/pytorch/run_benchmark.py
+++ b/train/compute/python/pytorch/run_benchmark.py
@@ -173,7 +173,7 @@ def main():
         " eg: L2 misses, L1 bank conflicts.\n "
         "Additionally, Two special metrics are useful for measuring FLOPS\n"
         "-  kineto__cuda_core_flops = CUDA floating point op counts\n"
-        "-  kineto__tensor_core_insts = Tensor core op couunts\n",
+        "-  kineto__tensor_core_insts = Tensor core op counts\n",
     )
     parser.add_argument(
         "--cupti-profiler-measure-per-kernel",
@@ -318,10 +318,9 @@ def main():
             use_kineto=True,
             record_shapes=False,
             experimental_config=cupti_profiler_config,
-            # CUPTI Profiler mode is not allowed when also instrumenting CPU operators,
             # use_cpu enables profiling and recodring of CPU pytorch operators.
-            # Thus this needs to be disabled while using CUPTI profiler.
-            use_cpu=not args.cupti_profiler,
+            # This is useful in CUPTI profiler mode if we are measuring per GPU kernel metrics.
+            use_cpu=(not args.cupti_profiler) or args.cupti_profiler_measure_per_kernel,
         ) as prof:
             with record_function(f"[param|{run_options['device']}]"):
                 benchmark.run()


### PR DESCRIPTION
Summary:
## Motivation
Initial version of CUPTI Range profile was conservative in turning of all other event types in kineto/pytorch profiler.
However, there is value in enabling CPU side activity logging. This let's us correlate the CPU operator -> GPU kernel statistics, helps us analyze flops/other performance metrics at the operator level.

## Details
1. Kineto CUPTI Range profiler plugin relaxes conditions on enabling the profiler, it only warns you if you also record GPU events that will conflict with CUPTI Range profielr.
1. Update pytorch profiler experimental configs parsing to allow setting CPU activities along with range profiler. Only enable on per kernel measurement mode.

Differential Revision: D44165104

