### PR TITLE
Remove CPU and GPU support for approx_sgd

### DIFF
--- a/train/compute/python/test/test_split_table_batched_embeddings_ops.py
+++ b/train/compute/python/test/test_split_table_batched_embeddings_ops.py
@@ -22,7 +22,7 @@ class TestSplitTableBatchedEmbeddingOps(unittest.TestCase):
             0,  # PoolingMode.SUM
             False,
             "fp16",
-            "sgd",
+            "exact_adagrad",
         )
         self.assertEqual(op_config.op.op.embedding_specs[0][0], 1000)
         self.assertEqual(op_config.op.op.embedding_specs[0][1], 64)
@@ -34,7 +34,7 @@ class TestSplitTableBatchedEmbeddingOps(unittest.TestCase):
             0,  # PoolingMode.SUM
             False,
             "fp16",
-            "sgd",
+            "exact_adagrad",
         )
         self.assertEqual(op_config.op.op.embedding_specs[0][0], 2000)
         self.assertEqual(op_config.op.op.embedding_specs[0][1], 128)
@@ -46,7 +46,7 @@ class TestSplitTableBatchedEmbeddingOps(unittest.TestCase):
             0,  # PoolingMode.SUM
             False,
             "fp16",
-            "sgd",
+            "exact_adagrad",
         )
         self.assertEqual(op_config.op.op.embedding_specs[0][0], 1000)
         self.assertEqual(op_config.op.op.embedding_specs[1][0], 2000)


### PR DESCRIPTION
Summary:
X-link: https://github.com/pytorch/FBGEMM/pull/1769

This diff is a part of FBGEMM TBE optimizer deprecation plan (see
https://github.com/pytorch/FBGEMM/discussions/1727)

Changes include:
- Setting `has_cpu_support` and `has_gpu_support` of `approx_sgd` to
  `False` in the code gen script
- Updating `codegen/TARGETS` and `CMakeLists.txt`

See D45835048 for how the changes affect the code generation

Reviewed By: csmiler

Differential Revision: D45844197

