### PR TITLE
Upload scripts to link execution trace and kineto trace

### DIFF
--- a/train/comms/pt/comms_utils.py
+++ b/train/comms/pt/comms_utils.py
@@ -587,7 +587,8 @@ class commsArgs:
             commData: Dictionary containing the comms metadata.
         """
         commData = {}
-        commData["comms"] = self.comms
+        if self.comms is not None:
+            commData["comms"] = self.comms
         if self.compute is not None:
             commData["compute"] = self.compute
             if commData["compute"] == "gemm":

--- a/train/compute/python/test/data/linear_et.json
+++ b/train/compute/python/test/data/linear_et.json
@@ -1,0 +1,4661 @@
+{
+  "schema": "1.0.1", "pid": 24248, "time": "2023-07-12 12:47:27", "start_ts": 69838573,
+  "nodes": [
+    {
+      "name": "[pytorch|profiler|execution_graph|thread]", "id": 2, "rf_id": 0, "parent": 1, "fw_parent": 0, "seq_id": -1, "scope": 7, "tid": 1, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::as_strided", "id": 12, "rf_id": 4, "parent": 11, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::as_strided(Tensor(a) self, SymInt[] size, SymInt[] stride, SymInt? storage_offset=None) -> Tensor(a)",
+      "inputs": [[5,6,0,1048576,4,"cuda:0"],[1024,1024],[1,1024],"<None>"], "input_shapes": [[1024,1024],[[],[]],[[],[]],[]], "input_types": ["Tensor(float)","GenericList[Int,Int]","GenericList[Int,Int]","None"],
+      "outputs": [[13,6,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::transpose", "id": 11, "rf_id": 3, "parent": 10, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::transpose.int(Tensor(a) self, int dim0, int dim1) -> Tensor(a)",
+      "inputs": [[5,6,0,1048576,4,"cuda:0"],0,1], "input_shapes": [[1024,1024],[],[]], "input_types": ["Tensor(float)","Int","Int"],
+      "outputs": [[13,6,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::t", "id": 10, "rf_id": 2, "parent": 9, "fw_parent": 0, "seq_id": 660, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::t(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[5,6,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[13,6,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty", "id": 15, "rf_id": 6, "parent": 14, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[1048576],0,"<None>","cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","None","Device","None","None"],
+      "outputs": [[16,17,0,1048576,1,"cuda:0"]], "output_shapes": [[1048576]], "output_types": ["Tensor(unsigned char)"]
+    },
+    {
+      "name": "aten::addmm", "id": 14, "rf_id": 5, "parent": 9, "fw_parent": 0, "seq_id": 661, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::addmm(Tensor self, Tensor mat1, Tensor mat2, *, Scalar beta=1, Scalar alpha=1) -> Tensor",
+      "inputs": [[7,8,0,1024,4,"cuda:0"],[3,4,0,524288,4,"cuda:0"],[13,6,0,1048576,4,"cuda:0"],1,1], "input_shapes": [[1024],[512,1024],[1024,1024],[],[]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(float)","Int","Int"],
+      "outputs": [[18,19,0,524288,4,"cuda:0"]], "output_shapes": [[512,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::linear", "id": 9, "rf_id": 1, "parent": 2, "fw_parent": 0, "seq_id": 660, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::linear(Tensor input, Tensor weight, Tensor? bias=None) -> Tensor",
+      "inputs": [[3,4,0,524288,4,"cuda:0"],[5,6,0,1048576,4,"cuda:0"],[7,8,0,1024,4,"cuda:0"]], "input_shapes": [[512,1024],[1024,1024],[1024]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(float)"],
+      "outputs": [[18,19,0,524288,4,"cuda:0"]], "output_shapes": [[512,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::clamp_min", "id": 21, "rf_id": 8, "parent": 20, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::clamp_min(Tensor self, Scalar min) -> Tensor",
+      "inputs": [[18,19,0,524288,4,"cuda:0"],0], "input_shapes": [[512,1024],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [[22,23,0,524288,4,"cuda:0"]], "output_shapes": [[512,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::relu", "id": 20, "rf_id": 7, "parent": 2, "fw_parent": 0, "seq_id": 662, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::relu(Tensor self) -> Tensor",
+      "inputs": [[18,19,0,524288,4,"cuda:0"]], "input_shapes": [[512,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[22,23,0,524288,4,"cuda:0"]], "output_shapes": [[512,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::as_strided", "id": 31, "rf_id": 12, "parent": 30, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::as_strided(Tensor(a) self, SymInt[] size, SymInt[] stride, SymInt? storage_offset=None) -> Tensor(a)",
+      "inputs": [[24,25,0,1048576,4,"cuda:0"],[1024,1024],[1,1024],"<None>"], "input_shapes": [[1024,1024],[[],[]],[[],[]],[]], "input_types": ["Tensor(float)","GenericList[Int,Int]","GenericList[Int,Int]","None"],
+      "outputs": [[18,25,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::transpose", "id": 30, "rf_id": 11, "parent": 29, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::transpose.int(Tensor(a) self, int dim0, int dim1) -> Tensor(a)",
+      "inputs": [[24,25,0,1048576,4,"cuda:0"],0,1], "input_shapes": [[1024,1024],[],[]], "input_types": ["Tensor(float)","Int","Int"],
+      "outputs": [[18,25,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::t", "id": 29, "rf_id": 10, "parent": 28, "fw_parent": 0, "seq_id": 663, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::t(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[24,25,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[18,25,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty", "id": 33, "rf_id": 14, "parent": 32, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[1048576],0,"<None>","cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","None","Device","None","None"],
+      "outputs": [[34,17,0,1048576,1,"cuda:0"]], "output_shapes": [[1048576]], "output_types": ["Tensor(unsigned char)"]
+    },
+    {
+      "name": "aten::addmm", "id": 32, "rf_id": 13, "parent": 28, "fw_parent": 0, "seq_id": 664, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::addmm(Tensor self, Tensor mat1, Tensor mat2, *, Scalar beta=1, Scalar alpha=1) -> Tensor",
+      "inputs": [[26,27,0,1024,4,"cuda:0"],[22,23,0,524288,4,"cuda:0"],[18,25,0,1048576,4,"cuda:0"],1,1], "input_shapes": [[1024],[512,1024],[1024,1024],[],[]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(float)","Int","Int"],
+      "outputs": [[35,19,0,524288,4,"cuda:0"]], "output_shapes": [[512,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::linear", "id": 28, "rf_id": 9, "parent": 2, "fw_parent": 0, "seq_id": 663, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::linear(Tensor input, Tensor weight, Tensor? bias=None) -> Tensor",
+      "inputs": [[22,23,0,524288,4,"cuda:0"],[24,25,0,1048576,4,"cuda:0"],[26,27,0,1024,4,"cuda:0"]], "input_shapes": [[512,1024],[1024,1024],[1024]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(float)"],
+      "outputs": [[35,19,0,524288,4,"cuda:0"]], "output_shapes": [[512,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::clamp_min", "id": 37, "rf_id": 16, "parent": 36, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::clamp_min(Tensor self, Scalar min) -> Tensor",
+      "inputs": [[35,19,0,524288,4,"cuda:0"],0], "input_shapes": [[512,1024],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [[34,38,0,524288,4,"cuda:0"]], "output_shapes": [[512,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::relu", "id": 36, "rf_id": 15, "parent": 2, "fw_parent": 0, "seq_id": 665, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::relu(Tensor self) -> Tensor",
+      "inputs": [[35,19,0,524288,4,"cuda:0"]], "input_shapes": [[512,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[34,38,0,524288,4,"cuda:0"]], "output_shapes": [[512,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::as_strided", "id": 46, "rf_id": 20, "parent": 45, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::as_strided(Tensor(a) self, SymInt[] size, SymInt[] stride, SymInt? storage_offset=None) -> Tensor(a)",
+      "inputs": [[39,40,0,1048576,4,"cuda:0"],[1024,1024],[1,1024],"<None>"], "input_shapes": [[1024,1024],[[],[]],[[],[]],[]], "input_types": ["Tensor(float)","GenericList[Int,Int]","GenericList[Int,Int]","None"],
+      "outputs": [[35,40,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::transpose", "id": 45, "rf_id": 19, "parent": 44, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::transpose.int(Tensor(a) self, int dim0, int dim1) -> Tensor(a)",
+      "inputs": [[39,40,0,1048576,4,"cuda:0"],0,1], "input_shapes": [[1024,1024],[],[]], "input_types": ["Tensor(float)","Int","Int"],
+      "outputs": [[35,40,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::t", "id": 44, "rf_id": 18, "parent": 43, "fw_parent": 0, "seq_id": 666, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::t(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[39,40,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[35,40,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty", "id": 48, "rf_id": 22, "parent": 47, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[1048576],0,"<None>","cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","None","Device","None","None"],
+      "outputs": [[49,17,0,1048576,1,"cuda:0"]], "output_shapes": [[1048576]], "output_types": ["Tensor(unsigned char)"]
+    },
+    {
+      "name": "aten::addmm", "id": 47, "rf_id": 21, "parent": 43, "fw_parent": 0, "seq_id": 667, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::addmm(Tensor self, Tensor mat1, Tensor mat2, *, Scalar beta=1, Scalar alpha=1) -> Tensor",
+      "inputs": [[41,42,0,1024,4,"cuda:0"],[34,38,0,524288,4,"cuda:0"],[35,40,0,1048576,4,"cuda:0"],1,1], "input_shapes": [[1024],[512,1024],[1024,1024],[],[]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(float)","Int","Int"],
+      "outputs": [[50,19,0,524288,4,"cuda:0"]], "output_shapes": [[512,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::linear", "id": 43, "rf_id": 17, "parent": 2, "fw_parent": 0, "seq_id": 666, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::linear(Tensor input, Tensor weight, Tensor? bias=None) -> Tensor",
+      "inputs": [[34,38,0,524288,4,"cuda:0"],[39,40,0,1048576,4,"cuda:0"],[41,42,0,1024,4,"cuda:0"]], "input_shapes": [[512,1024],[1024,1024],[1024]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(float)"],
+      "outputs": [[50,19,0,524288,4,"cuda:0"]], "output_shapes": [[512,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::clamp_min", "id": 52, "rf_id": 24, "parent": 51, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::clamp_min(Tensor self, Scalar min) -> Tensor",
+      "inputs": [[50,19,0,524288,4,"cuda:0"],0], "input_shapes": [[512,1024],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [[49,53,0,524288,4,"cuda:0"]], "output_shapes": [[512,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::relu", "id": 51, "rf_id": 23, "parent": 2, "fw_parent": 0, "seq_id": 668, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::relu(Tensor self) -> Tensor",
+      "inputs": [[50,19,0,524288,4,"cuda:0"]], "input_shapes": [[512,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[49,53,0,524288,4,"cuda:0"]], "output_shapes": [[512,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::as_strided", "id": 61, "rf_id": 28, "parent": 60, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::as_strided(Tensor(a) self, SymInt[] size, SymInt[] stride, SymInt? storage_offset=None) -> Tensor(a)",
+      "inputs": [[54,55,0,1048576,4,"cuda:0"],[1024,1024],[1,1024],"<None>"], "input_shapes": [[1024,1024],[[],[]],[[],[]],[]], "input_types": ["Tensor(float)","GenericList[Int,Int]","GenericList[Int,Int]","None"],
+      "outputs": [[62,55,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::transpose", "id": 60, "rf_id": 27, "parent": 59, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::transpose.int(Tensor(a) self, int dim0, int dim1) -> Tensor(a)",
+      "inputs": [[54,55,0,1048576,4,"cuda:0"],0,1], "input_shapes": [[1024,1024],[],[]], "input_types": ["Tensor(float)","Int","Int"],
+      "outputs": [[62,55,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::t", "id": 59, "rf_id": 26, "parent": 58, "fw_parent": 0, "seq_id": 669, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::t(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[54,55,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[62,55,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty", "id": 64, "rf_id": 30, "parent": 63, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[1048576],0,"<None>","cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","None","Device","None","None"],
+      "outputs": [[65,17,0,1048576,1,"cuda:0"]], "output_shapes": [[1048576]], "output_types": ["Tensor(unsigned char)"]
+    },
+    {
+      "name": "aten::addmm", "id": 63, "rf_id": 29, "parent": 58, "fw_parent": 0, "seq_id": 670, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::addmm(Tensor self, Tensor mat1, Tensor mat2, *, Scalar beta=1, Scalar alpha=1) -> Tensor",
+      "inputs": [[56,57,0,1024,4,"cuda:0"],[49,53,0,524288,4,"cuda:0"],[62,55,0,1048576,4,"cuda:0"],1,1], "input_shapes": [[1024],[512,1024],[1024,1024],[],[]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(float)","Int","Int"],
+      "outputs": [[66,19,0,524288,4,"cuda:0"]], "output_shapes": [[512,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::linear", "id": 58, "rf_id": 25, "parent": 2, "fw_parent": 0, "seq_id": 669, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::linear(Tensor input, Tensor weight, Tensor? bias=None) -> Tensor",
+      "inputs": [[49,53,0,524288,4,"cuda:0"],[54,55,0,1048576,4,"cuda:0"],[56,57,0,1024,4,"cuda:0"]], "input_shapes": [[512,1024],[1024,1024],[1024]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(float)"],
+      "outputs": [[66,19,0,524288,4,"cuda:0"]], "output_shapes": [[512,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::clamp_min", "id": 68, "rf_id": 32, "parent": 67, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::clamp_min(Tensor self, Scalar min) -> Tensor",
+      "inputs": [[66,19,0,524288,4,"cuda:0"],0], "input_shapes": [[512,1024],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [[65,69,0,524288,4,"cuda:0"]], "output_shapes": [[512,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::relu", "id": 67, "rf_id": 31, "parent": 2, "fw_parent": 0, "seq_id": 671, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::relu(Tensor self) -> Tensor",
+      "inputs": [[66,19,0,524288,4,"cuda:0"]], "input_shapes": [[512,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[65,69,0,524288,4,"cuda:0"]], "output_shapes": [[512,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::as_strided", "id": 77, "rf_id": 36, "parent": 76, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::as_strided(Tensor(a) self, SymInt[] size, SymInt[] stride, SymInt? storage_offset=None) -> Tensor(a)",
+      "inputs": [[70,71,0,1048576,4,"cuda:0"],[1024,1024],[1,1024],"<None>"], "input_shapes": [[1024,1024],[[],[]],[[],[]],[]], "input_types": ["Tensor(float)","GenericList[Int,Int]","GenericList[Int,Int]","None"],
+      "outputs": [[66,71,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::transpose", "id": 76, "rf_id": 35, "parent": 75, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::transpose.int(Tensor(a) self, int dim0, int dim1) -> Tensor(a)",
+      "inputs": [[70,71,0,1048576,4,"cuda:0"],0,1], "input_shapes": [[1024,1024],[],[]], "input_types": ["Tensor(float)","Int","Int"],
+      "outputs": [[66,71,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::t", "id": 75, "rf_id": 34, "parent": 74, "fw_parent": 0, "seq_id": 672, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::t(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[70,71,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[66,71,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty", "id": 79, "rf_id": 38, "parent": 78, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[1048576],0,"<None>","cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","None","Device","None","None"],
+      "outputs": [[80,17,0,1048576,1,"cuda:0"]], "output_shapes": [[1048576]], "output_types": ["Tensor(unsigned char)"]
+    },
+    {
+      "name": "aten::addmm", "id": 78, "rf_id": 37, "parent": 74, "fw_parent": 0, "seq_id": 673, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::addmm(Tensor self, Tensor mat1, Tensor mat2, *, Scalar beta=1, Scalar alpha=1) -> Tensor",
+      "inputs": [[72,73,0,1024,4,"cuda:0"],[65,69,0,524288,4,"cuda:0"],[66,71,0,1048576,4,"cuda:0"],1,1], "input_shapes": [[1024],[512,1024],[1024,1024],[],[]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(float)","Int","Int"],
+      "outputs": [[81,19,0,524288,4,"cuda:0"]], "output_shapes": [[512,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::linear", "id": 74, "rf_id": 33, "parent": 2, "fw_parent": 0, "seq_id": 672, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::linear(Tensor input, Tensor weight, Tensor? bias=None) -> Tensor",
+      "inputs": [[65,69,0,524288,4,"cuda:0"],[70,71,0,1048576,4,"cuda:0"],[72,73,0,1024,4,"cuda:0"]], "input_shapes": [[512,1024],[1024,1024],[1024]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(float)"],
+      "outputs": [[81,19,0,524288,4,"cuda:0"]], "output_shapes": [[512,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::clamp_min", "id": 83, "rf_id": 40, "parent": 82, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::clamp_min(Tensor self, Scalar min) -> Tensor",
+      "inputs": [[81,19,0,524288,4,"cuda:0"],0], "input_shapes": [[512,1024],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [[80,84,0,524288,4,"cuda:0"]], "output_shapes": [[512,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::relu", "id": 82, "rf_id": 39, "parent": 2, "fw_parent": 0, "seq_id": 674, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::relu(Tensor self) -> Tensor",
+      "inputs": [[81,19,0,524288,4,"cuda:0"]], "input_shapes": [[512,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[80,84,0,524288,4,"cuda:0"]], "output_shapes": [[512,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::as_strided", "id": 92, "rf_id": 44, "parent": 91, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::as_strided(Tensor(a) self, SymInt[] size, SymInt[] stride, SymInt? storage_offset=None) -> Tensor(a)",
+      "inputs": [[85,86,0,1048576,4,"cuda:0"],[1024,1024],[1,1024],"<None>"], "input_shapes": [[1024,1024],[[],[]],[[],[]],[]], "input_types": ["Tensor(float)","GenericList[Int,Int]","GenericList[Int,Int]","None"],
+      "outputs": [[81,86,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::transpose", "id": 91, "rf_id": 43, "parent": 90, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::transpose.int(Tensor(a) self, int dim0, int dim1) -> Tensor(a)",
+      "inputs": [[85,86,0,1048576,4,"cuda:0"],0,1], "input_shapes": [[1024,1024],[],[]], "input_types": ["Tensor(float)","Int","Int"],
+      "outputs": [[81,86,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::t", "id": 90, "rf_id": 42, "parent": 89, "fw_parent": 0, "seq_id": 675, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::t(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[85,86,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[81,86,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty", "id": 94, "rf_id": 46, "parent": 93, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[1048576],0,"<None>","cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","None","Device","None","None"],
+      "outputs": [[95,17,0,1048576,1,"cuda:0"]], "output_shapes": [[1048576]], "output_types": ["Tensor(unsigned char)"]
+    },
+    {
+      "name": "aten::addmm", "id": 93, "rf_id": 45, "parent": 89, "fw_parent": 0, "seq_id": 676, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::addmm(Tensor self, Tensor mat1, Tensor mat2, *, Scalar beta=1, Scalar alpha=1) -> Tensor",
+      "inputs": [[87,88,0,1024,4,"cuda:0"],[80,84,0,524288,4,"cuda:0"],[81,86,0,1048576,4,"cuda:0"],1,1], "input_shapes": [[1024],[512,1024],[1024,1024],[],[]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(float)","Int","Int"],
+      "outputs": [[96,19,0,524288,4,"cuda:0"]], "output_shapes": [[512,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::linear", "id": 89, "rf_id": 41, "parent": 2, "fw_parent": 0, "seq_id": 675, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::linear(Tensor input, Tensor weight, Tensor? bias=None) -> Tensor",
+      "inputs": [[80,84,0,524288,4,"cuda:0"],[85,86,0,1048576,4,"cuda:0"],[87,88,0,1024,4,"cuda:0"]], "input_shapes": [[512,1024],[1024,1024],[1024]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(float)"],
+      "outputs": [[96,19,0,524288,4,"cuda:0"]], "output_shapes": [[512,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::clamp_min", "id": 98, "rf_id": 48, "parent": 97, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::clamp_min(Tensor self, Scalar min) -> Tensor",
+      "inputs": [[96,19,0,524288,4,"cuda:0"],0], "input_shapes": [[512,1024],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [[95,99,0,524288,4,"cuda:0"]], "output_shapes": [[512,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::relu", "id": 97, "rf_id": 47, "parent": 2, "fw_parent": 0, "seq_id": 677, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::relu(Tensor self) -> Tensor",
+      "inputs": [[96,19,0,524288,4,"cuda:0"]], "input_shapes": [[512,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[95,99,0,524288,4,"cuda:0"]], "output_shapes": [[512,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::as_strided", "id": 107, "rf_id": 52, "parent": 106, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::as_strided(Tensor(a) self, SymInt[] size, SymInt[] stride, SymInt? storage_offset=None) -> Tensor(a)",
+      "inputs": [[100,101,0,1048576,4,"cuda:0"],[1024,1024],[1,1024],"<None>"], "input_shapes": [[1024,1024],[[],[]],[[],[]],[]], "input_types": ["Tensor(float)","GenericList[Int,Int]","GenericList[Int,Int]","None"],
+      "outputs": [[108,101,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::transpose", "id": 106, "rf_id": 51, "parent": 105, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::transpose.int(Tensor(a) self, int dim0, int dim1) -> Tensor(a)",
+      "inputs": [[100,101,0,1048576,4,"cuda:0"],0,1], "input_shapes": [[1024,1024],[],[]], "input_types": ["Tensor(float)","Int","Int"],
+      "outputs": [[108,101,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::t", "id": 105, "rf_id": 50, "parent": 104, "fw_parent": 0, "seq_id": 678, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::t(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[100,101,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[108,101,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty", "id": 110, "rf_id": 54, "parent": 109, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[1048576],0,"<None>","cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","None","Device","None","None"],
+      "outputs": [[111,17,0,1048576,1,"cuda:0"]], "output_shapes": [[1048576]], "output_types": ["Tensor(unsigned char)"]
+    },
+    {
+      "name": "aten::addmm", "id": 109, "rf_id": 53, "parent": 104, "fw_parent": 0, "seq_id": 679, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::addmm(Tensor self, Tensor mat1, Tensor mat2, *, Scalar beta=1, Scalar alpha=1) -> Tensor",
+      "inputs": [[102,103,0,1024,4,"cuda:0"],[95,99,0,524288,4,"cuda:0"],[108,101,0,1048576,4,"cuda:0"],1,1], "input_shapes": [[1024],[512,1024],[1024,1024],[],[]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(float)","Int","Int"],
+      "outputs": [[112,19,0,524288,4,"cuda:0"]], "output_shapes": [[512,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::linear", "id": 104, "rf_id": 49, "parent": 2, "fw_parent": 0, "seq_id": 678, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::linear(Tensor input, Tensor weight, Tensor? bias=None) -> Tensor",
+      "inputs": [[95,99,0,524288,4,"cuda:0"],[100,101,0,1048576,4,"cuda:0"],[102,103,0,1024,4,"cuda:0"]], "input_shapes": [[512,1024],[1024,1024],[1024]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(float)"],
+      "outputs": [[112,19,0,524288,4,"cuda:0"]], "output_shapes": [[512,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::clamp_min", "id": 114, "rf_id": 56, "parent": 113, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::clamp_min(Tensor self, Scalar min) -> Tensor",
+      "inputs": [[112,19,0,524288,4,"cuda:0"],0], "input_shapes": [[512,1024],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [[111,115,0,524288,4,"cuda:0"]], "output_shapes": [[512,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::relu", "id": 113, "rf_id": 55, "parent": 2, "fw_parent": 0, "seq_id": 680, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::relu(Tensor self) -> Tensor",
+      "inputs": [[112,19,0,524288,4,"cuda:0"]], "input_shapes": [[512,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[111,115,0,524288,4,"cuda:0"]], "output_shapes": [[512,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::as_strided", "id": 123, "rf_id": 60, "parent": 122, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::as_strided(Tensor(a) self, SymInt[] size, SymInt[] stride, SymInt? storage_offset=None) -> Tensor(a)",
+      "inputs": [[116,117,0,1048576,4,"cuda:0"],[1024,1024],[1,1024],"<None>"], "input_shapes": [[1024,1024],[[],[]],[[],[]],[]], "input_types": ["Tensor(float)","GenericList[Int,Int]","GenericList[Int,Int]","None"],
+      "outputs": [[112,117,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::transpose", "id": 122, "rf_id": 59, "parent": 121, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::transpose.int(Tensor(a) self, int dim0, int dim1) -> Tensor(a)",
+      "inputs": [[116,117,0,1048576,4,"cuda:0"],0,1], "input_shapes": [[1024,1024],[],[]], "input_types": ["Tensor(float)","Int","Int"],
+      "outputs": [[112,117,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::t", "id": 121, "rf_id": 58, "parent": 120, "fw_parent": 0, "seq_id": 681, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::t(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[116,117,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[112,117,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty", "id": 125, "rf_id": 62, "parent": 124, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[1048576],0,"<None>","cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","None","Device","None","None"],
+      "outputs": [[126,17,0,1048576,1,"cuda:0"]], "output_shapes": [[1048576]], "output_types": ["Tensor(unsigned char)"]
+    },
+    {
+      "name": "aten::addmm", "id": 124, "rf_id": 61, "parent": 120, "fw_parent": 0, "seq_id": 682, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::addmm(Tensor self, Tensor mat1, Tensor mat2, *, Scalar beta=1, Scalar alpha=1) -> Tensor",
+      "inputs": [[118,119,0,1024,4,"cuda:0"],[111,115,0,524288,4,"cuda:0"],[112,117,0,1048576,4,"cuda:0"],1,1], "input_shapes": [[1024],[512,1024],[1024,1024],[],[]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(float)","Int","Int"],
+      "outputs": [[127,128,0,524288,4,"cuda:0"]], "output_shapes": [[512,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::linear", "id": 120, "rf_id": 57, "parent": 2, "fw_parent": 0, "seq_id": 681, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::linear(Tensor input, Tensor weight, Tensor? bias=None) -> Tensor",
+      "inputs": [[111,115,0,524288,4,"cuda:0"],[116,117,0,1048576,4,"cuda:0"],[118,119,0,1024,4,"cuda:0"]], "input_shapes": [[512,1024],[1024,1024],[1024]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(float)"],
+      "outputs": [[127,128,0,524288,4,"cuda:0"]], "output_shapes": [[512,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::clamp_min", "id": 130, "rf_id": 64, "parent": 129, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::clamp_min(Tensor self, Scalar min) -> Tensor",
+      "inputs": [[127,128,0,524288,4,"cuda:0"],0], "input_shapes": [[512,1024],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [[126,19,0,524288,4,"cuda:0"]], "output_shapes": [[512,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::relu", "id": 129, "rf_id": 63, "parent": 2, "fw_parent": 0, "seq_id": 683, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::relu(Tensor self) -> Tensor",
+      "inputs": [[127,128,0,524288,4,"cuda:0"]], "input_shapes": [[512,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[126,19,0,524288,4,"cuda:0"]], "output_shapes": [[512,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::as_strided", "id": 138, "rf_id": 68, "parent": 137, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::as_strided(Tensor(a) self, SymInt[] size, SymInt[] stride, SymInt? storage_offset=None) -> Tensor(a)",
+      "inputs": [[131,132,0,1048576,4,"cuda:0"],[1024,1024],[1,1024],"<None>"], "input_shapes": [[1024,1024],[[],[]],[[],[]],[]], "input_types": ["Tensor(float)","GenericList[Int,Int]","GenericList[Int,Int]","None"],
+      "outputs": [[127,132,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::transpose", "id": 137, "rf_id": 67, "parent": 136, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::transpose.int(Tensor(a) self, int dim0, int dim1) -> Tensor(a)",
+      "inputs": [[131,132,0,1048576,4,"cuda:0"],0,1], "input_shapes": [[1024,1024],[],[]], "input_types": ["Tensor(float)","Int","Int"],
+      "outputs": [[127,132,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::t", "id": 136, "rf_id": 66, "parent": 135, "fw_parent": 0, "seq_id": 684, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::t(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[131,132,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[127,132,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty", "id": 140, "rf_id": 70, "parent": 139, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[1048576],0,"<None>","cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","None","Device","None","None"],
+      "outputs": [[141,17,0,1048576,1,"cuda:0"]], "output_shapes": [[1048576]], "output_types": ["Tensor(unsigned char)"]
+    },
+    {
+      "name": "aten::addmm", "id": 139, "rf_id": 69, "parent": 135, "fw_parent": 0, "seq_id": 685, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::addmm(Tensor self, Tensor mat1, Tensor mat2, *, Scalar beta=1, Scalar alpha=1) -> Tensor",
+      "inputs": [[133,134,0,1024,4,"cuda:0"],[126,19,0,524288,4,"cuda:0"],[127,132,0,1048576,4,"cuda:0"],1,1], "input_shapes": [[1024],[512,1024],[1024,1024],[],[]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(float)","Int","Int"],
+      "outputs": [[142,128,0,524288,4,"cuda:0"]], "output_shapes": [[512,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::linear", "id": 135, "rf_id": 65, "parent": 2, "fw_parent": 0, "seq_id": 684, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::linear(Tensor input, Tensor weight, Tensor? bias=None) -> Tensor",
+      "inputs": [[126,19,0,524288,4,"cuda:0"],[131,132,0,1048576,4,"cuda:0"],[133,134,0,1024,4,"cuda:0"]], "input_shapes": [[512,1024],[1024,1024],[1024]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(float)"],
+      "outputs": [[142,128,0,524288,4,"cuda:0"]], "output_shapes": [[512,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::clamp_min", "id": 144, "rf_id": 72, "parent": 143, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::clamp_min(Tensor self, Scalar min) -> Tensor",
+      "inputs": [[142,128,0,524288,4,"cuda:0"],0], "input_shapes": [[512,1024],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [[141,145,0,524288,4,"cuda:0"]], "output_shapes": [[512,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::relu", "id": 143, "rf_id": 71, "parent": 2, "fw_parent": 0, "seq_id": 686, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::relu(Tensor self) -> Tensor",
+      "inputs": [[142,128,0,524288,4,"cuda:0"]], "input_shapes": [[512,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[141,145,0,524288,4,"cuda:0"]], "output_shapes": [[512,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::as_strided", "id": 153, "rf_id": 76, "parent": 152, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::as_strided(Tensor(a) self, SymInt[] size, SymInt[] stride, SymInt? storage_offset=None) -> Tensor(a)",
+      "inputs": [[146,147,0,1048576,4,"cuda:0"],[1024,1024],[1,1024],"<None>"], "input_shapes": [[1024,1024],[[],[]],[[],[]],[]], "input_types": ["Tensor(float)","GenericList[Int,Int]","GenericList[Int,Int]","None"],
+      "outputs": [[142,147,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::transpose", "id": 152, "rf_id": 75, "parent": 151, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::transpose.int(Tensor(a) self, int dim0, int dim1) -> Tensor(a)",
+      "inputs": [[146,147,0,1048576,4,"cuda:0"],0,1], "input_shapes": [[1024,1024],[],[]], "input_types": ["Tensor(float)","Int","Int"],
+      "outputs": [[142,147,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::t", "id": 151, "rf_id": 74, "parent": 150, "fw_parent": 0, "seq_id": 687, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::t(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[146,147,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[142,147,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty", "id": 155, "rf_id": 78, "parent": 154, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[1048576],0,"<None>","cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","None","Device","None","None"],
+      "outputs": [[156,17,0,1048576,1,"cuda:0"]], "output_shapes": [[1048576]], "output_types": ["Tensor(unsigned char)"]
+    },
+    {
+      "name": "aten::addmm", "id": 154, "rf_id": 77, "parent": 150, "fw_parent": 0, "seq_id": 688, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::addmm(Tensor self, Tensor mat1, Tensor mat2, *, Scalar beta=1, Scalar alpha=1) -> Tensor",
+      "inputs": [[148,149,0,1024,4,"cuda:0"],[141,145,0,524288,4,"cuda:0"],[142,147,0,1048576,4,"cuda:0"],1,1], "input_shapes": [[1024],[512,1024],[1024,1024],[],[]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(float)","Int","Int"],
+      "outputs": [[157,128,0,524288,4,"cuda:0"]], "output_shapes": [[512,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::linear", "id": 150, "rf_id": 73, "parent": 2, "fw_parent": 0, "seq_id": 687, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::linear(Tensor input, Tensor weight, Tensor? bias=None) -> Tensor",
+      "inputs": [[141,145,0,524288,4,"cuda:0"],[146,147,0,1048576,4,"cuda:0"],[148,149,0,1024,4,"cuda:0"]], "input_shapes": [[512,1024],[1024,1024],[1024]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(float)"],
+      "outputs": [[157,128,0,524288,4,"cuda:0"]], "output_shapes": [[512,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::clamp_min", "id": 159, "rf_id": 80, "parent": 158, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::clamp_min(Tensor self, Scalar min) -> Tensor",
+      "inputs": [[157,128,0,524288,4,"cuda:0"],0], "input_shapes": [[512,1024],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [[156,160,0,524288,4,"cuda:0"]], "output_shapes": [[512,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::relu", "id": 158, "rf_id": 79, "parent": 2, "fw_parent": 0, "seq_id": 689, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::relu(Tensor self) -> Tensor",
+      "inputs": [[157,128,0,524288,4,"cuda:0"]], "input_shapes": [[512,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[156,160,0,524288,4,"cuda:0"]], "output_shapes": [[512,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::as_strided", "id": 168, "rf_id": 84, "parent": 167, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::as_strided(Tensor(a) self, SymInt[] size, SymInt[] stride, SymInt? storage_offset=None) -> Tensor(a)",
+      "inputs": [[161,162,0,1048576,4,"cuda:0"],[1024,1024],[1,1024],"<None>"], "input_shapes": [[1024,1024],[[],[]],[[],[]],[]], "input_types": ["Tensor(float)","GenericList[Int,Int]","GenericList[Int,Int]","None"],
+      "outputs": [[157,162,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::transpose", "id": 167, "rf_id": 83, "parent": 166, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::transpose.int(Tensor(a) self, int dim0, int dim1) -> Tensor(a)",
+      "inputs": [[161,162,0,1048576,4,"cuda:0"],0,1], "input_shapes": [[1024,1024],[],[]], "input_types": ["Tensor(float)","Int","Int"],
+      "outputs": [[157,162,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::t", "id": 166, "rf_id": 82, "parent": 165, "fw_parent": 0, "seq_id": 690, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::t(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[161,162,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[157,162,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty", "id": 170, "rf_id": 86, "parent": 169, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[1048576],0,"<None>","cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","None","Device","None","None"],
+      "outputs": [[171,17,0,1048576,1,"cuda:0"]], "output_shapes": [[1048576]], "output_types": ["Tensor(unsigned char)"]
+    },
+    {
+      "name": "aten::addmm", "id": 169, "rf_id": 85, "parent": 165, "fw_parent": 0, "seq_id": 691, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::addmm(Tensor self, Tensor mat1, Tensor mat2, *, Scalar beta=1, Scalar alpha=1) -> Tensor",
+      "inputs": [[163,164,0,1024,4,"cuda:0"],[156,160,0,524288,4,"cuda:0"],[157,162,0,1048576,4,"cuda:0"],1,1], "input_shapes": [[1024],[512,1024],[1024,1024],[],[]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(float)","Int","Int"],
+      "outputs": [[172,128,0,524288,4,"cuda:0"]], "output_shapes": [[512,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::linear", "id": 165, "rf_id": 81, "parent": 2, "fw_parent": 0, "seq_id": 690, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::linear(Tensor input, Tensor weight, Tensor? bias=None) -> Tensor",
+      "inputs": [[156,160,0,524288,4,"cuda:0"],[161,162,0,1048576,4,"cuda:0"],[163,164,0,1024,4,"cuda:0"]], "input_shapes": [[512,1024],[1024,1024],[1024]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(float)"],
+      "outputs": [[172,128,0,524288,4,"cuda:0"]], "output_shapes": [[512,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::clamp_min", "id": 174, "rf_id": 88, "parent": 173, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::clamp_min(Tensor self, Scalar min) -> Tensor",
+      "inputs": [[172,128,0,524288,4,"cuda:0"],0], "input_shapes": [[512,1024],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [[171,175,0,524288,4,"cuda:0"]], "output_shapes": [[512,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::relu", "id": 173, "rf_id": 87, "parent": 2, "fw_parent": 0, "seq_id": 692, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::relu(Tensor self) -> Tensor",
+      "inputs": [[172,128,0,524288,4,"cuda:0"]], "input_shapes": [[512,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[171,175,0,524288,4,"cuda:0"]], "output_shapes": [[512,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::as_strided", "id": 183, "rf_id": 92, "parent": 182, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::as_strided(Tensor(a) self, SymInt[] size, SymInt[] stride, SymInt? storage_offset=None) -> Tensor(a)",
+      "inputs": [[176,177,0,1048576,4,"cuda:0"],[1024,1024],[1,1024],"<None>"], "input_shapes": [[1024,1024],[[],[]],[[],[]],[]], "input_types": ["Tensor(float)","GenericList[Int,Int]","GenericList[Int,Int]","None"],
+      "outputs": [[172,177,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::transpose", "id": 182, "rf_id": 91, "parent": 181, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::transpose.int(Tensor(a) self, int dim0, int dim1) -> Tensor(a)",
+      "inputs": [[176,177,0,1048576,4,"cuda:0"],0,1], "input_shapes": [[1024,1024],[],[]], "input_types": ["Tensor(float)","Int","Int"],
+      "outputs": [[172,177,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::t", "id": 181, "rf_id": 90, "parent": 180, "fw_parent": 0, "seq_id": 693, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::t(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[176,177,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[172,177,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty", "id": 185, "rf_id": 94, "parent": 184, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[1048576],0,"<None>","cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","None","Device","None","None"],
+      "outputs": [[186,17,0,1048576,1,"cuda:0"]], "output_shapes": [[1048576]], "output_types": ["Tensor(unsigned char)"]
+    },
+    {
+      "name": "aten::addmm", "id": 184, "rf_id": 93, "parent": 180, "fw_parent": 0, "seq_id": 694, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::addmm(Tensor self, Tensor mat1, Tensor mat2, *, Scalar beta=1, Scalar alpha=1) -> Tensor",
+      "inputs": [[178,179,0,1024,4,"cuda:0"],[171,175,0,524288,4,"cuda:0"],[172,177,0,1048576,4,"cuda:0"],1,1], "input_shapes": [[1024],[512,1024],[1024,1024],[],[]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(float)","Int","Int"],
+      "outputs": [[187,128,0,524288,4,"cuda:0"]], "output_shapes": [[512,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::linear", "id": 180, "rf_id": 89, "parent": 2, "fw_parent": 0, "seq_id": 693, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::linear(Tensor input, Tensor weight, Tensor? bias=None) -> Tensor",
+      "inputs": [[171,175,0,524288,4,"cuda:0"],[176,177,0,1048576,4,"cuda:0"],[178,179,0,1024,4,"cuda:0"]], "input_shapes": [[512,1024],[1024,1024],[1024]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(float)"],
+      "outputs": [[187,128,0,524288,4,"cuda:0"]], "output_shapes": [[512,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::clamp_min", "id": 189, "rf_id": 96, "parent": 188, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::clamp_min(Tensor self, Scalar min) -> Tensor",
+      "inputs": [[187,128,0,524288,4,"cuda:0"],0], "input_shapes": [[512,1024],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [[186,190,0,524288,4,"cuda:0"]], "output_shapes": [[512,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::relu", "id": 188, "rf_id": 95, "parent": 2, "fw_parent": 0, "seq_id": 695, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::relu(Tensor self) -> Tensor",
+      "inputs": [[187,128,0,524288,4,"cuda:0"]], "input_shapes": [[512,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[186,190,0,524288,4,"cuda:0"]], "output_shapes": [[512,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::as_strided", "id": 198, "rf_id": 100, "parent": 197, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::as_strided(Tensor(a) self, SymInt[] size, SymInt[] stride, SymInt? storage_offset=None) -> Tensor(a)",
+      "inputs": [[191,192,0,1048576,4,"cuda:0"],[1024,1024],[1,1024],"<None>"], "input_shapes": [[1024,1024],[[],[]],[[],[]],[]], "input_types": ["Tensor(float)","GenericList[Int,Int]","GenericList[Int,Int]","None"],
+      "outputs": [[187,192,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::transpose", "id": 197, "rf_id": 99, "parent": 196, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::transpose.int(Tensor(a) self, int dim0, int dim1) -> Tensor(a)",
+      "inputs": [[191,192,0,1048576,4,"cuda:0"],0,1], "input_shapes": [[1024,1024],[],[]], "input_types": ["Tensor(float)","Int","Int"],
+      "outputs": [[187,192,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::t", "id": 196, "rf_id": 98, "parent": 195, "fw_parent": 0, "seq_id": 696, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::t(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[191,192,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[187,192,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty", "id": 200, "rf_id": 102, "parent": 199, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[1048576],0,"<None>","cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","None","Device","None","None"],
+      "outputs": [[201,17,0,1048576,1,"cuda:0"]], "output_shapes": [[1048576]], "output_types": ["Tensor(unsigned char)"]
+    },
+    {
+      "name": "aten::addmm", "id": 199, "rf_id": 101, "parent": 195, "fw_parent": 0, "seq_id": 697, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::addmm(Tensor self, Tensor mat1, Tensor mat2, *, Scalar beta=1, Scalar alpha=1) -> Tensor",
+      "inputs": [[193,194,0,1024,4,"cuda:0"],[186,190,0,524288,4,"cuda:0"],[187,192,0,1048576,4,"cuda:0"],1,1], "input_shapes": [[1024],[512,1024],[1024,1024],[],[]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(float)","Int","Int"],
+      "outputs": [[202,203,0,524288,4,"cuda:0"]], "output_shapes": [[512,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::linear", "id": 195, "rf_id": 97, "parent": 2, "fw_parent": 0, "seq_id": 696, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::linear(Tensor input, Tensor weight, Tensor? bias=None) -> Tensor",
+      "inputs": [[186,190,0,524288,4,"cuda:0"],[191,192,0,1048576,4,"cuda:0"],[193,194,0,1024,4,"cuda:0"]], "input_shapes": [[512,1024],[1024,1024],[1024]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(float)"],
+      "outputs": [[202,203,0,524288,4,"cuda:0"]], "output_shapes": [[512,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::clamp_min", "id": 205, "rf_id": 104, "parent": 204, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::clamp_min(Tensor self, Scalar min) -> Tensor",
+      "inputs": [[202,203,0,524288,4,"cuda:0"],0], "input_shapes": [[512,1024],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [[201,128,0,524288,4,"cuda:0"]], "output_shapes": [[512,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::relu", "id": 204, "rf_id": 103, "parent": 2, "fw_parent": 0, "seq_id": 698, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::relu(Tensor self) -> Tensor",
+      "inputs": [[202,203,0,524288,4,"cuda:0"]], "input_shapes": [[512,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[201,128,0,524288,4,"cuda:0"]], "output_shapes": [[512,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::as_strided", "id": 213, "rf_id": 108, "parent": 212, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::as_strided(Tensor(a) self, SymInt[] size, SymInt[] stride, SymInt? storage_offset=None) -> Tensor(a)",
+      "inputs": [[206,207,0,1048576,4,"cuda:0"],[1024,1024],[1,1024],"<None>"], "input_shapes": [[1024,1024],[[],[]],[[],[]],[]], "input_types": ["Tensor(float)","GenericList[Int,Int]","GenericList[Int,Int]","None"],
+      "outputs": [[202,207,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::transpose", "id": 212, "rf_id": 107, "parent": 211, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::transpose.int(Tensor(a) self, int dim0, int dim1) -> Tensor(a)",
+      "inputs": [[206,207,0,1048576,4,"cuda:0"],0,1], "input_shapes": [[1024,1024],[],[]], "input_types": ["Tensor(float)","Int","Int"],
+      "outputs": [[202,207,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::t", "id": 211, "rf_id": 106, "parent": 210, "fw_parent": 0, "seq_id": 699, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::t(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[206,207,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[202,207,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty", "id": 215, "rf_id": 110, "parent": 214, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[1048576],0,"<None>","cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","None","Device","None","None"],
+      "outputs": [[216,17,0,1048576,1,"cuda:0"]], "output_shapes": [[1048576]], "output_types": ["Tensor(unsigned char)"]
+    },
+    {
+      "name": "aten::addmm", "id": 214, "rf_id": 109, "parent": 210, "fw_parent": 0, "seq_id": 700, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::addmm(Tensor self, Tensor mat1, Tensor mat2, *, Scalar beta=1, Scalar alpha=1) -> Tensor",
+      "inputs": [[208,209,0,1024,4,"cuda:0"],[201,128,0,524288,4,"cuda:0"],[202,207,0,1048576,4,"cuda:0"],1,1], "input_shapes": [[1024],[512,1024],[1024,1024],[],[]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(float)","Int","Int"],
+      "outputs": [[217,203,0,524288,4,"cuda:0"]], "output_shapes": [[512,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::linear", "id": 210, "rf_id": 105, "parent": 2, "fw_parent": 0, "seq_id": 699, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::linear(Tensor input, Tensor weight, Tensor? bias=None) -> Tensor",
+      "inputs": [[201,128,0,524288,4,"cuda:0"],[206,207,0,1048576,4,"cuda:0"],[208,209,0,1024,4,"cuda:0"]], "input_shapes": [[512,1024],[1024,1024],[1024]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(float)"],
+      "outputs": [[217,203,0,524288,4,"cuda:0"]], "output_shapes": [[512,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::clamp_min", "id": 219, "rf_id": 112, "parent": 218, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::clamp_min(Tensor self, Scalar min) -> Tensor",
+      "inputs": [[217,203,0,524288,4,"cuda:0"],0], "input_shapes": [[512,1024],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [[216,220,0,524288,4,"cuda:0"]], "output_shapes": [[512,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::relu", "id": 218, "rf_id": 111, "parent": 2, "fw_parent": 0, "seq_id": 701, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::relu(Tensor self) -> Tensor",
+      "inputs": [[217,203,0,524288,4,"cuda:0"]], "input_shapes": [[512,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[216,220,0,524288,4,"cuda:0"]], "output_shapes": [[512,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::as_strided", "id": 228, "rf_id": 116, "parent": 227, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::as_strided(Tensor(a) self, SymInt[] size, SymInt[] stride, SymInt? storage_offset=None) -> Tensor(a)",
+      "inputs": [[221,222,0,1048576,4,"cuda:0"],[1024,1024],[1,1024],"<None>"], "input_shapes": [[1024,1024],[[],[]],[[],[]],[]], "input_types": ["Tensor(float)","GenericList[Int,Int]","GenericList[Int,Int]","None"],
+      "outputs": [[217,222,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::transpose", "id": 227, "rf_id": 115, "parent": 226, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::transpose.int(Tensor(a) self, int dim0, int dim1) -> Tensor(a)",
+      "inputs": [[221,222,0,1048576,4,"cuda:0"],0,1], "input_shapes": [[1024,1024],[],[]], "input_types": ["Tensor(float)","Int","Int"],
+      "outputs": [[217,222,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::t", "id": 226, "rf_id": 114, "parent": 225, "fw_parent": 0, "seq_id": 702, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::t(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[221,222,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[217,222,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty", "id": 230, "rf_id": 118, "parent": 229, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[1048576],0,"<None>","cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","None","Device","None","None"],
+      "outputs": [[231,17,0,1048576,1,"cuda:0"]], "output_shapes": [[1048576]], "output_types": ["Tensor(unsigned char)"]
+    },
+    {
+      "name": "aten::addmm", "id": 229, "rf_id": 117, "parent": 225, "fw_parent": 0, "seq_id": 703, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::addmm(Tensor self, Tensor mat1, Tensor mat2, *, Scalar beta=1, Scalar alpha=1) -> Tensor",
+      "inputs": [[223,224,0,1024,4,"cuda:0"],[216,220,0,524288,4,"cuda:0"],[217,222,0,1048576,4,"cuda:0"],1,1], "input_shapes": [[1024],[512,1024],[1024,1024],[],[]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(float)","Int","Int"],
+      "outputs": [[232,203,0,524288,4,"cuda:0"]], "output_shapes": [[512,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::linear", "id": 225, "rf_id": 113, "parent": 2, "fw_parent": 0, "seq_id": 702, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::linear(Tensor input, Tensor weight, Tensor? bias=None) -> Tensor",
+      "inputs": [[216,220,0,524288,4,"cuda:0"],[221,222,0,1048576,4,"cuda:0"],[223,224,0,1024,4,"cuda:0"]], "input_shapes": [[512,1024],[1024,1024],[1024]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(float)"],
+      "outputs": [[232,203,0,524288,4,"cuda:0"]], "output_shapes": [[512,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::clamp_min", "id": 234, "rf_id": 120, "parent": 233, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::clamp_min(Tensor self, Scalar min) -> Tensor",
+      "inputs": [[232,203,0,524288,4,"cuda:0"],0], "input_shapes": [[512,1024],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [[231,235,0,524288,4,"cuda:0"]], "output_shapes": [[512,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::relu", "id": 233, "rf_id": 119, "parent": 2, "fw_parent": 0, "seq_id": 704, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::relu(Tensor self) -> Tensor",
+      "inputs": [[232,203,0,524288,4,"cuda:0"]], "input_shapes": [[512,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[231,235,0,524288,4,"cuda:0"]], "output_shapes": [[512,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::as_strided", "id": 243, "rf_id": 124, "parent": 242, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::as_strided(Tensor(a) self, SymInt[] size, SymInt[] stride, SymInt? storage_offset=None) -> Tensor(a)",
+      "inputs": [[236,237,0,1048576,4,"cuda:0"],[1024,1024],[1,1024],"<None>"], "input_shapes": [[1024,1024],[[],[]],[[],[]],[]], "input_types": ["Tensor(float)","GenericList[Int,Int]","GenericList[Int,Int]","None"],
+      "outputs": [[232,237,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::transpose", "id": 242, "rf_id": 123, "parent": 241, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::transpose.int(Tensor(a) self, int dim0, int dim1) -> Tensor(a)",
+      "inputs": [[236,237,0,1048576,4,"cuda:0"],0,1], "input_shapes": [[1024,1024],[],[]], "input_types": ["Tensor(float)","Int","Int"],
+      "outputs": [[232,237,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::t", "id": 241, "rf_id": 122, "parent": 240, "fw_parent": 0, "seq_id": 705, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::t(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[236,237,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[232,237,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty", "id": 245, "rf_id": 126, "parent": 244, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[1048576],0,"<None>","cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","None","Device","None","None"],
+      "outputs": [[246,17,0,1048576,1,"cuda:0"]], "output_shapes": [[1048576]], "output_types": ["Tensor(unsigned char)"]
+    },
+    {
+      "name": "aten::addmm", "id": 244, "rf_id": 125, "parent": 240, "fw_parent": 0, "seq_id": 706, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::addmm(Tensor self, Tensor mat1, Tensor mat2, *, Scalar beta=1, Scalar alpha=1) -> Tensor",
+      "inputs": [[238,239,0,1024,4,"cuda:0"],[231,235,0,524288,4,"cuda:0"],[232,237,0,1048576,4,"cuda:0"],1,1], "input_shapes": [[1024],[512,1024],[1024,1024],[],[]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(float)","Int","Int"],
+      "outputs": [[247,203,0,524288,4,"cuda:0"]], "output_shapes": [[512,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::linear", "id": 240, "rf_id": 121, "parent": 2, "fw_parent": 0, "seq_id": 705, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::linear(Tensor input, Tensor weight, Tensor? bias=None) -> Tensor",
+      "inputs": [[231,235,0,524288,4,"cuda:0"],[236,237,0,1048576,4,"cuda:0"],[238,239,0,1024,4,"cuda:0"]], "input_shapes": [[512,1024],[1024,1024],[1024]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(float)"],
+      "outputs": [[247,203,0,524288,4,"cuda:0"]], "output_shapes": [[512,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::clamp_min", "id": 249, "rf_id": 128, "parent": 248, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::clamp_min(Tensor self, Scalar min) -> Tensor",
+      "inputs": [[247,203,0,524288,4,"cuda:0"],0], "input_shapes": [[512,1024],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [[246,250,0,524288,4,"cuda:0"]], "output_shapes": [[512,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::relu", "id": 248, "rf_id": 127, "parent": 2, "fw_parent": 0, "seq_id": 707, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::relu(Tensor self) -> Tensor",
+      "inputs": [[247,203,0,524288,4,"cuda:0"]], "input_shapes": [[512,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[246,250,0,524288,4,"cuda:0"]], "output_shapes": [[512,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::as_strided", "id": 258, "rf_id": 132, "parent": 257, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::as_strided(Tensor(a) self, SymInt[] size, SymInt[] stride, SymInt? storage_offset=None) -> Tensor(a)",
+      "inputs": [[251,252,0,1048576,4,"cuda:0"],[1024,1024],[1,1024],"<None>"], "input_shapes": [[1024,1024],[[],[]],[[],[]],[]], "input_types": ["Tensor(float)","GenericList[Int,Int]","GenericList[Int,Int]","None"],
+      "outputs": [[247,252,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::transpose", "id": 257, "rf_id": 131, "parent": 256, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::transpose.int(Tensor(a) self, int dim0, int dim1) -> Tensor(a)",
+      "inputs": [[251,252,0,1048576,4,"cuda:0"],0,1], "input_shapes": [[1024,1024],[],[]], "input_types": ["Tensor(float)","Int","Int"],
+      "outputs": [[247,252,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::t", "id": 256, "rf_id": 130, "parent": 255, "fw_parent": 0, "seq_id": 708, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::t(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[251,252,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[247,252,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty", "id": 260, "rf_id": 134, "parent": 259, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[1048576],0,"<None>","cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","None","Device","None","None"],
+      "outputs": [[261,17,0,1048576,1,"cuda:0"]], "output_shapes": [[1048576]], "output_types": ["Tensor(unsigned char)"]
+    },
+    {
+      "name": "aten::addmm", "id": 259, "rf_id": 133, "parent": 255, "fw_parent": 0, "seq_id": 709, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::addmm(Tensor self, Tensor mat1, Tensor mat2, *, Scalar beta=1, Scalar alpha=1) -> Tensor",
+      "inputs": [[253,254,0,1024,4,"cuda:0"],[246,250,0,524288,4,"cuda:0"],[247,252,0,1048576,4,"cuda:0"],1,1], "input_shapes": [[1024],[512,1024],[1024,1024],[],[]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(float)","Int","Int"],
+      "outputs": [[262,203,0,524288,4,"cuda:0"]], "output_shapes": [[512,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::linear", "id": 255, "rf_id": 129, "parent": 2, "fw_parent": 0, "seq_id": 708, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::linear(Tensor input, Tensor weight, Tensor? bias=None) -> Tensor",
+      "inputs": [[246,250,0,524288,4,"cuda:0"],[251,252,0,1048576,4,"cuda:0"],[253,254,0,1024,4,"cuda:0"]], "input_shapes": [[512,1024],[1024,1024],[1024]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(float)"],
+      "outputs": [[262,203,0,524288,4,"cuda:0"]], "output_shapes": [[512,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::clamp_min", "id": 264, "rf_id": 136, "parent": 263, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::clamp_min(Tensor self, Scalar min) -> Tensor",
+      "inputs": [[262,203,0,524288,4,"cuda:0"],0], "input_shapes": [[512,1024],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [[261,265,0,524288,4,"cuda:0"]], "output_shapes": [[512,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::relu", "id": 263, "rf_id": 135, "parent": 2, "fw_parent": 0, "seq_id": 710, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::relu(Tensor self) -> Tensor",
+      "inputs": [[262,203,0,524288,4,"cuda:0"]], "input_shapes": [[512,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[261,265,0,524288,4,"cuda:0"]], "output_shapes": [[512,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::as_strided", "id": 273, "rf_id": 140, "parent": 272, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::as_strided(Tensor(a) self, SymInt[] size, SymInt[] stride, SymInt? storage_offset=None) -> Tensor(a)",
+      "inputs": [[266,267,0,1048576,4,"cuda:0"],[1024,1024],[1,1024],"<None>"], "input_shapes": [[1024,1024],[[],[]],[[],[]],[]], "input_types": ["Tensor(float)","GenericList[Int,Int]","GenericList[Int,Int]","None"],
+      "outputs": [[262,267,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::transpose", "id": 272, "rf_id": 139, "parent": 271, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::transpose.int(Tensor(a) self, int dim0, int dim1) -> Tensor(a)",
+      "inputs": [[266,267,0,1048576,4,"cuda:0"],0,1], "input_shapes": [[1024,1024],[],[]], "input_types": ["Tensor(float)","Int","Int"],
+      "outputs": [[262,267,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::t", "id": 271, "rf_id": 138, "parent": 270, "fw_parent": 0, "seq_id": 711, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::t(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[266,267,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[262,267,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty", "id": 275, "rf_id": 142, "parent": 274, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[1048576],0,"<None>","cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","None","Device","None","None"],
+      "outputs": [[276,17,0,1048576,1,"cuda:0"]], "output_shapes": [[1048576]], "output_types": ["Tensor(unsigned char)"]
+    },
+    {
+      "name": "aten::addmm", "id": 274, "rf_id": 141, "parent": 270, "fw_parent": 0, "seq_id": 712, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::addmm(Tensor self, Tensor mat1, Tensor mat2, *, Scalar beta=1, Scalar alpha=1) -> Tensor",
+      "inputs": [[268,269,0,1024,4,"cuda:0"],[261,265,0,524288,4,"cuda:0"],[262,267,0,1048576,4,"cuda:0"],1,1], "input_shapes": [[1024],[512,1024],[1024,1024],[],[]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(float)","Int","Int"],
+      "outputs": [[277,203,0,524288,4,"cuda:0"]], "output_shapes": [[512,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::linear", "id": 270, "rf_id": 137, "parent": 2, "fw_parent": 0, "seq_id": 711, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::linear(Tensor input, Tensor weight, Tensor? bias=None) -> Tensor",
+      "inputs": [[261,265,0,524288,4,"cuda:0"],[266,267,0,1048576,4,"cuda:0"],[268,269,0,1024,4,"cuda:0"]], "input_shapes": [[512,1024],[1024,1024],[1024]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(float)"],
+      "outputs": [[277,203,0,524288,4,"cuda:0"]], "output_shapes": [[512,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::clamp_min", "id": 279, "rf_id": 144, "parent": 278, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::clamp_min(Tensor self, Scalar min) -> Tensor",
+      "inputs": [[277,203,0,524288,4,"cuda:0"],0], "input_shapes": [[512,1024],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [[276,280,0,524288,4,"cuda:0"]], "output_shapes": [[512,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::relu", "id": 278, "rf_id": 143, "parent": 2, "fw_parent": 0, "seq_id": 713, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::relu(Tensor self) -> Tensor",
+      "inputs": [[277,203,0,524288,4,"cuda:0"]], "input_shapes": [[512,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[276,280,0,524288,4,"cuda:0"]], "output_shapes": [[512,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::as_strided", "id": 288, "rf_id": 148, "parent": 287, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::as_strided(Tensor(a) self, SymInt[] size, SymInt[] stride, SymInt? storage_offset=None) -> Tensor(a)",
+      "inputs": [[281,282,0,1048576,4,"cuda:0"],[1024,1024],[1,1024],"<None>"], "input_shapes": [[1024,1024],[[],[]],[[],[]],[]], "input_types": ["Tensor(float)","GenericList[Int,Int]","GenericList[Int,Int]","None"],
+      "outputs": [[277,282,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::transpose", "id": 287, "rf_id": 147, "parent": 286, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::transpose.int(Tensor(a) self, int dim0, int dim1) -> Tensor(a)",
+      "inputs": [[281,282,0,1048576,4,"cuda:0"],0,1], "input_shapes": [[1024,1024],[],[]], "input_types": ["Tensor(float)","Int","Int"],
+      "outputs": [[277,282,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::t", "id": 286, "rf_id": 146, "parent": 285, "fw_parent": 0, "seq_id": 714, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::t(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[281,282,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[277,282,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty", "id": 290, "rf_id": 150, "parent": 289, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[1048576],0,"<None>","cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","None","Device","None","None"],
+      "outputs": [[291,17,0,1048576,1,"cuda:0"]], "output_shapes": [[1048576]], "output_types": ["Tensor(unsigned char)"]
+    },
+    {
+      "name": "aten::addmm", "id": 289, "rf_id": 149, "parent": 285, "fw_parent": 0, "seq_id": 715, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::addmm(Tensor self, Tensor mat1, Tensor mat2, *, Scalar beta=1, Scalar alpha=1) -> Tensor",
+      "inputs": [[283,284,0,1024,4,"cuda:0"],[276,280,0,524288,4,"cuda:0"],[277,282,0,1048576,4,"cuda:0"],1,1], "input_shapes": [[1024],[512,1024],[1024,1024],[],[]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(float)","Int","Int"],
+      "outputs": [[292,203,0,524288,4,"cuda:0"]], "output_shapes": [[512,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::linear", "id": 285, "rf_id": 145, "parent": 2, "fw_parent": 0, "seq_id": 714, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::linear(Tensor input, Tensor weight, Tensor? bias=None) -> Tensor",
+      "inputs": [[276,280,0,524288,4,"cuda:0"],[281,282,0,1048576,4,"cuda:0"],[283,284,0,1024,4,"cuda:0"]], "input_shapes": [[512,1024],[1024,1024],[1024]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(float)"],
+      "outputs": [[292,203,0,524288,4,"cuda:0"]], "output_shapes": [[512,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::clamp_min", "id": 294, "rf_id": 152, "parent": 293, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::clamp_min(Tensor self, Scalar min) -> Tensor",
+      "inputs": [[292,203,0,524288,4,"cuda:0"],0], "input_shapes": [[512,1024],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [[291,295,0,524288,4,"cuda:0"]], "output_shapes": [[512,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::relu", "id": 293, "rf_id": 151, "parent": 2, "fw_parent": 0, "seq_id": 716, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::relu(Tensor self) -> Tensor",
+      "inputs": [[292,203,0,524288,4,"cuda:0"]], "input_shapes": [[512,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[291,295,0,524288,4,"cuda:0"]], "output_shapes": [[512,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::as_strided", "id": 303, "rf_id": 156, "parent": 302, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::as_strided(Tensor(a) self, SymInt[] size, SymInt[] stride, SymInt? storage_offset=None) -> Tensor(a)",
+      "inputs": [[296,297,0,1048576,4,"cuda:0"],[1024,1024],[1,1024],"<None>"], "input_shapes": [[1024,1024],[[],[]],[[],[]],[]], "input_types": ["Tensor(float)","GenericList[Int,Int]","GenericList[Int,Int]","None"],
+      "outputs": [[292,297,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::transpose", "id": 302, "rf_id": 155, "parent": 301, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::transpose.int(Tensor(a) self, int dim0, int dim1) -> Tensor(a)",
+      "inputs": [[296,297,0,1048576,4,"cuda:0"],0,1], "input_shapes": [[1024,1024],[],[]], "input_types": ["Tensor(float)","Int","Int"],
+      "outputs": [[292,297,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::t", "id": 301, "rf_id": 154, "parent": 300, "fw_parent": 0, "seq_id": 717, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::t(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[296,297,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[292,297,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty", "id": 305, "rf_id": 158, "parent": 304, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[1048576],0,"<None>","cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","None","Device","None","None"],
+      "outputs": [[306,17,0,1048576,1,"cuda:0"]], "output_shapes": [[1048576]], "output_types": ["Tensor(unsigned char)"]
+    },
+    {
+      "name": "aten::addmm", "id": 304, "rf_id": 157, "parent": 300, "fw_parent": 0, "seq_id": 718, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::addmm(Tensor self, Tensor mat1, Tensor mat2, *, Scalar beta=1, Scalar alpha=1) -> Tensor",
+      "inputs": [[298,299,0,1024,4,"cuda:0"],[291,295,0,524288,4,"cuda:0"],[292,297,0,1048576,4,"cuda:0"],1,1], "input_shapes": [[1024],[512,1024],[1024,1024],[],[]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(float)","Int","Int"],
+      "outputs": [[307,203,0,524288,4,"cuda:0"]], "output_shapes": [[512,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::linear", "id": 300, "rf_id": 153, "parent": 2, "fw_parent": 0, "seq_id": 717, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::linear(Tensor input, Tensor weight, Tensor? bias=None) -> Tensor",
+      "inputs": [[291,295,0,524288,4,"cuda:0"],[296,297,0,1048576,4,"cuda:0"],[298,299,0,1024,4,"cuda:0"]], "input_shapes": [[512,1024],[1024,1024],[1024]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(float)"],
+      "outputs": [[307,203,0,524288,4,"cuda:0"]], "output_shapes": [[512,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::clamp_min", "id": 309, "rf_id": 160, "parent": 308, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::clamp_min(Tensor self, Scalar min) -> Tensor",
+      "inputs": [[307,203,0,524288,4,"cuda:0"],0], "input_shapes": [[512,1024],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [[306,310,0,524288,4,"cuda:0"]], "output_shapes": [[512,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::relu", "id": 308, "rf_id": 159, "parent": 2, "fw_parent": 0, "seq_id": 719, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::relu(Tensor self) -> Tensor",
+      "inputs": [[307,203,0,524288,4,"cuda:0"]], "input_shapes": [[512,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[306,310,0,524288,4,"cuda:0"]], "output_shapes": [[512,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::as_strided", "id": 318, "rf_id": 164, "parent": 317, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::as_strided(Tensor(a) self, SymInt[] size, SymInt[] stride, SymInt? storage_offset=None) -> Tensor(a)",
+      "inputs": [[311,312,0,1048576,4,"cuda:0"],[1024,1024],[1,1024],"<None>"], "input_shapes": [[1024,1024],[[],[]],[[],[]],[]], "input_types": ["Tensor(float)","GenericList[Int,Int]","GenericList[Int,Int]","None"],
+      "outputs": [[307,312,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::transpose", "id": 317, "rf_id": 163, "parent": 316, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::transpose.int(Tensor(a) self, int dim0, int dim1) -> Tensor(a)",
+      "inputs": [[311,312,0,1048576,4,"cuda:0"],0,1], "input_shapes": [[1024,1024],[],[]], "input_types": ["Tensor(float)","Int","Int"],
+      "outputs": [[307,312,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::t", "id": 316, "rf_id": 162, "parent": 315, "fw_parent": 0, "seq_id": 720, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::t(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[311,312,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[307,312,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty", "id": 320, "rf_id": 166, "parent": 319, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[1048576],0,"<None>","cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","None","Device","None","None"],
+      "outputs": [[321,17,0,1048576,1,"cuda:0"]], "output_shapes": [[1048576]], "output_types": ["Tensor(unsigned char)"]
+    },
+    {
+      "name": "aten::addmm", "id": 319, "rf_id": 165, "parent": 315, "fw_parent": 0, "seq_id": 721, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::addmm(Tensor self, Tensor mat1, Tensor mat2, *, Scalar beta=1, Scalar alpha=1) -> Tensor",
+      "inputs": [[313,314,0,1024,4,"cuda:0"],[306,310,0,524288,4,"cuda:0"],[307,312,0,1048576,4,"cuda:0"],1,1], "input_shapes": [[1024],[512,1024],[1024,1024],[],[]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(float)","Int","Int"],
+      "outputs": [[322,203,0,524288,4,"cuda:0"]], "output_shapes": [[512,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::linear", "id": 315, "rf_id": 161, "parent": 2, "fw_parent": 0, "seq_id": 720, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::linear(Tensor input, Tensor weight, Tensor? bias=None) -> Tensor",
+      "inputs": [[306,310,0,524288,4,"cuda:0"],[311,312,0,1048576,4,"cuda:0"],[313,314,0,1024,4,"cuda:0"]], "input_shapes": [[512,1024],[1024,1024],[1024]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(float)"],
+      "outputs": [[322,203,0,524288,4,"cuda:0"]], "output_shapes": [[512,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::clamp_min", "id": 324, "rf_id": 168, "parent": 323, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::clamp_min(Tensor self, Scalar min) -> Tensor",
+      "inputs": [[322,203,0,524288,4,"cuda:0"],0], "input_shapes": [[512,1024],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [[321,325,0,524288,4,"cuda:0"]], "output_shapes": [[512,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::relu", "id": 323, "rf_id": 167, "parent": 2, "fw_parent": 0, "seq_id": 722, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::relu(Tensor self) -> Tensor",
+      "inputs": [[322,203,0,524288,4,"cuda:0"]], "input_shapes": [[512,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[321,325,0,524288,4,"cuda:0"]], "output_shapes": [[512,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::_softmax", "id": 327, "rf_id": 170, "parent": 326, "fw_parent": 0, "seq_id": 723, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::_softmax(Tensor self, int dim, bool half_to_float) -> Tensor",
+      "inputs": [[321,325,0,524288,4,"cuda:0"],1,false], "input_shapes": [[512,1024],[],[]], "input_types": ["Tensor(float)","Int","Bool"],
+      "outputs": [[322,203,0,524288,4,"cuda:0"]], "output_shapes": [[512,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::softmax", "id": 326, "rf_id": 169, "parent": 2, "fw_parent": 0, "seq_id": 723, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::softmax.int(Tensor self, int dim, ScalarType? dtype=None) -> Tensor",
+      "inputs": [[321,325,0,524288,4,"cuda:0"],1,"<None>"], "input_shapes": [[512,1024],[],[]], "input_types": ["Tensor(float)","Int","None"],
+      "outputs": [[322,203,0,524288,4,"cuda:0"]], "output_shapes": [[512,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::fill_", "id": 332, "rf_id": 173, "parent": 331, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::fill_.Scalar(Tensor(a!) self, Scalar value) -> Tensor(a!)",
+      "inputs": [[329,330,0,1048576,4,"cuda:0"],0], "input_shapes": [[1024,1024],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [[329,330,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::zero_", "id": 331, "rf_id": 172, "parent": 328, "fw_parent": 0, "seq_id": 724, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::zero_(Tensor(a!) self) -> Tensor(a!)",
+      "inputs": [[329,330,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[329,330,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::fill_", "id": 336, "rf_id": 175, "parent": 335, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::fill_.Scalar(Tensor(a!) self, Scalar value) -> Tensor(a!)",
+      "inputs": [[333,334,0,1024,4,"cuda:0"],0], "input_shapes": [[1024],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [[333,334,0,1024,4,"cuda:0"]], "output_shapes": [[1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::zero_", "id": 335, "rf_id": 174, "parent": 328, "fw_parent": 0, "seq_id": 724, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::zero_(Tensor(a!) self) -> Tensor(a!)",
+      "inputs": [[333,334,0,1024,4,"cuda:0"]], "input_shapes": [[1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[333,334,0,1024,4,"cuda:0"]], "output_shapes": [[1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::fill_", "id": 340, "rf_id": 177, "parent": 339, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::fill_.Scalar(Tensor(a!) self, Scalar value) -> Tensor(a!)",
+      "inputs": [[337,338,0,1048576,4,"cuda:0"],0], "input_shapes": [[1024,1024],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [[337,338,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::zero_", "id": 339, "rf_id": 176, "parent": 328, "fw_parent": 0, "seq_id": 724, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::zero_(Tensor(a!) self) -> Tensor(a!)",
+      "inputs": [[337,338,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[337,338,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::fill_", "id": 344, "rf_id": 179, "parent": 343, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::fill_.Scalar(Tensor(a!) self, Scalar value) -> Tensor(a!)",
+      "inputs": [[341,342,0,1024,4,"cuda:0"],0], "input_shapes": [[1024],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [[341,342,0,1024,4,"cuda:0"]], "output_shapes": [[1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::zero_", "id": 343, "rf_id": 178, "parent": 328, "fw_parent": 0, "seq_id": 724, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::zero_(Tensor(a!) self) -> Tensor(a!)",
+      "inputs": [[341,342,0,1024,4,"cuda:0"]], "input_shapes": [[1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[341,342,0,1024,4,"cuda:0"]], "output_shapes": [[1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::fill_", "id": 348, "rf_id": 181, "parent": 347, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::fill_.Scalar(Tensor(a!) self, Scalar value) -> Tensor(a!)",
+      "inputs": [[345,346,0,1048576,4,"cuda:0"],0], "input_shapes": [[1024,1024],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [[345,346,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::zero_", "id": 347, "rf_id": 180, "parent": 328, "fw_parent": 0, "seq_id": 724, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::zero_(Tensor(a!) self) -> Tensor(a!)",
+      "inputs": [[345,346,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[345,346,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::fill_", "id": 352, "rf_id": 183, "parent": 351, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::fill_.Scalar(Tensor(a!) self, Scalar value) -> Tensor(a!)",
+      "inputs": [[349,350,0,1024,4,"cuda:0"],0], "input_shapes": [[1024],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [[349,350,0,1024,4,"cuda:0"]], "output_shapes": [[1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::zero_", "id": 351, "rf_id": 182, "parent": 328, "fw_parent": 0, "seq_id": 724, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::zero_(Tensor(a!) self) -> Tensor(a!)",
+      "inputs": [[349,350,0,1024,4,"cuda:0"]], "input_shapes": [[1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[349,350,0,1024,4,"cuda:0"]], "output_shapes": [[1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::fill_", "id": 356, "rf_id": 185, "parent": 355, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::fill_.Scalar(Tensor(a!) self, Scalar value) -> Tensor(a!)",
+      "inputs": [[353,354,0,1048576,4,"cuda:0"],0], "input_shapes": [[1024,1024],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [[353,354,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::zero_", "id": 355, "rf_id": 184, "parent": 328, "fw_parent": 0, "seq_id": 724, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::zero_(Tensor(a!) self) -> Tensor(a!)",
+      "inputs": [[353,354,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[353,354,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::fill_", "id": 360, "rf_id": 187, "parent": 359, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::fill_.Scalar(Tensor(a!) self, Scalar value) -> Tensor(a!)",
+      "inputs": [[357,358,0,1024,4,"cuda:0"],0], "input_shapes": [[1024],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [[357,358,0,1024,4,"cuda:0"]], "output_shapes": [[1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::zero_", "id": 359, "rf_id": 186, "parent": 328, "fw_parent": 0, "seq_id": 724, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::zero_(Tensor(a!) self) -> Tensor(a!)",
+      "inputs": [[357,358,0,1024,4,"cuda:0"]], "input_shapes": [[1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[357,358,0,1024,4,"cuda:0"]], "output_shapes": [[1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::fill_", "id": 364, "rf_id": 189, "parent": 363, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::fill_.Scalar(Tensor(a!) self, Scalar value) -> Tensor(a!)",
+      "inputs": [[361,362,0,1048576,4,"cuda:0"],0], "input_shapes": [[1024,1024],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [[361,362,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::zero_", "id": 363, "rf_id": 188, "parent": 328, "fw_parent": 0, "seq_id": 724, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::zero_(Tensor(a!) self) -> Tensor(a!)",
+      "inputs": [[361,362,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[361,362,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::fill_", "id": 368, "rf_id": 191, "parent": 367, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::fill_.Scalar(Tensor(a!) self, Scalar value) -> Tensor(a!)",
+      "inputs": [[365,366,0,1024,4,"cuda:0"],0], "input_shapes": [[1024],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [[365,366,0,1024,4,"cuda:0"]], "output_shapes": [[1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::zero_", "id": 367, "rf_id": 190, "parent": 328, "fw_parent": 0, "seq_id": 724, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::zero_(Tensor(a!) self) -> Tensor(a!)",
+      "inputs": [[365,366,0,1024,4,"cuda:0"]], "input_shapes": [[1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[365,366,0,1024,4,"cuda:0"]], "output_shapes": [[1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::fill_", "id": 372, "rf_id": 193, "parent": 371, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::fill_.Scalar(Tensor(a!) self, Scalar value) -> Tensor(a!)",
+      "inputs": [[369,370,0,1048576,4,"cuda:0"],0], "input_shapes": [[1024,1024],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [[369,370,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::zero_", "id": 371, "rf_id": 192, "parent": 328, "fw_parent": 0, "seq_id": 724, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::zero_(Tensor(a!) self) -> Tensor(a!)",
+      "inputs": [[369,370,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[369,370,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::fill_", "id": 376, "rf_id": 195, "parent": 375, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::fill_.Scalar(Tensor(a!) self, Scalar value) -> Tensor(a!)",
+      "inputs": [[373,374,0,1024,4,"cuda:0"],0], "input_shapes": [[1024],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [[373,374,0,1024,4,"cuda:0"]], "output_shapes": [[1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::zero_", "id": 375, "rf_id": 194, "parent": 328, "fw_parent": 0, "seq_id": 724, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::zero_(Tensor(a!) self) -> Tensor(a!)",
+      "inputs": [[373,374,0,1024,4,"cuda:0"]], "input_shapes": [[1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[373,374,0,1024,4,"cuda:0"]], "output_shapes": [[1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::fill_", "id": 380, "rf_id": 197, "parent": 379, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::fill_.Scalar(Tensor(a!) self, Scalar value) -> Tensor(a!)",
+      "inputs": [[377,378,0,1048576,4,"cuda:0"],0], "input_shapes": [[1024,1024],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [[377,378,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::zero_", "id": 379, "rf_id": 196, "parent": 328, "fw_parent": 0, "seq_id": 724, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::zero_(Tensor(a!) self) -> Tensor(a!)",
+      "inputs": [[377,378,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[377,378,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::fill_", "id": 384, "rf_id": 199, "parent": 383, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::fill_.Scalar(Tensor(a!) self, Scalar value) -> Tensor(a!)",
+      "inputs": [[381,382,0,1024,4,"cuda:0"],0], "input_shapes": [[1024],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [[381,382,0,1024,4,"cuda:0"]], "output_shapes": [[1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::zero_", "id": 383, "rf_id": 198, "parent": 328, "fw_parent": 0, "seq_id": 724, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::zero_(Tensor(a!) self) -> Tensor(a!)",
+      "inputs": [[381,382,0,1024,4,"cuda:0"]], "input_shapes": [[1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[381,382,0,1024,4,"cuda:0"]], "output_shapes": [[1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::fill_", "id": 388, "rf_id": 201, "parent": 387, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::fill_.Scalar(Tensor(a!) self, Scalar value) -> Tensor(a!)",
+      "inputs": [[385,386,0,1048576,4,"cuda:0"],0], "input_shapes": [[1024,1024],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [[385,386,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::zero_", "id": 387, "rf_id": 200, "parent": 328, "fw_parent": 0, "seq_id": 724, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::zero_(Tensor(a!) self) -> Tensor(a!)",
+      "inputs": [[385,386,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[385,386,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::fill_", "id": 392, "rf_id": 203, "parent": 391, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::fill_.Scalar(Tensor(a!) self, Scalar value) -> Tensor(a!)",
+      "inputs": [[389,390,0,1024,4,"cuda:0"],0], "input_shapes": [[1024],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [[389,390,0,1024,4,"cuda:0"]], "output_shapes": [[1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::zero_", "id": 391, "rf_id": 202, "parent": 328, "fw_parent": 0, "seq_id": 724, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::zero_(Tensor(a!) self) -> Tensor(a!)",
+      "inputs": [[389,390,0,1024,4,"cuda:0"]], "input_shapes": [[1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[389,390,0,1024,4,"cuda:0"]], "output_shapes": [[1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::fill_", "id": 396, "rf_id": 205, "parent": 395, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::fill_.Scalar(Tensor(a!) self, Scalar value) -> Tensor(a!)",
+      "inputs": [[393,394,0,1048576,4,"cuda:0"],0], "input_shapes": [[1024,1024],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [[393,394,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::zero_", "id": 395, "rf_id": 204, "parent": 328, "fw_parent": 0, "seq_id": 724, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::zero_(Tensor(a!) self) -> Tensor(a!)",
+      "inputs": [[393,394,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[393,394,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::fill_", "id": 400, "rf_id": 207, "parent": 399, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::fill_.Scalar(Tensor(a!) self, Scalar value) -> Tensor(a!)",
+      "inputs": [[397,398,0,1024,4,"cuda:0"],0], "input_shapes": [[1024],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [[397,398,0,1024,4,"cuda:0"]], "output_shapes": [[1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::zero_", "id": 399, "rf_id": 206, "parent": 328, "fw_parent": 0, "seq_id": 724, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::zero_(Tensor(a!) self) -> Tensor(a!)",
+      "inputs": [[397,398,0,1024,4,"cuda:0"]], "input_shapes": [[1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[397,398,0,1024,4,"cuda:0"]], "output_shapes": [[1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::fill_", "id": 404, "rf_id": 209, "parent": 403, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::fill_.Scalar(Tensor(a!) self, Scalar value) -> Tensor(a!)",
+      "inputs": [[401,402,0,1048576,4,"cuda:0"],0], "input_shapes": [[1024,1024],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [[401,402,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::zero_", "id": 403, "rf_id": 208, "parent": 328, "fw_parent": 0, "seq_id": 724, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::zero_(Tensor(a!) self) -> Tensor(a!)",
+      "inputs": [[401,402,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[401,402,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::fill_", "id": 408, "rf_id": 211, "parent": 407, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::fill_.Scalar(Tensor(a!) self, Scalar value) -> Tensor(a!)",
+      "inputs": [[405,406,0,1024,4,"cuda:0"],0], "input_shapes": [[1024],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [[405,406,0,1024,4,"cuda:0"]], "output_shapes": [[1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::zero_", "id": 407, "rf_id": 210, "parent": 328, "fw_parent": 0, "seq_id": 724, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::zero_(Tensor(a!) self) -> Tensor(a!)",
+      "inputs": [[405,406,0,1024,4,"cuda:0"]], "input_shapes": [[1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[405,406,0,1024,4,"cuda:0"]], "output_shapes": [[1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::fill_", "id": 412, "rf_id": 213, "parent": 411, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::fill_.Scalar(Tensor(a!) self, Scalar value) -> Tensor(a!)",
+      "inputs": [[409,410,0,1048576,4,"cuda:0"],0], "input_shapes": [[1024,1024],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [[409,410,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::zero_", "id": 411, "rf_id": 212, "parent": 328, "fw_parent": 0, "seq_id": 724, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::zero_(Tensor(a!) self) -> Tensor(a!)",
+      "inputs": [[409,410,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[409,410,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::fill_", "id": 416, "rf_id": 215, "parent": 415, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::fill_.Scalar(Tensor(a!) self, Scalar value) -> Tensor(a!)",
+      "inputs": [[413,414,0,1024,4,"cuda:0"],0], "input_shapes": [[1024],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [[413,414,0,1024,4,"cuda:0"]], "output_shapes": [[1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::zero_", "id": 415, "rf_id": 214, "parent": 328, "fw_parent": 0, "seq_id": 724, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::zero_(Tensor(a!) self) -> Tensor(a!)",
+      "inputs": [[413,414,0,1024,4,"cuda:0"]], "input_shapes": [[1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[413,414,0,1024,4,"cuda:0"]], "output_shapes": [[1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::fill_", "id": 420, "rf_id": 217, "parent": 419, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::fill_.Scalar(Tensor(a!) self, Scalar value) -> Tensor(a!)",
+      "inputs": [[417,418,0,1048576,4,"cuda:0"],0], "input_shapes": [[1024,1024],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [[417,418,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::zero_", "id": 419, "rf_id": 216, "parent": 328, "fw_parent": 0, "seq_id": 724, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::zero_(Tensor(a!) self) -> Tensor(a!)",
+      "inputs": [[417,418,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[417,418,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::fill_", "id": 424, "rf_id": 219, "parent": 423, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::fill_.Scalar(Tensor(a!) self, Scalar value) -> Tensor(a!)",
+      "inputs": [[421,422,0,1024,4,"cuda:0"],0], "input_shapes": [[1024],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [[421,422,0,1024,4,"cuda:0"]], "output_shapes": [[1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::zero_", "id": 423, "rf_id": 218, "parent": 328, "fw_parent": 0, "seq_id": 724, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::zero_(Tensor(a!) self) -> Tensor(a!)",
+      "inputs": [[421,422,0,1024,4,"cuda:0"]], "input_shapes": [[1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[421,422,0,1024,4,"cuda:0"]], "output_shapes": [[1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::fill_", "id": 428, "rf_id": 221, "parent": 427, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::fill_.Scalar(Tensor(a!) self, Scalar value) -> Tensor(a!)",
+      "inputs": [[425,426,0,1048576,4,"cuda:0"],0], "input_shapes": [[1024,1024],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [[425,426,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::zero_", "id": 427, "rf_id": 220, "parent": 328, "fw_parent": 0, "seq_id": 724, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::zero_(Tensor(a!) self) -> Tensor(a!)",
+      "inputs": [[425,426,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[425,426,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::fill_", "id": 432, "rf_id": 223, "parent": 431, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::fill_.Scalar(Tensor(a!) self, Scalar value) -> Tensor(a!)",
+      "inputs": [[429,430,0,1024,4,"cuda:0"],0], "input_shapes": [[1024],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [[429,430,0,1024,4,"cuda:0"]], "output_shapes": [[1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::zero_", "id": 431, "rf_id": 222, "parent": 328, "fw_parent": 0, "seq_id": 724, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::zero_(Tensor(a!) self) -> Tensor(a!)",
+      "inputs": [[429,430,0,1024,4,"cuda:0"]], "input_shapes": [[1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[429,430,0,1024,4,"cuda:0"]], "output_shapes": [[1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::fill_", "id": 436, "rf_id": 225, "parent": 435, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::fill_.Scalar(Tensor(a!) self, Scalar value) -> Tensor(a!)",
+      "inputs": [[433,434,0,1048576,4,"cuda:0"],0], "input_shapes": [[1024,1024],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [[433,434,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::zero_", "id": 435, "rf_id": 224, "parent": 328, "fw_parent": 0, "seq_id": 724, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::zero_(Tensor(a!) self) -> Tensor(a!)",
+      "inputs": [[433,434,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[433,434,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::fill_", "id": 440, "rf_id": 227, "parent": 439, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::fill_.Scalar(Tensor(a!) self, Scalar value) -> Tensor(a!)",
+      "inputs": [[437,438,0,1024,4,"cuda:0"],0], "input_shapes": [[1024],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [[437,438,0,1024,4,"cuda:0"]], "output_shapes": [[1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::zero_", "id": 439, "rf_id": 226, "parent": 328, "fw_parent": 0, "seq_id": 724, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::zero_(Tensor(a!) self) -> Tensor(a!)",
+      "inputs": [[437,438,0,1024,4,"cuda:0"]], "input_shapes": [[1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[437,438,0,1024,4,"cuda:0"]], "output_shapes": [[1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::fill_", "id": 444, "rf_id": 229, "parent": 443, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::fill_.Scalar(Tensor(a!) self, Scalar value) -> Tensor(a!)",
+      "inputs": [[441,442,0,1048576,4,"cuda:0"],0], "input_shapes": [[1024,1024],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [[441,442,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::zero_", "id": 443, "rf_id": 228, "parent": 328, "fw_parent": 0, "seq_id": 724, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::zero_(Tensor(a!) self) -> Tensor(a!)",
+      "inputs": [[441,442,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[441,442,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::fill_", "id": 448, "rf_id": 231, "parent": 447, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::fill_.Scalar(Tensor(a!) self, Scalar value) -> Tensor(a!)",
+      "inputs": [[445,446,0,1024,4,"cuda:0"],0], "input_shapes": [[1024],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [[445,446,0,1024,4,"cuda:0"]], "output_shapes": [[1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::zero_", "id": 447, "rf_id": 230, "parent": 328, "fw_parent": 0, "seq_id": 724, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::zero_(Tensor(a!) self) -> Tensor(a!)",
+      "inputs": [[445,446,0,1024,4,"cuda:0"]], "input_shapes": [[1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[445,446,0,1024,4,"cuda:0"]], "output_shapes": [[1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::fill_", "id": 452, "rf_id": 233, "parent": 451, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::fill_.Scalar(Tensor(a!) self, Scalar value) -> Tensor(a!)",
+      "inputs": [[449,450,0,1048576,4,"cuda:0"],0], "input_shapes": [[1024,1024],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [[449,450,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::zero_", "id": 451, "rf_id": 232, "parent": 328, "fw_parent": 0, "seq_id": 724, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::zero_(Tensor(a!) self) -> Tensor(a!)",
+      "inputs": [[449,450,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[449,450,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::fill_", "id": 456, "rf_id": 235, "parent": 455, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::fill_.Scalar(Tensor(a!) self, Scalar value) -> Tensor(a!)",
+      "inputs": [[453,454,0,1024,4,"cuda:0"],0], "input_shapes": [[1024],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [[453,454,0,1024,4,"cuda:0"]], "output_shapes": [[1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::zero_", "id": 455, "rf_id": 234, "parent": 328, "fw_parent": 0, "seq_id": 724, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::zero_(Tensor(a!) self) -> Tensor(a!)",
+      "inputs": [[453,454,0,1024,4,"cuda:0"]], "input_shapes": [[1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[453,454,0,1024,4,"cuda:0"]], "output_shapes": [[1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::fill_", "id": 460, "rf_id": 237, "parent": 459, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::fill_.Scalar(Tensor(a!) self, Scalar value) -> Tensor(a!)",
+      "inputs": [[457,458,0,1048576,4,"cuda:0"],0], "input_shapes": [[1024,1024],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [[457,458,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::zero_", "id": 459, "rf_id": 236, "parent": 328, "fw_parent": 0, "seq_id": 724, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::zero_(Tensor(a!) self) -> Tensor(a!)",
+      "inputs": [[457,458,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[457,458,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::fill_", "id": 464, "rf_id": 239, "parent": 463, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::fill_.Scalar(Tensor(a!) self, Scalar value) -> Tensor(a!)",
+      "inputs": [[461,462,0,1024,4,"cuda:0"],0], "input_shapes": [[1024],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [[461,462,0,1024,4,"cuda:0"]], "output_shapes": [[1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::zero_", "id": 463, "rf_id": 238, "parent": 328, "fw_parent": 0, "seq_id": 724, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::zero_(Tensor(a!) self) -> Tensor(a!)",
+      "inputs": [[461,462,0,1024,4,"cuda:0"]], "input_shapes": [[1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[461,462,0,1024,4,"cuda:0"]], "output_shapes": [[1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::fill_", "id": 468, "rf_id": 241, "parent": 467, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::fill_.Scalar(Tensor(a!) self, Scalar value) -> Tensor(a!)",
+      "inputs": [[465,466,0,1048576,4,"cuda:0"],0], "input_shapes": [[1024,1024],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [[465,466,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::zero_", "id": 467, "rf_id": 240, "parent": 328, "fw_parent": 0, "seq_id": 724, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::zero_(Tensor(a!) self) -> Tensor(a!)",
+      "inputs": [[465,466,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[465,466,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::fill_", "id": 472, "rf_id": 243, "parent": 471, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::fill_.Scalar(Tensor(a!) self, Scalar value) -> Tensor(a!)",
+      "inputs": [[469,470,0,1024,4,"cuda:0"],0], "input_shapes": [[1024],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [[469,470,0,1024,4,"cuda:0"]], "output_shapes": [[1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::zero_", "id": 471, "rf_id": 242, "parent": 328, "fw_parent": 0, "seq_id": 724, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::zero_(Tensor(a!) self) -> Tensor(a!)",
+      "inputs": [[469,470,0,1024,4,"cuda:0"]], "input_shapes": [[1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[469,470,0,1024,4,"cuda:0"]], "output_shapes": [[1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::fill_", "id": 476, "rf_id": 245, "parent": 475, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::fill_.Scalar(Tensor(a!) self, Scalar value) -> Tensor(a!)",
+      "inputs": [[473,474,0,1048576,4,"cuda:0"],0], "input_shapes": [[1024,1024],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [[473,474,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::zero_", "id": 475, "rf_id": 244, "parent": 328, "fw_parent": 0, "seq_id": 724, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::zero_(Tensor(a!) self) -> Tensor(a!)",
+      "inputs": [[473,474,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[473,474,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::fill_", "id": 480, "rf_id": 247, "parent": 479, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::fill_.Scalar(Tensor(a!) self, Scalar value) -> Tensor(a!)",
+      "inputs": [[477,478,0,1024,4,"cuda:0"],0], "input_shapes": [[1024],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [[477,478,0,1024,4,"cuda:0"]], "output_shapes": [[1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::zero_", "id": 479, "rf_id": 246, "parent": 328, "fw_parent": 0, "seq_id": 724, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::zero_(Tensor(a!) self) -> Tensor(a!)",
+      "inputs": [[477,478,0,1024,4,"cuda:0"]], "input_shapes": [[1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[477,478,0,1024,4,"cuda:0"]], "output_shapes": [[1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::fill_", "id": 484, "rf_id": 249, "parent": 483, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::fill_.Scalar(Tensor(a!) self, Scalar value) -> Tensor(a!)",
+      "inputs": [[481,482,0,1048576,4,"cuda:0"],0], "input_shapes": [[1024,1024],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [[481,482,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::zero_", "id": 483, "rf_id": 248, "parent": 328, "fw_parent": 0, "seq_id": 724, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::zero_(Tensor(a!) self) -> Tensor(a!)",
+      "inputs": [[481,482,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[481,482,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::fill_", "id": 488, "rf_id": 251, "parent": 487, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::fill_.Scalar(Tensor(a!) self, Scalar value) -> Tensor(a!)",
+      "inputs": [[485,486,0,1024,4,"cuda:0"],0], "input_shapes": [[1024],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [[485,486,0,1024,4,"cuda:0"]], "output_shapes": [[1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::zero_", "id": 487, "rf_id": 250, "parent": 328, "fw_parent": 0, "seq_id": 724, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::zero_(Tensor(a!) self) -> Tensor(a!)",
+      "inputs": [[485,486,0,1024,4,"cuda:0"]], "input_shapes": [[1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[485,486,0,1024,4,"cuda:0"]], "output_shapes": [[1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::fill_", "id": 492, "rf_id": 253, "parent": 491, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::fill_.Scalar(Tensor(a!) self, Scalar value) -> Tensor(a!)",
+      "inputs": [[489,490,0,1048576,4,"cuda:0"],0], "input_shapes": [[1024,1024],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [[489,490,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::zero_", "id": 491, "rf_id": 252, "parent": 328, "fw_parent": 0, "seq_id": 724, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::zero_(Tensor(a!) self) -> Tensor(a!)",
+      "inputs": [[489,490,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[489,490,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::fill_", "id": 496, "rf_id": 255, "parent": 495, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::fill_.Scalar(Tensor(a!) self, Scalar value) -> Tensor(a!)",
+      "inputs": [[493,494,0,1024,4,"cuda:0"],0], "input_shapes": [[1024],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [[493,494,0,1024,4,"cuda:0"]], "output_shapes": [[1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::zero_", "id": 495, "rf_id": 254, "parent": 328, "fw_parent": 0, "seq_id": 724, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::zero_(Tensor(a!) self) -> Tensor(a!)",
+      "inputs": [[493,494,0,1024,4,"cuda:0"]], "input_shapes": [[1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[493,494,0,1024,4,"cuda:0"]], "output_shapes": [[1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "Optimizer.zero_grad#SGD.zero_grad", "id": 328, "rf_id": 171, "parent": 2, "fw_parent": 0, "seq_id": -1, "scope": 7, "tid": 1, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::to", "id": 501, "rf_id": 258, "parent": 500, "fw_parent": 0, "seq_id": 724, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::to.dtype_layout(Tensor(a) self, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, bool non_blocking=False, bool copy=False, MemoryFormat? memory_format=None) -> Tensor(a)",
+      "inputs": [[322,203,0,524288,4,"cuda:0"],6,0,"cuda:0","<None>",false,false,"<None>"], "input_shapes": [[512,1024],[],[],[],[],[],[],[]], "input_types": ["Tensor(float)","Int","Int","Device","None","Bool","Bool","None"],
+      "outputs": [[322,203,0,524288,4,"cuda:0"]], "output_shapes": [[512,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::_log_softmax", "id": 502, "rf_id": 259, "parent": 500, "fw_parent": 0, "seq_id": 724, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::_log_softmax(Tensor self, int dim, bool half_to_float) -> Tensor",
+      "inputs": [[322,203,0,524288,4,"cuda:0"],1,false], "input_shapes": [[512,1024],[],[]], "input_types": ["Tensor(float)","Int","Bool"],
+      "outputs": [[503,504,0,524288,4,"cuda:0"]], "output_shapes": [[512,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::log_softmax", "id": 500, "rf_id": 257, "parent": 499, "fw_parent": 0, "seq_id": 724, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::log_softmax.int(Tensor self, int dim, ScalarType? dtype=None) -> Tensor",
+      "inputs": [[322,203,0,524288,4,"cuda:0"],1,6], "input_shapes": [[512,1024],[],[]], "input_types": ["Tensor(float)","Int","Int"],
+      "outputs": [[503,504,0,524288,4,"cuda:0"]], "output_shapes": [[512,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::resize_", "id": 511, "rf_id": 263, "parent": 508, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::resize_(Tensor(a!) self, SymInt[] size, *, MemoryFormat? memory_format=None) -> Tensor(a!)",
+      "inputs": [[509,510,0,1,4,"cuda:0"],[],"<None>"], "input_shapes": [[],[],[]], "input_types": ["Tensor(float)","GenericList[]","None"],
+      "outputs": [[509,510,0,1,4,"cuda:0"]], "output_shapes": [[]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::nll_loss_forward", "id": 508, "rf_id": 262, "parent": 506, "fw_parent": 0, "seq_id": 725, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::nll_loss_forward(Tensor self, Tensor target, Tensor? weight, int reduction, SymInt ignore_index) -> (Tensor output, Tensor total_weight)",
+      "inputs": [[503,504,0,524288,4,"cuda:0"],[497,498,0,512,8,"cuda:0"],[507,0,0,0,0,""],1,-100], "input_shapes": [[512,1024],[512],[],[],[]], "input_types": ["Tensor(float)","Tensor(long int)","Tensor(nullptr (uninitialized))","Int","Int"],
+      "outputs": [[321,512,0,1,4,"cuda:0"],[509,510,0,1,4,"cuda:0"]], "output_shapes": [[],[]], "output_types": ["Tensor(float)","Tensor(float)"]
+    },
+    {
+      "name": "aten::nll_loss", "id": 506, "rf_id": 261, "parent": 505, "fw_parent": 0, "seq_id": 725, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::nll_loss(Tensor self, Tensor target, Tensor? weight=None, int reduction=1, SymInt ignore_index=-100) -> Tensor",
+      "inputs": [[503,504,0,524288,4,"cuda:0"],[497,498,0,512,8,"cuda:0"],"<None>",1,-100], "input_shapes": [[512,1024],[512],[],[],[]], "input_types": ["Tensor(float)","Tensor(long int)","None","Int","Int"],
+      "outputs": [[321,512,0,1,4,"cuda:0"]], "output_shapes": [[]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::nll_loss_nd", "id": 505, "rf_id": 260, "parent": 499, "fw_parent": 0, "seq_id": 725, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::nll_loss_nd(Tensor self, Tensor target, Tensor? weight=None, int reduction=1, SymInt ignore_index=-100) -> Tensor",
+      "inputs": [[503,504,0,524288,4,"cuda:0"],[497,498,0,512,8,"cuda:0"],"<None>",1,-100], "input_shapes": [[512,1024],[512],[],[],[]], "input_types": ["Tensor(float)","Tensor(long int)","None","Int","Int"],
+      "outputs": [[321,512,0,1,4,"cuda:0"]], "output_shapes": [[]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::cross_entropy_loss", "id": 499, "rf_id": 256, "parent": 2, "fw_parent": 0, "seq_id": 724, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::cross_entropy_loss(Tensor self, Tensor target, Tensor? weight=None, int reduction=1, SymInt ignore_index=-100, float label_smoothing=0.) -> Tensor",
+      "inputs": [[322,203,0,524288,4,"cuda:0"],[497,498,0,512,8,"cuda:0"],"<None>",1,-100,0.000000], "input_shapes": [[512,1024],[512],[],[],[],[]], "input_types": ["Tensor(float)","Tensor(long int)","None","Int","Int","Double"],
+      "outputs": [[321,512,0,1,4,"cuda:0"]], "output_shapes": [[]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty_strided", "id": 515, "rf_id": 266, "parent": 514, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty_strided(SymInt[] size, SymInt[] stride, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor",
+      "inputs": [[],[],6,0,"cuda:0",false], "input_shapes": [[],[],[],[],[],[]], "input_types": ["GenericList[]","GenericList[]","Int","Int","Device","Bool"],
+      "outputs": [[516,517,0,1,4,"cuda:0"]], "output_shapes": [[]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty_like", "id": 514, "rf_id": 265, "parent": 513, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty_like(Tensor self, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[321,512,0,1,4,"cuda:0"],6,0,"cuda:0",false,1], "input_shapes": [[],[],[],[],[],[]], "input_types": ["Tensor(float)","Int","Int","Device","Bool","Int"],
+      "outputs": [[516,517,0,1,4,"cuda:0"]], "output_shapes": [[]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::fill_", "id": 518, "rf_id": 267, "parent": 513, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::fill_.Scalar(Tensor(a!) self, Scalar value) -> Tensor(a!)",
+      "inputs": [[516,517,0,1,4,"cuda:0"],1.000000], "input_shapes": [[],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [[516,517,0,1,4,"cuda:0"]], "output_shapes": [[]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::ones_like", "id": 513, "rf_id": 264, "parent": 2, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::ones_like(Tensor self, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[321,512,0,1,4,"cuda:0"],6,0,"cuda:0",false,1], "input_shapes": [[],[],[],[],[],[]], "input_types": ["Tensor(float)","Int","Int","Device","Bool","Int"],
+      "outputs": [[516,517,0,1,4,"cuda:0"]], "output_shapes": [[]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "[pytorch|profiler|execution_graph|thread]", "id": 519, "rf_id": 0, "parent": 1, "fw_parent": 0, "seq_id": -1, "scope": 7, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::fill_", "id": 526, "rf_id": 272, "parent": 525, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::fill_.Scalar(Tensor(a!) self, Scalar value) -> Tensor(a!)",
+      "inputs": [[523,524,0,524288,4,"cuda:0"],0], "input_shapes": [[512,1024],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [[523,524,0,524288,4,"cuda:0"]], "output_shapes": [[512,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::zero_", "id": 525, "rf_id": 271, "parent": 522, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::zero_(Tensor(a!) self) -> Tensor(a!)",
+      "inputs": [[523,524,0,524288,4,"cuda:0"]], "input_shapes": [[512,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[523,524,0,524288,4,"cuda:0"]], "output_shapes": [[512,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::nll_loss_backward", "id": 522, "rf_id": 270, "parent": 521, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::nll_loss_backward(Tensor grad_output, Tensor self, Tensor target, Tensor? weight, int reduction, SymInt ignore_index, Tensor total_weight) -> Tensor",
+      "inputs": [[516,517,0,1,4,"cuda:0"],[503,504,0,524288,4,"cuda:0"],[497,498,0,512,8,"cuda:0"],[507,0,0,0,0,""],1,-100,[509,510,0,1,4,"cuda:0"]], "input_shapes": [[],[512,1024],[512],[],[],[],[]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(long int)","Tensor(nullptr (uninitialized))","Int","Int","Tensor(float)"],
+      "outputs": [[523,524,0,524288,4,"cuda:0"]], "output_shapes": [[512,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "NllLossBackward0", "id": 521, "rf_id": 269, "parent": 520, "fw_parent": 2, "seq_id": 725, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[516,517,0,1,4,"cuda:0"]], "input_shapes": [[]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: NllLossBackward0", "id": 520, "rf_id": 268, "parent": 519, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::_log_softmax_backward_data", "id": 529, "rf_id": 275, "parent": 528, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::_log_softmax_backward_data(Tensor grad_output, Tensor output, int dim, ScalarType input_dtype) -> Tensor",
+      "inputs": [[523,524,0,524288,4,"cuda:0"],[503,504,0,524288,4,"cuda:0"],1,6], "input_shapes": [[512,1024],[512,1024],[],[]], "input_types": ["Tensor(float)","Tensor(float)","Int","Int"],
+      "outputs": [[530,531,0,524288,4,"cuda:0"]], "output_shapes": [[512,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "LogSoftmaxBackward0", "id": 528, "rf_id": 274, "parent": 527, "fw_parent": 2, "seq_id": 724, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[523,524,0,524288,4,"cuda:0"]], "input_shapes": [[512,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: LogSoftmaxBackward0", "id": 527, "rf_id": 273, "parent": 519, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::mul", "id": 535, "rf_id": 279, "parent": 534, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::mul.Tensor(Tensor self, Tensor other) -> Tensor",
+      "inputs": [[530,531,0,524288,4,"cuda:0"],[523,203,0,524288,4,"cuda:0"]], "input_shapes": [[512,1024],[512,1024]], "input_types": ["Tensor(float)","Tensor(float)"],
+      "outputs": [[536,504,0,524288,4,"cuda:0"]], "output_shapes": [[512,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::_softmax_backward_data", "id": 534, "rf_id": 278, "parent": 533, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::_softmax_backward_data(Tensor grad_output, Tensor output, int dim, ScalarType input_dtype) -> Tensor",
+      "inputs": [[530,531,0,524288,4,"cuda:0"],[523,203,0,524288,4,"cuda:0"],1,6], "input_shapes": [[512,1024],[512,1024],[],[]], "input_types": ["Tensor(float)","Tensor(float)","Int","Int"],
+      "outputs": [[503,524,0,524288,4,"cuda:0"]], "output_shapes": [[512,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "SoftmaxBackward0", "id": 533, "rf_id": 277, "parent": 532, "fw_parent": 2, "seq_id": 723, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[530,531,0,524288,4,"cuda:0"]], "input_shapes": [[512,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: SoftmaxBackward0", "id": 532, "rf_id": 276, "parent": 519, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::threshold_backward", "id": 539, "rf_id": 282, "parent": 538, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::threshold_backward(Tensor grad_output, Tensor self, Scalar threshold) -> Tensor",
+      "inputs": [[503,524,0,524288,4,"cuda:0"],[530,325,0,524288,4,"cuda:0"],0], "input_shapes": [[512,1024],[512,1024],[]], "input_types": ["Tensor(float)","Tensor(float)","Int"],
+      "outputs": [[523,531,0,524288,4,"cuda:0"]], "output_shapes": [[512,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "ReluBackward0", "id": 538, "rf_id": 281, "parent": 537, "fw_parent": 2, "seq_id": 722, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[503,524,0,524288,4,"cuda:0"]], "input_shapes": [[512,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: ReluBackward0", "id": 537, "rf_id": 280, "parent": 519, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::as_strided", "id": 544, "rf_id": 287, "parent": 543, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::as_strided(Tensor(a) self, SymInt[] size, SymInt[] stride, SymInt? storage_offset=None) -> Tensor(a)",
+      "inputs": [[307,312,0,1048576,4,"cuda:0"],[1024,1024],[1024,1],"<None>"], "input_shapes": [[1024,1024],[[],[]],[[],[]],[]], "input_types": ["Tensor(float)","GenericList[Int,Int]","GenericList[Int,Int]","None"],
+      "outputs": [[503,312,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::transpose", "id": 543, "rf_id": 286, "parent": 542, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::transpose.int(Tensor(a) self, int dim0, int dim1) -> Tensor(a)",
+      "inputs": [[307,312,0,1048576,4,"cuda:0"],0,1], "input_shapes": [[1024,1024],[],[]], "input_types": ["Tensor(float)","Int","Int"],
+      "outputs": [[503,312,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::t", "id": 542, "rf_id": 285, "parent": 541, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::t(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[307,312,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[503,312,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::mm", "id": 545, "rf_id": 288, "parent": 541, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::mm(Tensor self, Tensor mat2) -> Tensor",
+      "inputs": [[523,531,0,524288,4,"cuda:0"],[503,312,0,1048576,4,"cuda:0"]], "input_shapes": [[512,1024],[1024,1024]], "input_types": ["Tensor(float)","Tensor(float)"],
+      "outputs": [[530,504,0,524288,4,"cuda:0"]], "output_shapes": [[512,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::as_strided", "id": 548, "rf_id": 291, "parent": 547, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::as_strided(Tensor(a) self, SymInt[] size, SymInt[] stride, SymInt? storage_offset=None) -> Tensor(a)",
+      "inputs": [[523,531,0,524288,4,"cuda:0"],[1024,512],[1,1024],"<None>"], "input_shapes": [[512,1024],[[],[]],[[],[]],[]], "input_types": ["Tensor(float)","GenericList[Int,Int]","GenericList[Int,Int]","None"],
+      "outputs": [[503,531,0,524288,4,"cuda:0"]], "output_shapes": [[1024,512]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::transpose", "id": 547, "rf_id": 290, "parent": 546, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::transpose.int(Tensor(a) self, int dim0, int dim1) -> Tensor(a)",
+      "inputs": [[523,531,0,524288,4,"cuda:0"],0,1], "input_shapes": [[512,1024],[],[]], "input_types": ["Tensor(float)","Int","Int"],
+      "outputs": [[503,531,0,524288,4,"cuda:0"]], "output_shapes": [[1024,512]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::t", "id": 546, "rf_id": 289, "parent": 541, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::t(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[523,531,0,524288,4,"cuda:0"]], "input_shapes": [[512,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[503,531,0,524288,4,"cuda:0"]], "output_shapes": [[1024,512]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::mm", "id": 549, "rf_id": 292, "parent": 541, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::mm(Tensor self, Tensor mat2) -> Tensor",
+      "inputs": [[503,531,0,524288,4,"cuda:0"],[306,310,0,524288,4,"cuda:0"]], "input_shapes": [[1024,512],[512,1024]], "input_types": ["Tensor(float)","Tensor(float)"],
+      "outputs": [[536,325,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::as_strided", "id": 552, "rf_id": 295, "parent": 551, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::as_strided(Tensor(a) self, SymInt[] size, SymInt[] stride, SymInt? storage_offset=None) -> Tensor(a)",
+      "inputs": [[536,325,0,1048576,4,"cuda:0"],[1024,1024],[1,1024],"<None>"], "input_shapes": [[1024,1024],[[],[]],[[],[]],[]], "input_types": ["Tensor(float)","GenericList[Int,Int]","GenericList[Int,Int]","None"],
+      "outputs": [[553,325,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::transpose", "id": 551, "rf_id": 294, "parent": 550, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::transpose.int(Tensor(a) self, int dim0, int dim1) -> Tensor(a)",
+      "inputs": [[536,325,0,1048576,4,"cuda:0"],0,1], "input_shapes": [[1024,1024],[],[]], "input_types": ["Tensor(float)","Int","Int"],
+      "outputs": [[553,325,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::t", "id": 550, "rf_id": 293, "parent": 541, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::t(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[536,325,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[553,325,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "AddmmBackward0", "id": 541, "rf_id": 284, "parent": 540, "fw_parent": 2, "seq_id": 721, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[523,531,0,524288,4,"cuda:0"]], "input_shapes": [[512,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::sum", "id": 554, "rf_id": 296, "parent": 540, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::sum.dim_IntList(Tensor self, int[1]? dim, bool keepdim=False, *, ScalarType? dtype=None) -> Tensor",
+      "inputs": [[523,531,0,524288,4,"cuda:0"],[0],true,"<None>"], "input_shapes": [[512,1024],[[]],[],[]], "input_types": ["Tensor(float)","GenericList[Int]","Bool","None"],
+      "outputs": [[503,17,0,1024,4,"cuda:0"]], "output_shapes": [[1,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::view", "id": 555, "rf_id": 297, "parent": 540, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::view(Tensor(a) self, SymInt[] size) -> Tensor(a)",
+      "inputs": [[503,17,0,1024,4,"cuda:0"],[1024]], "input_shapes": [[1,1024],[[]]], "input_types": ["Tensor(float)","GenericList[Int]"],
+      "outputs": [[556,17,0,1024,4,"cuda:0"]], "output_shapes": [[1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "autograd::engine::evaluate_function: AddmmBackward0", "id": 540, "rf_id": 283, "parent": 519, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::add_", "id": 559, "rf_id": 300, "parent": 558, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::add_.Tensor(Tensor(a!) self, Tensor other, *, Scalar alpha=1) -> Tensor(a!)",
+      "inputs": [[493,494,0,1024,4,"cuda:0"],[556,17,0,1024,4,"cuda:0"],1], "input_shapes": [[1024],[1024],[]], "input_types": ["Tensor(float)","Tensor(float)","Int"],
+      "outputs": [[493,494,0,1024,4,"cuda:0"]], "output_shapes": [[1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "torch::autograd::AccumulateGrad", "id": 558, "rf_id": 299, "parent": 557, "fw_parent": 2, "seq_id": -1, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[556,17,0,1024,4,"cuda:0"]], "input_shapes": [[1024]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: torch::autograd::AccumulateGrad", "id": 557, "rf_id": 298, "parent": 519, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::as_strided", "id": 564, "rf_id": 305, "parent": 563, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::as_strided(Tensor(a) self, SymInt[] size, SymInt[] stride, SymInt? storage_offset=None) -> Tensor(a)",
+      "inputs": [[553,325,0,1048576,4,"cuda:0"],[1024,1024],[1024,1],"<None>"], "input_shapes": [[1024,1024],[[],[]],[[],[]],[]], "input_types": ["Tensor(float)","GenericList[Int,Int]","GenericList[Int,Int]","None"],
+      "outputs": [[556,325,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::transpose", "id": 563, "rf_id": 304, "parent": 562, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::transpose.int(Tensor(a) self, int dim0, int dim1) -> Tensor(a)",
+      "inputs": [[553,325,0,1048576,4,"cuda:0"],0,1], "input_shapes": [[1024,1024],[],[]], "input_types": ["Tensor(float)","Int","Int"],
+      "outputs": [[556,325,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::t", "id": 562, "rf_id": 303, "parent": 561, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::t(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[553,325,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[556,325,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "TBackward0", "id": 561, "rf_id": 302, "parent": 560, "fw_parent": 2, "seq_id": 720, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[553,325,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: TBackward0", "id": 560, "rf_id": 301, "parent": 519, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::add_", "id": 567, "rf_id": 308, "parent": 566, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::add_.Tensor(Tensor(a!) self, Tensor other, *, Scalar alpha=1) -> Tensor(a!)",
+      "inputs": [[489,490,0,1048576,4,"cuda:0"],[556,325,0,1048576,4,"cuda:0"],1], "input_shapes": [[1024,1024],[1024,1024],[]], "input_types": ["Tensor(float)","Tensor(float)","Int"],
+      "outputs": [[489,490,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "torch::autograd::AccumulateGrad", "id": 566, "rf_id": 307, "parent": 565, "fw_parent": 2, "seq_id": -1, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[556,325,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: torch::autograd::AccumulateGrad", "id": 565, "rf_id": 306, "parent": 519, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::threshold_backward", "id": 570, "rf_id": 311, "parent": 569, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::threshold_backward(Tensor grad_output, Tensor self, Scalar threshold) -> Tensor",
+      "inputs": [[530,504,0,524288,4,"cuda:0"],[553,310,0,524288,4,"cuda:0"],0], "input_shapes": [[512,1024],[512,1024],[]], "input_types": ["Tensor(float)","Tensor(float)","Int"],
+      "outputs": [[503,325,0,524288,4,"cuda:0"]], "output_shapes": [[512,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "ReluBackward0", "id": 569, "rf_id": 310, "parent": 568, "fw_parent": 2, "seq_id": 719, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[530,504,0,524288,4,"cuda:0"]], "input_shapes": [[512,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: ReluBackward0", "id": 568, "rf_id": 309, "parent": 519, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::as_strided", "id": 575, "rf_id": 316, "parent": 574, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::as_strided(Tensor(a) self, SymInt[] size, SymInt[] stride, SymInt? storage_offset=None) -> Tensor(a)",
+      "inputs": [[292,297,0,1048576,4,"cuda:0"],[1024,1024],[1024,1],"<None>"], "input_shapes": [[1024,1024],[[],[]],[[],[]],[]], "input_types": ["Tensor(float)","GenericList[Int,Int]","GenericList[Int,Int]","None"],
+      "outputs": [[530,297,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::transpose", "id": 574, "rf_id": 315, "parent": 573, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::transpose.int(Tensor(a) self, int dim0, int dim1) -> Tensor(a)",
+      "inputs": [[292,297,0,1048576,4,"cuda:0"],0,1], "input_shapes": [[1024,1024],[],[]], "input_types": ["Tensor(float)","Int","Int"],
+      "outputs": [[530,297,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::t", "id": 573, "rf_id": 314, "parent": 572, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::t(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[292,297,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[530,297,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::mm", "id": 576, "rf_id": 317, "parent": 572, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::mm(Tensor self, Tensor mat2) -> Tensor",
+      "inputs": [[503,325,0,524288,4,"cuda:0"],[530,297,0,1048576,4,"cuda:0"]], "input_shapes": [[512,1024],[1024,1024]], "input_types": ["Tensor(float)","Tensor(float)"],
+      "outputs": [[553,310,0,524288,4,"cuda:0"]], "output_shapes": [[512,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::as_strided", "id": 579, "rf_id": 320, "parent": 578, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::as_strided(Tensor(a) self, SymInt[] size, SymInt[] stride, SymInt? storage_offset=None) -> Tensor(a)",
+      "inputs": [[503,325,0,524288,4,"cuda:0"],[1024,512],[1,1024],"<None>"], "input_shapes": [[512,1024],[[],[]],[[],[]],[]], "input_types": ["Tensor(float)","GenericList[Int,Int]","GenericList[Int,Int]","None"],
+      "outputs": [[530,325,0,524288,4,"cuda:0"]], "output_shapes": [[1024,512]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::transpose", "id": 578, "rf_id": 319, "parent": 577, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::transpose.int(Tensor(a) self, int dim0, int dim1) -> Tensor(a)",
+      "inputs": [[503,325,0,524288,4,"cuda:0"],0,1], "input_shapes": [[512,1024],[],[]], "input_types": ["Tensor(float)","Int","Int"],
+      "outputs": [[530,325,0,524288,4,"cuda:0"]], "output_shapes": [[1024,512]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::t", "id": 577, "rf_id": 318, "parent": 572, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::t(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[503,325,0,524288,4,"cuda:0"]], "input_shapes": [[512,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[530,325,0,524288,4,"cuda:0"]], "output_shapes": [[1024,512]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::mm", "id": 580, "rf_id": 321, "parent": 572, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::mm(Tensor self, Tensor mat2) -> Tensor",
+      "inputs": [[530,325,0,524288,4,"cuda:0"],[291,295,0,524288,4,"cuda:0"]], "input_shapes": [[1024,512],[512,1024]], "input_types": ["Tensor(float)","Tensor(float)"],
+      "outputs": [[306,524,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::as_strided", "id": 583, "rf_id": 324, "parent": 582, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::as_strided(Tensor(a) self, SymInt[] size, SymInt[] stride, SymInt? storage_offset=None) -> Tensor(a)",
+      "inputs": [[306,524,0,1048576,4,"cuda:0"],[1024,1024],[1,1024],"<None>"], "input_shapes": [[1024,1024],[[],[]],[[],[]],[]], "input_types": ["Tensor(float)","GenericList[Int,Int]","GenericList[Int,Int]","None"],
+      "outputs": [[307,524,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::transpose", "id": 582, "rf_id": 323, "parent": 581, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::transpose.int(Tensor(a) self, int dim0, int dim1) -> Tensor(a)",
+      "inputs": [[306,524,0,1048576,4,"cuda:0"],0,1], "input_shapes": [[1024,1024],[],[]], "input_types": ["Tensor(float)","Int","Int"],
+      "outputs": [[307,524,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::t", "id": 581, "rf_id": 322, "parent": 572, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::t(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[306,524,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[307,524,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "AddmmBackward0", "id": 572, "rf_id": 313, "parent": 571, "fw_parent": 2, "seq_id": 718, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[503,325,0,524288,4,"cuda:0"]], "input_shapes": [[512,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::sum", "id": 584, "rf_id": 325, "parent": 571, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::sum.dim_IntList(Tensor self, int[1]? dim, bool keepdim=False, *, ScalarType? dtype=None) -> Tensor",
+      "inputs": [[503,325,0,524288,4,"cuda:0"],[0],true,"<None>"], "input_shapes": [[512,1024],[[]],[],[]], "input_types": ["Tensor(float)","GenericList[Int]","Bool","None"],
+      "outputs": [[530,17,0,1024,4,"cuda:0"]], "output_shapes": [[1,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::view", "id": 585, "rf_id": 326, "parent": 571, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::view(Tensor(a) self, SymInt[] size) -> Tensor(a)",
+      "inputs": [[530,17,0,1024,4,"cuda:0"],[1024]], "input_shapes": [[1,1024],[[]]], "input_types": ["Tensor(float)","GenericList[Int]"],
+      "outputs": [[523,17,0,1024,4,"cuda:0"]], "output_shapes": [[1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "autograd::engine::evaluate_function: AddmmBackward0", "id": 571, "rf_id": 312, "parent": 519, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::add_", "id": 588, "rf_id": 329, "parent": 587, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::add_.Tensor(Tensor(a!) self, Tensor other, *, Scalar alpha=1) -> Tensor(a!)",
+      "inputs": [[485,486,0,1024,4,"cuda:0"],[523,17,0,1024,4,"cuda:0"],1], "input_shapes": [[1024],[1024],[]], "input_types": ["Tensor(float)","Tensor(float)","Int"],
+      "outputs": [[485,486,0,1024,4,"cuda:0"]], "output_shapes": [[1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "torch::autograd::AccumulateGrad", "id": 587, "rf_id": 328, "parent": 586, "fw_parent": 2, "seq_id": -1, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[523,17,0,1024,4,"cuda:0"]], "input_shapes": [[1024]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: torch::autograd::AccumulateGrad", "id": 586, "rf_id": 327, "parent": 519, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::as_strided", "id": 593, "rf_id": 334, "parent": 592, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::as_strided(Tensor(a) self, SymInt[] size, SymInt[] stride, SymInt? storage_offset=None) -> Tensor(a)",
+      "inputs": [[307,524,0,1048576,4,"cuda:0"],[1024,1024],[1024,1],"<None>"], "input_shapes": [[1024,1024],[[],[]],[[],[]],[]], "input_types": ["Tensor(float)","GenericList[Int,Int]","GenericList[Int,Int]","None"],
+      "outputs": [[523,524,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::transpose", "id": 592, "rf_id": 333, "parent": 591, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::transpose.int(Tensor(a) self, int dim0, int dim1) -> Tensor(a)",
+      "inputs": [[307,524,0,1048576,4,"cuda:0"],0,1], "input_shapes": [[1024,1024],[],[]], "input_types": ["Tensor(float)","Int","Int"],
+      "outputs": [[523,524,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::t", "id": 591, "rf_id": 332, "parent": 590, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::t(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[307,524,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[523,524,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "TBackward0", "id": 590, "rf_id": 331, "parent": 589, "fw_parent": 2, "seq_id": 717, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[307,524,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: TBackward0", "id": 589, "rf_id": 330, "parent": 519, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::add_", "id": 596, "rf_id": 337, "parent": 595, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::add_.Tensor(Tensor(a!) self, Tensor other, *, Scalar alpha=1) -> Tensor(a!)",
+      "inputs": [[481,482,0,1048576,4,"cuda:0"],[523,524,0,1048576,4,"cuda:0"],1], "input_shapes": [[1024,1024],[1024,1024],[]], "input_types": ["Tensor(float)","Tensor(float)","Int"],
+      "outputs": [[481,482,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "torch::autograd::AccumulateGrad", "id": 595, "rf_id": 336, "parent": 594, "fw_parent": 2, "seq_id": -1, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[523,524,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: torch::autograd::AccumulateGrad", "id": 594, "rf_id": 335, "parent": 519, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::threshold_backward", "id": 599, "rf_id": 340, "parent": 598, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::threshold_backward(Tensor grad_output, Tensor self, Scalar threshold) -> Tensor",
+      "inputs": [[553,310,0,524288,4,"cuda:0"],[307,295,0,524288,4,"cuda:0"],0], "input_shapes": [[512,1024],[512,1024],[]], "input_types": ["Tensor(float)","Tensor(float)","Int"],
+      "outputs": [[530,504,0,524288,4,"cuda:0"]], "output_shapes": [[512,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "ReluBackward0", "id": 598, "rf_id": 339, "parent": 597, "fw_parent": 2, "seq_id": 716, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[553,310,0,524288,4,"cuda:0"]], "input_shapes": [[512,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: ReluBackward0", "id": 597, "rf_id": 338, "parent": 519, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::as_strided", "id": 604, "rf_id": 345, "parent": 603, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::as_strided(Tensor(a) self, SymInt[] size, SymInt[] stride, SymInt? storage_offset=None) -> Tensor(a)",
+      "inputs": [[277,282,0,1048576,4,"cuda:0"],[1024,1024],[1024,1],"<None>"], "input_shapes": [[1024,1024],[[],[]],[[],[]],[]], "input_types": ["Tensor(float)","GenericList[Int,Int]","GenericList[Int,Int]","None"],
+      "outputs": [[553,282,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::transpose", "id": 603, "rf_id": 344, "parent": 602, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::transpose.int(Tensor(a) self, int dim0, int dim1) -> Tensor(a)",
+      "inputs": [[277,282,0,1048576,4,"cuda:0"],0,1], "input_shapes": [[1024,1024],[],[]], "input_types": ["Tensor(float)","Int","Int"],
+      "outputs": [[553,282,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::t", "id": 602, "rf_id": 343, "parent": 601, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::t(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[277,282,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[553,282,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::mm", "id": 605, "rf_id": 346, "parent": 601, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::mm(Tensor self, Tensor mat2) -> Tensor",
+      "inputs": [[530,504,0,524288,4,"cuda:0"],[553,282,0,1048576,4,"cuda:0"]], "input_shapes": [[512,1024],[1024,1024]], "input_types": ["Tensor(float)","Tensor(float)"],
+      "outputs": [[307,295,0,524288,4,"cuda:0"]], "output_shapes": [[512,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::as_strided", "id": 608, "rf_id": 349, "parent": 607, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::as_strided(Tensor(a) self, SymInt[] size, SymInt[] stride, SymInt? storage_offset=None) -> Tensor(a)",
+      "inputs": [[530,504,0,524288,4,"cuda:0"],[1024,512],[1,1024],"<None>"], "input_shapes": [[512,1024],[[],[]],[[],[]],[]], "input_types": ["Tensor(float)","GenericList[Int,Int]","GenericList[Int,Int]","None"],
+      "outputs": [[553,504,0,524288,4,"cuda:0"]], "output_shapes": [[1024,512]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::transpose", "id": 607, "rf_id": 348, "parent": 606, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::transpose.int(Tensor(a) self, int dim0, int dim1) -> Tensor(a)",
+      "inputs": [[530,504,0,524288,4,"cuda:0"],0,1], "input_shapes": [[512,1024],[],[]], "input_types": ["Tensor(float)","Int","Int"],
+      "outputs": [[553,504,0,524288,4,"cuda:0"]], "output_shapes": [[1024,512]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::t", "id": 606, "rf_id": 347, "parent": 601, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::t(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[530,504,0,524288,4,"cuda:0"]], "input_shapes": [[512,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[553,504,0,524288,4,"cuda:0"]], "output_shapes": [[1024,512]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::mm", "id": 609, "rf_id": 350, "parent": 601, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::mm(Tensor self, Tensor mat2) -> Tensor",
+      "inputs": [[553,504,0,524288,4,"cuda:0"],[276,280,0,524288,4,"cuda:0"]], "input_shapes": [[1024,512],[512,1024]], "input_types": ["Tensor(float)","Tensor(float)"],
+      "outputs": [[291,310,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::as_strided", "id": 612, "rf_id": 353, "parent": 611, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::as_strided(Tensor(a) self, SymInt[] size, SymInt[] stride, SymInt? storage_offset=None) -> Tensor(a)",
+      "inputs": [[291,310,0,1048576,4,"cuda:0"],[1024,1024],[1,1024],"<None>"], "input_shapes": [[1024,1024],[[],[]],[[],[]],[]], "input_types": ["Tensor(float)","GenericList[Int,Int]","GenericList[Int,Int]","None"],
+      "outputs": [[292,310,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::transpose", "id": 611, "rf_id": 352, "parent": 610, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::transpose.int(Tensor(a) self, int dim0, int dim1) -> Tensor(a)",
+      "inputs": [[291,310,0,1048576,4,"cuda:0"],0,1], "input_shapes": [[1024,1024],[],[]], "input_types": ["Tensor(float)","Int","Int"],
+      "outputs": [[292,310,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::t", "id": 610, "rf_id": 351, "parent": 601, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::t(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[291,310,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[292,310,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "AddmmBackward0", "id": 601, "rf_id": 342, "parent": 600, "fw_parent": 2, "seq_id": 715, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[530,504,0,524288,4,"cuda:0"]], "input_shapes": [[512,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::sum", "id": 613, "rf_id": 354, "parent": 600, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::sum.dim_IntList(Tensor self, int[1]? dim, bool keepdim=False, *, ScalarType? dtype=None) -> Tensor",
+      "inputs": [[530,504,0,524288,4,"cuda:0"],[0],true,"<None>"], "input_shapes": [[512,1024],[[]],[],[]], "input_types": ["Tensor(float)","GenericList[Int]","Bool","None"],
+      "outputs": [[553,17,0,1024,4,"cuda:0"]], "output_shapes": [[1,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::view", "id": 614, "rf_id": 355, "parent": 600, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::view(Tensor(a) self, SymInt[] size) -> Tensor(a)",
+      "inputs": [[553,17,0,1024,4,"cuda:0"],[1024]], "input_shapes": [[1,1024],[[]]], "input_types": ["Tensor(float)","GenericList[Int]"],
+      "outputs": [[503,17,0,1024,4,"cuda:0"]], "output_shapes": [[1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "autograd::engine::evaluate_function: AddmmBackward0", "id": 600, "rf_id": 341, "parent": 519, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::add_", "id": 617, "rf_id": 358, "parent": 616, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::add_.Tensor(Tensor(a!) self, Tensor other, *, Scalar alpha=1) -> Tensor(a!)",
+      "inputs": [[477,478,0,1024,4,"cuda:0"],[503,17,0,1024,4,"cuda:0"],1], "input_shapes": [[1024],[1024],[]], "input_types": ["Tensor(float)","Tensor(float)","Int"],
+      "outputs": [[477,478,0,1024,4,"cuda:0"]], "output_shapes": [[1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "torch::autograd::AccumulateGrad", "id": 616, "rf_id": 357, "parent": 615, "fw_parent": 2, "seq_id": -1, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[503,17,0,1024,4,"cuda:0"]], "input_shapes": [[1024]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: torch::autograd::AccumulateGrad", "id": 615, "rf_id": 356, "parent": 519, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::as_strided", "id": 622, "rf_id": 363, "parent": 621, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::as_strided(Tensor(a) self, SymInt[] size, SymInt[] stride, SymInt? storage_offset=None) -> Tensor(a)",
+      "inputs": [[292,310,0,1048576,4,"cuda:0"],[1024,1024],[1024,1],"<None>"], "input_shapes": [[1024,1024],[[],[]],[[],[]],[]], "input_types": ["Tensor(float)","GenericList[Int,Int]","GenericList[Int,Int]","None"],
+      "outputs": [[503,310,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::transpose", "id": 621, "rf_id": 362, "parent": 620, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::transpose.int(Tensor(a) self, int dim0, int dim1) -> Tensor(a)",
+      "inputs": [[292,310,0,1048576,4,"cuda:0"],0,1], "input_shapes": [[1024,1024],[],[]], "input_types": ["Tensor(float)","Int","Int"],
+      "outputs": [[503,310,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::t", "id": 620, "rf_id": 361, "parent": 619, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::t(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[292,310,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[503,310,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "TBackward0", "id": 619, "rf_id": 360, "parent": 618, "fw_parent": 2, "seq_id": 714, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[292,310,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: TBackward0", "id": 618, "rf_id": 359, "parent": 519, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::add_", "id": 625, "rf_id": 366, "parent": 624, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::add_.Tensor(Tensor(a!) self, Tensor other, *, Scalar alpha=1) -> Tensor(a!)",
+      "inputs": [[473,474,0,1048576,4,"cuda:0"],[503,310,0,1048576,4,"cuda:0"],1], "input_shapes": [[1024,1024],[1024,1024],[]], "input_types": ["Tensor(float)","Tensor(float)","Int"],
+      "outputs": [[473,474,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "torch::autograd::AccumulateGrad", "id": 624, "rf_id": 365, "parent": 623, "fw_parent": 2, "seq_id": -1, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[503,310,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: torch::autograd::AccumulateGrad", "id": 623, "rf_id": 364, "parent": 519, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::threshold_backward", "id": 628, "rf_id": 369, "parent": 627, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::threshold_backward(Tensor grad_output, Tensor self, Scalar threshold) -> Tensor",
+      "inputs": [[307,295,0,524288,4,"cuda:0"],[292,280,0,524288,4,"cuda:0"],0], "input_shapes": [[512,1024],[512,1024],[]], "input_types": ["Tensor(float)","Tensor(float)","Int"],
+      "outputs": [[553,504,0,524288,4,"cuda:0"]], "output_shapes": [[512,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "ReluBackward0", "id": 627, "rf_id": 368, "parent": 626, "fw_parent": 2, "seq_id": 713, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[307,295,0,524288,4,"cuda:0"]], "input_shapes": [[512,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: ReluBackward0", "id": 626, "rf_id": 367, "parent": 519, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::as_strided", "id": 633, "rf_id": 374, "parent": 632, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::as_strided(Tensor(a) self, SymInt[] size, SymInt[] stride, SymInt? storage_offset=None) -> Tensor(a)",
+      "inputs": [[262,267,0,1048576,4,"cuda:0"],[1024,1024],[1024,1],"<None>"], "input_shapes": [[1024,1024],[[],[]],[[],[]],[]], "input_types": ["Tensor(float)","GenericList[Int,Int]","GenericList[Int,Int]","None"],
+      "outputs": [[307,267,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::transpose", "id": 632, "rf_id": 373, "parent": 631, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::transpose.int(Tensor(a) self, int dim0, int dim1) -> Tensor(a)",
+      "inputs": [[262,267,0,1048576,4,"cuda:0"],0,1], "input_shapes": [[1024,1024],[],[]], "input_types": ["Tensor(float)","Int","Int"],
+      "outputs": [[307,267,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::t", "id": 631, "rf_id": 372, "parent": 630, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::t(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[262,267,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[307,267,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::mm", "id": 634, "rf_id": 375, "parent": 630, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::mm(Tensor self, Tensor mat2) -> Tensor",
+      "inputs": [[553,504,0,524288,4,"cuda:0"],[307,267,0,1048576,4,"cuda:0"]], "input_shapes": [[512,1024],[1024,1024]], "input_types": ["Tensor(float)","Tensor(float)"],
+      "outputs": [[292,280,0,524288,4,"cuda:0"]], "output_shapes": [[512,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::as_strided", "id": 637, "rf_id": 378, "parent": 636, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::as_strided(Tensor(a) self, SymInt[] size, SymInt[] stride, SymInt? storage_offset=None) -> Tensor(a)",
+      "inputs": [[553,504,0,524288,4,"cuda:0"],[1024,512],[1,1024],"<None>"], "input_shapes": [[512,1024],[[],[]],[[],[]],[]], "input_types": ["Tensor(float)","GenericList[Int,Int]","GenericList[Int,Int]","None"],
+      "outputs": [[307,504,0,524288,4,"cuda:0"]], "output_shapes": [[1024,512]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::transpose", "id": 636, "rf_id": 377, "parent": 635, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::transpose.int(Tensor(a) self, int dim0, int dim1) -> Tensor(a)",
+      "inputs": [[553,504,0,524288,4,"cuda:0"],0,1], "input_shapes": [[512,1024],[],[]], "input_types": ["Tensor(float)","Int","Int"],
+      "outputs": [[307,504,0,524288,4,"cuda:0"]], "output_shapes": [[1024,512]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::t", "id": 635, "rf_id": 376, "parent": 630, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::t(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[553,504,0,524288,4,"cuda:0"]], "input_shapes": [[512,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[307,504,0,524288,4,"cuda:0"]], "output_shapes": [[1024,512]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::mm", "id": 638, "rf_id": 379, "parent": 630, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::mm(Tensor self, Tensor mat2) -> Tensor",
+      "inputs": [[307,504,0,524288,4,"cuda:0"],[261,265,0,524288,4,"cuda:0"]], "input_shapes": [[1024,512],[512,1024]], "input_types": ["Tensor(float)","Tensor(float)"],
+      "outputs": [[276,295,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::as_strided", "id": 641, "rf_id": 382, "parent": 640, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::as_strided(Tensor(a) self, SymInt[] size, SymInt[] stride, SymInt? storage_offset=None) -> Tensor(a)",
+      "inputs": [[276,295,0,1048576,4,"cuda:0"],[1024,1024],[1,1024],"<None>"], "input_shapes": [[1024,1024],[[],[]],[[],[]],[]], "input_types": ["Tensor(float)","GenericList[Int,Int]","GenericList[Int,Int]","None"],
+      "outputs": [[277,295,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::transpose", "id": 640, "rf_id": 381, "parent": 639, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::transpose.int(Tensor(a) self, int dim0, int dim1) -> Tensor(a)",
+      "inputs": [[276,295,0,1048576,4,"cuda:0"],0,1], "input_shapes": [[1024,1024],[],[]], "input_types": ["Tensor(float)","Int","Int"],
+      "outputs": [[277,295,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::t", "id": 639, "rf_id": 380, "parent": 630, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::t(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[276,295,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[277,295,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "AddmmBackward0", "id": 630, "rf_id": 371, "parent": 629, "fw_parent": 2, "seq_id": 712, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[553,504,0,524288,4,"cuda:0"]], "input_shapes": [[512,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::sum", "id": 642, "rf_id": 383, "parent": 629, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::sum.dim_IntList(Tensor self, int[1]? dim, bool keepdim=False, *, ScalarType? dtype=None) -> Tensor",
+      "inputs": [[553,504,0,524288,4,"cuda:0"],[0],true,"<None>"], "input_shapes": [[512,1024],[[]],[],[]], "input_types": ["Tensor(float)","GenericList[Int]","Bool","None"],
+      "outputs": [[307,17,0,1024,4,"cuda:0"]], "output_shapes": [[1,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::view", "id": 643, "rf_id": 384, "parent": 629, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::view(Tensor(a) self, SymInt[] size) -> Tensor(a)",
+      "inputs": [[307,17,0,1024,4,"cuda:0"],[1024]], "input_shapes": [[1,1024],[[]]], "input_types": ["Tensor(float)","GenericList[Int]"],
+      "outputs": [[530,17,0,1024,4,"cuda:0"]], "output_shapes": [[1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "autograd::engine::evaluate_function: AddmmBackward0", "id": 629, "rf_id": 370, "parent": 519, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::add_", "id": 646, "rf_id": 387, "parent": 645, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::add_.Tensor(Tensor(a!) self, Tensor other, *, Scalar alpha=1) -> Tensor(a!)",
+      "inputs": [[469,470,0,1024,4,"cuda:0"],[530,17,0,1024,4,"cuda:0"],1], "input_shapes": [[1024],[1024],[]], "input_types": ["Tensor(float)","Tensor(float)","Int"],
+      "outputs": [[469,470,0,1024,4,"cuda:0"]], "output_shapes": [[1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "torch::autograd::AccumulateGrad", "id": 645, "rf_id": 386, "parent": 644, "fw_parent": 2, "seq_id": -1, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[530,17,0,1024,4,"cuda:0"]], "input_shapes": [[1024]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: torch::autograd::AccumulateGrad", "id": 644, "rf_id": 385, "parent": 519, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::as_strided", "id": 651, "rf_id": 392, "parent": 650, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::as_strided(Tensor(a) self, SymInt[] size, SymInt[] stride, SymInt? storage_offset=None) -> Tensor(a)",
+      "inputs": [[277,295,0,1048576,4,"cuda:0"],[1024,1024],[1024,1],"<None>"], "input_shapes": [[1024,1024],[[],[]],[[],[]],[]], "input_types": ["Tensor(float)","GenericList[Int,Int]","GenericList[Int,Int]","None"],
+      "outputs": [[530,295,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::transpose", "id": 650, "rf_id": 391, "parent": 649, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::transpose.int(Tensor(a) self, int dim0, int dim1) -> Tensor(a)",
+      "inputs": [[277,295,0,1048576,4,"cuda:0"],0,1], "input_shapes": [[1024,1024],[],[]], "input_types": ["Tensor(float)","Int","Int"],
+      "outputs": [[530,295,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::t", "id": 649, "rf_id": 390, "parent": 648, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::t(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[277,295,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[530,295,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "TBackward0", "id": 648, "rf_id": 389, "parent": 647, "fw_parent": 2, "seq_id": 711, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[277,295,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: TBackward0", "id": 647, "rf_id": 388, "parent": 519, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::add_", "id": 654, "rf_id": 395, "parent": 653, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::add_.Tensor(Tensor(a!) self, Tensor other, *, Scalar alpha=1) -> Tensor(a!)",
+      "inputs": [[465,466,0,1048576,4,"cuda:0"],[530,295,0,1048576,4,"cuda:0"],1], "input_shapes": [[1024,1024],[1024,1024],[]], "input_types": ["Tensor(float)","Tensor(float)","Int"],
+      "outputs": [[465,466,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "torch::autograd::AccumulateGrad", "id": 653, "rf_id": 394, "parent": 652, "fw_parent": 2, "seq_id": -1, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[530,295,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: torch::autograd::AccumulateGrad", "id": 652, "rf_id": 393, "parent": 519, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::threshold_backward", "id": 657, "rf_id": 398, "parent": 656, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::threshold_backward(Tensor grad_output, Tensor self, Scalar threshold) -> Tensor",
+      "inputs": [[292,280,0,524288,4,"cuda:0"],[277,265,0,524288,4,"cuda:0"],0], "input_shapes": [[512,1024],[512,1024],[]], "input_types": ["Tensor(float)","Tensor(float)","Int"],
+      "outputs": [[307,504,0,524288,4,"cuda:0"]], "output_shapes": [[512,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "ReluBackward0", "id": 656, "rf_id": 397, "parent": 655, "fw_parent": 2, "seq_id": 710, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[292,280,0,524288,4,"cuda:0"]], "input_shapes": [[512,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: ReluBackward0", "id": 655, "rf_id": 396, "parent": 519, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::as_strided", "id": 662, "rf_id": 403, "parent": 661, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::as_strided(Tensor(a) self, SymInt[] size, SymInt[] stride, SymInt? storage_offset=None) -> Tensor(a)",
+      "inputs": [[247,252,0,1048576,4,"cuda:0"],[1024,1024],[1024,1],"<None>"], "input_shapes": [[1024,1024],[[],[]],[[],[]],[]], "input_types": ["Tensor(float)","GenericList[Int,Int]","GenericList[Int,Int]","None"],
+      "outputs": [[292,252,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::transpose", "id": 661, "rf_id": 402, "parent": 660, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::transpose.int(Tensor(a) self, int dim0, int dim1) -> Tensor(a)",
+      "inputs": [[247,252,0,1048576,4,"cuda:0"],0,1], "input_shapes": [[1024,1024],[],[]], "input_types": ["Tensor(float)","Int","Int"],
+      "outputs": [[292,252,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::t", "id": 660, "rf_id": 401, "parent": 659, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::t(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[247,252,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[292,252,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::mm", "id": 663, "rf_id": 404, "parent": 659, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::mm(Tensor self, Tensor mat2) -> Tensor",
+      "inputs": [[307,504,0,524288,4,"cuda:0"],[292,252,0,1048576,4,"cuda:0"]], "input_shapes": [[512,1024],[1024,1024]], "input_types": ["Tensor(float)","Tensor(float)"],
+      "outputs": [[277,265,0,524288,4,"cuda:0"]], "output_shapes": [[512,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::as_strided", "id": 666, "rf_id": 407, "parent": 665, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::as_strided(Tensor(a) self, SymInt[] size, SymInt[] stride, SymInt? storage_offset=None) -> Tensor(a)",
+      "inputs": [[307,504,0,524288,4,"cuda:0"],[1024,512],[1,1024],"<None>"], "input_shapes": [[512,1024],[[],[]],[[],[]],[]], "input_types": ["Tensor(float)","GenericList[Int,Int]","GenericList[Int,Int]","None"],
+      "outputs": [[292,504,0,524288,4,"cuda:0"]], "output_shapes": [[1024,512]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::transpose", "id": 665, "rf_id": 406, "parent": 664, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::transpose.int(Tensor(a) self, int dim0, int dim1) -> Tensor(a)",
+      "inputs": [[307,504,0,524288,4,"cuda:0"],0,1], "input_shapes": [[512,1024],[],[]], "input_types": ["Tensor(float)","Int","Int"],
+      "outputs": [[292,504,0,524288,4,"cuda:0"]], "output_shapes": [[1024,512]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::t", "id": 664, "rf_id": 405, "parent": 659, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::t(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[307,504,0,524288,4,"cuda:0"]], "input_shapes": [[512,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[292,504,0,524288,4,"cuda:0"]], "output_shapes": [[1024,512]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::mm", "id": 667, "rf_id": 408, "parent": 659, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::mm(Tensor self, Tensor mat2) -> Tensor",
+      "inputs": [[292,504,0,524288,4,"cuda:0"],[246,250,0,524288,4,"cuda:0"]], "input_shapes": [[1024,512],[512,1024]], "input_types": ["Tensor(float)","Tensor(float)"],
+      "outputs": [[261,280,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::as_strided", "id": 670, "rf_id": 411, "parent": 669, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::as_strided(Tensor(a) self, SymInt[] size, SymInt[] stride, SymInt? storage_offset=None) -> Tensor(a)",
+      "inputs": [[261,280,0,1048576,4,"cuda:0"],[1024,1024],[1,1024],"<None>"], "input_shapes": [[1024,1024],[[],[]],[[],[]],[]], "input_types": ["Tensor(float)","GenericList[Int,Int]","GenericList[Int,Int]","None"],
+      "outputs": [[262,280,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::transpose", "id": 669, "rf_id": 410, "parent": 668, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::transpose.int(Tensor(a) self, int dim0, int dim1) -> Tensor(a)",
+      "inputs": [[261,280,0,1048576,4,"cuda:0"],0,1], "input_shapes": [[1024,1024],[],[]], "input_types": ["Tensor(float)","Int","Int"],
+      "outputs": [[262,280,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::t", "id": 668, "rf_id": 409, "parent": 659, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::t(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[261,280,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[262,280,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "AddmmBackward0", "id": 659, "rf_id": 400, "parent": 658, "fw_parent": 2, "seq_id": 709, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[307,504,0,524288,4,"cuda:0"]], "input_shapes": [[512,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::sum", "id": 671, "rf_id": 412, "parent": 658, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::sum.dim_IntList(Tensor self, int[1]? dim, bool keepdim=False, *, ScalarType? dtype=None) -> Tensor",
+      "inputs": [[307,504,0,524288,4,"cuda:0"],[0],true,"<None>"], "input_shapes": [[512,1024],[[]],[],[]], "input_types": ["Tensor(float)","GenericList[Int]","Bool","None"],
+      "outputs": [[292,17,0,1024,4,"cuda:0"]], "output_shapes": [[1,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::view", "id": 672, "rf_id": 413, "parent": 658, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::view(Tensor(a) self, SymInt[] size) -> Tensor(a)",
+      "inputs": [[292,17,0,1024,4,"cuda:0"],[1024]], "input_shapes": [[1,1024],[[]]], "input_types": ["Tensor(float)","GenericList[Int]"],
+      "outputs": [[553,17,0,1024,4,"cuda:0"]], "output_shapes": [[1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "autograd::engine::evaluate_function: AddmmBackward0", "id": 658, "rf_id": 399, "parent": 519, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::add_", "id": 675, "rf_id": 416, "parent": 674, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::add_.Tensor(Tensor(a!) self, Tensor other, *, Scalar alpha=1) -> Tensor(a!)",
+      "inputs": [[461,462,0,1024,4,"cuda:0"],[553,17,0,1024,4,"cuda:0"],1], "input_shapes": [[1024],[1024],[]], "input_types": ["Tensor(float)","Tensor(float)","Int"],
+      "outputs": [[461,462,0,1024,4,"cuda:0"]], "output_shapes": [[1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "torch::autograd::AccumulateGrad", "id": 674, "rf_id": 415, "parent": 673, "fw_parent": 2, "seq_id": -1, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[553,17,0,1024,4,"cuda:0"]], "input_shapes": [[1024]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: torch::autograd::AccumulateGrad", "id": 673, "rf_id": 414, "parent": 519, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::as_strided", "id": 680, "rf_id": 421, "parent": 679, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::as_strided(Tensor(a) self, SymInt[] size, SymInt[] stride, SymInt? storage_offset=None) -> Tensor(a)",
+      "inputs": [[262,280,0,1048576,4,"cuda:0"],[1024,1024],[1024,1],"<None>"], "input_shapes": [[1024,1024],[[],[]],[[],[]],[]], "input_types": ["Tensor(float)","GenericList[Int,Int]","GenericList[Int,Int]","None"],
+      "outputs": [[553,280,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::transpose", "id": 679, "rf_id": 420, "parent": 678, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::transpose.int(Tensor(a) self, int dim0, int dim1) -> Tensor(a)",
+      "inputs": [[262,280,0,1048576,4,"cuda:0"],0,1], "input_shapes": [[1024,1024],[],[]], "input_types": ["Tensor(float)","Int","Int"],
+      "outputs": [[553,280,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::t", "id": 678, "rf_id": 419, "parent": 677, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::t(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[262,280,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[553,280,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "TBackward0", "id": 677, "rf_id": 418, "parent": 676, "fw_parent": 2, "seq_id": 708, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[262,280,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: TBackward0", "id": 676, "rf_id": 417, "parent": 519, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::add_", "id": 683, "rf_id": 424, "parent": 682, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::add_.Tensor(Tensor(a!) self, Tensor other, *, Scalar alpha=1) -> Tensor(a!)",
+      "inputs": [[457,458,0,1048576,4,"cuda:0"],[553,280,0,1048576,4,"cuda:0"],1], "input_shapes": [[1024,1024],[1024,1024],[]], "input_types": ["Tensor(float)","Tensor(float)","Int"],
+      "outputs": [[457,458,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "torch::autograd::AccumulateGrad", "id": 682, "rf_id": 423, "parent": 681, "fw_parent": 2, "seq_id": -1, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[553,280,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: torch::autograd::AccumulateGrad", "id": 681, "rf_id": 422, "parent": 519, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::threshold_backward", "id": 686, "rf_id": 427, "parent": 685, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::threshold_backward(Tensor grad_output, Tensor self, Scalar threshold) -> Tensor",
+      "inputs": [[277,265,0,524288,4,"cuda:0"],[262,250,0,524288,4,"cuda:0"],0], "input_shapes": [[512,1024],[512,1024],[]], "input_types": ["Tensor(float)","Tensor(float)","Int"],
+      "outputs": [[292,504,0,524288,4,"cuda:0"]], "output_shapes": [[512,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "ReluBackward0", "id": 685, "rf_id": 426, "parent": 684, "fw_parent": 2, "seq_id": 707, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[277,265,0,524288,4,"cuda:0"]], "input_shapes": [[512,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: ReluBackward0", "id": 684, "rf_id": 425, "parent": 519, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::as_strided", "id": 691, "rf_id": 432, "parent": 690, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::as_strided(Tensor(a) self, SymInt[] size, SymInt[] stride, SymInt? storage_offset=None) -> Tensor(a)",
+      "inputs": [[232,237,0,1048576,4,"cuda:0"],[1024,1024],[1024,1],"<None>"], "input_shapes": [[1024,1024],[[],[]],[[],[]],[]], "input_types": ["Tensor(float)","GenericList[Int,Int]","GenericList[Int,Int]","None"],
+      "outputs": [[277,237,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::transpose", "id": 690, "rf_id": 431, "parent": 689, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::transpose.int(Tensor(a) self, int dim0, int dim1) -> Tensor(a)",
+      "inputs": [[232,237,0,1048576,4,"cuda:0"],0,1], "input_shapes": [[1024,1024],[],[]], "input_types": ["Tensor(float)","Int","Int"],
+      "outputs": [[277,237,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::t", "id": 689, "rf_id": 430, "parent": 688, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::t(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[232,237,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[277,237,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::mm", "id": 692, "rf_id": 433, "parent": 688, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::mm(Tensor self, Tensor mat2) -> Tensor",
+      "inputs": [[292,504,0,524288,4,"cuda:0"],[277,237,0,1048576,4,"cuda:0"]], "input_shapes": [[512,1024],[1024,1024]], "input_types": ["Tensor(float)","Tensor(float)"],
+      "outputs": [[262,250,0,524288,4,"cuda:0"]], "output_shapes": [[512,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::as_strided", "id": 695, "rf_id": 436, "parent": 694, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::as_strided(Tensor(a) self, SymInt[] size, SymInt[] stride, SymInt? storage_offset=None) -> Tensor(a)",
+      "inputs": [[292,504,0,524288,4,"cuda:0"],[1024,512],[1,1024],"<None>"], "input_shapes": [[512,1024],[[],[]],[[],[]],[]], "input_types": ["Tensor(float)","GenericList[Int,Int]","GenericList[Int,Int]","None"],
+      "outputs": [[277,504,0,524288,4,"cuda:0"]], "output_shapes": [[1024,512]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::transpose", "id": 694, "rf_id": 435, "parent": 693, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::transpose.int(Tensor(a) self, int dim0, int dim1) -> Tensor(a)",
+      "inputs": [[292,504,0,524288,4,"cuda:0"],0,1], "input_shapes": [[512,1024],[],[]], "input_types": ["Tensor(float)","Int","Int"],
+      "outputs": [[277,504,0,524288,4,"cuda:0"]], "output_shapes": [[1024,512]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::t", "id": 693, "rf_id": 434, "parent": 688, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::t(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[292,504,0,524288,4,"cuda:0"]], "input_shapes": [[512,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[277,504,0,524288,4,"cuda:0"]], "output_shapes": [[1024,512]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::mm", "id": 696, "rf_id": 437, "parent": 688, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::mm(Tensor self, Tensor mat2) -> Tensor",
+      "inputs": [[277,504,0,524288,4,"cuda:0"],[231,235,0,524288,4,"cuda:0"]], "input_shapes": [[1024,512],[512,1024]], "input_types": ["Tensor(float)","Tensor(float)"],
+      "outputs": [[246,265,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::as_strided", "id": 699, "rf_id": 440, "parent": 698, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::as_strided(Tensor(a) self, SymInt[] size, SymInt[] stride, SymInt? storage_offset=None) -> Tensor(a)",
+      "inputs": [[246,265,0,1048576,4,"cuda:0"],[1024,1024],[1,1024],"<None>"], "input_shapes": [[1024,1024],[[],[]],[[],[]],[]], "input_types": ["Tensor(float)","GenericList[Int,Int]","GenericList[Int,Int]","None"],
+      "outputs": [[247,265,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::transpose", "id": 698, "rf_id": 439, "parent": 697, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::transpose.int(Tensor(a) self, int dim0, int dim1) -> Tensor(a)",
+      "inputs": [[246,265,0,1048576,4,"cuda:0"],0,1], "input_shapes": [[1024,1024],[],[]], "input_types": ["Tensor(float)","Int","Int"],
+      "outputs": [[247,265,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::t", "id": 697, "rf_id": 438, "parent": 688, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::t(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[246,265,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[247,265,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "AddmmBackward0", "id": 688, "rf_id": 429, "parent": 687, "fw_parent": 2, "seq_id": 706, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[292,504,0,524288,4,"cuda:0"]], "input_shapes": [[512,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::sum", "id": 700, "rf_id": 441, "parent": 687, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::sum.dim_IntList(Tensor self, int[1]? dim, bool keepdim=False, *, ScalarType? dtype=None) -> Tensor",
+      "inputs": [[292,504,0,524288,4,"cuda:0"],[0],true,"<None>"], "input_shapes": [[512,1024],[[]],[],[]], "input_types": ["Tensor(float)","GenericList[Int]","Bool","None"],
+      "outputs": [[277,17,0,1024,4,"cuda:0"]], "output_shapes": [[1,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::view", "id": 701, "rf_id": 442, "parent": 687, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::view(Tensor(a) self, SymInt[] size) -> Tensor(a)",
+      "inputs": [[277,17,0,1024,4,"cuda:0"],[1024]], "input_shapes": [[1,1024],[[]]], "input_types": ["Tensor(float)","GenericList[Int]"],
+      "outputs": [[307,17,0,1024,4,"cuda:0"]], "output_shapes": [[1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "autograd::engine::evaluate_function: AddmmBackward0", "id": 687, "rf_id": 428, "parent": 519, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::add_", "id": 704, "rf_id": 445, "parent": 703, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::add_.Tensor(Tensor(a!) self, Tensor other, *, Scalar alpha=1) -> Tensor(a!)",
+      "inputs": [[453,454,0,1024,4,"cuda:0"],[307,17,0,1024,4,"cuda:0"],1], "input_shapes": [[1024],[1024],[]], "input_types": ["Tensor(float)","Tensor(float)","Int"],
+      "outputs": [[453,454,0,1024,4,"cuda:0"]], "output_shapes": [[1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "torch::autograd::AccumulateGrad", "id": 703, "rf_id": 444, "parent": 702, "fw_parent": 2, "seq_id": -1, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[307,17,0,1024,4,"cuda:0"]], "input_shapes": [[1024]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: torch::autograd::AccumulateGrad", "id": 702, "rf_id": 443, "parent": 519, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::as_strided", "id": 709, "rf_id": 450, "parent": 708, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::as_strided(Tensor(a) self, SymInt[] size, SymInt[] stride, SymInt? storage_offset=None) -> Tensor(a)",
+      "inputs": [[247,265,0,1048576,4,"cuda:0"],[1024,1024],[1024,1],"<None>"], "input_shapes": [[1024,1024],[[],[]],[[],[]],[]], "input_types": ["Tensor(float)","GenericList[Int,Int]","GenericList[Int,Int]","None"],
+      "outputs": [[307,265,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::transpose", "id": 708, "rf_id": 449, "parent": 707, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::transpose.int(Tensor(a) self, int dim0, int dim1) -> Tensor(a)",
+      "inputs": [[247,265,0,1048576,4,"cuda:0"],0,1], "input_shapes": [[1024,1024],[],[]], "input_types": ["Tensor(float)","Int","Int"],
+      "outputs": [[307,265,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::t", "id": 707, "rf_id": 448, "parent": 706, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::t(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[247,265,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[307,265,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "TBackward0", "id": 706, "rf_id": 447, "parent": 705, "fw_parent": 2, "seq_id": 705, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[247,265,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: TBackward0", "id": 705, "rf_id": 446, "parent": 519, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::add_", "id": 712, "rf_id": 453, "parent": 711, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::add_.Tensor(Tensor(a!) self, Tensor other, *, Scalar alpha=1) -> Tensor(a!)",
+      "inputs": [[449,450,0,1048576,4,"cuda:0"],[307,265,0,1048576,4,"cuda:0"],1], "input_shapes": [[1024,1024],[1024,1024],[]], "input_types": ["Tensor(float)","Tensor(float)","Int"],
+      "outputs": [[449,450,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "torch::autograd::AccumulateGrad", "id": 711, "rf_id": 452, "parent": 710, "fw_parent": 2, "seq_id": -1, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[307,265,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: torch::autograd::AccumulateGrad", "id": 710, "rf_id": 451, "parent": 519, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::threshold_backward", "id": 715, "rf_id": 456, "parent": 714, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::threshold_backward(Tensor grad_output, Tensor self, Scalar threshold) -> Tensor",
+      "inputs": [[262,250,0,524288,4,"cuda:0"],[247,235,0,524288,4,"cuda:0"],0], "input_shapes": [[512,1024],[512,1024],[]], "input_types": ["Tensor(float)","Tensor(float)","Int"],
+      "outputs": [[277,504,0,524288,4,"cuda:0"]], "output_shapes": [[512,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "ReluBackward0", "id": 714, "rf_id": 455, "parent": 713, "fw_parent": 2, "seq_id": 704, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[262,250,0,524288,4,"cuda:0"]], "input_shapes": [[512,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: ReluBackward0", "id": 713, "rf_id": 454, "parent": 519, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::as_strided", "id": 720, "rf_id": 461, "parent": 719, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::as_strided(Tensor(a) self, SymInt[] size, SymInt[] stride, SymInt? storage_offset=None) -> Tensor(a)",
+      "inputs": [[217,222,0,1048576,4,"cuda:0"],[1024,1024],[1024,1],"<None>"], "input_shapes": [[1024,1024],[[],[]],[[],[]],[]], "input_types": ["Tensor(float)","GenericList[Int,Int]","GenericList[Int,Int]","None"],
+      "outputs": [[262,222,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::transpose", "id": 719, "rf_id": 460, "parent": 718, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::transpose.int(Tensor(a) self, int dim0, int dim1) -> Tensor(a)",
+      "inputs": [[217,222,0,1048576,4,"cuda:0"],0,1], "input_shapes": [[1024,1024],[],[]], "input_types": ["Tensor(float)","Int","Int"],
+      "outputs": [[262,222,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::t", "id": 718, "rf_id": 459, "parent": 717, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::t(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[217,222,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[262,222,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::mm", "id": 721, "rf_id": 462, "parent": 717, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::mm(Tensor self, Tensor mat2) -> Tensor",
+      "inputs": [[277,504,0,524288,4,"cuda:0"],[262,222,0,1048576,4,"cuda:0"]], "input_shapes": [[512,1024],[1024,1024]], "input_types": ["Tensor(float)","Tensor(float)"],
+      "outputs": [[247,235,0,524288,4,"cuda:0"]], "output_shapes": [[512,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::as_strided", "id": 724, "rf_id": 465, "parent": 723, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::as_strided(Tensor(a) self, SymInt[] size, SymInt[] stride, SymInt? storage_offset=None) -> Tensor(a)",
+      "inputs": [[277,504,0,524288,4,"cuda:0"],[1024,512],[1,1024],"<None>"], "input_shapes": [[512,1024],[[],[]],[[],[]],[]], "input_types": ["Tensor(float)","GenericList[Int,Int]","GenericList[Int,Int]","None"],
+      "outputs": [[262,504,0,524288,4,"cuda:0"]], "output_shapes": [[1024,512]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::transpose", "id": 723, "rf_id": 464, "parent": 722, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::transpose.int(Tensor(a) self, int dim0, int dim1) -> Tensor(a)",
+      "inputs": [[277,504,0,524288,4,"cuda:0"],0,1], "input_shapes": [[512,1024],[],[]], "input_types": ["Tensor(float)","Int","Int"],
+      "outputs": [[262,504,0,524288,4,"cuda:0"]], "output_shapes": [[1024,512]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::t", "id": 722, "rf_id": 463, "parent": 717, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::t(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[277,504,0,524288,4,"cuda:0"]], "input_shapes": [[512,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[262,504,0,524288,4,"cuda:0"]], "output_shapes": [[1024,512]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::mm", "id": 725, "rf_id": 466, "parent": 717, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::mm(Tensor self, Tensor mat2) -> Tensor",
+      "inputs": [[262,504,0,524288,4,"cuda:0"],[216,220,0,524288,4,"cuda:0"]], "input_shapes": [[1024,512],[512,1024]], "input_types": ["Tensor(float)","Tensor(float)"],
+      "outputs": [[231,250,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::as_strided", "id": 728, "rf_id": 469, "parent": 727, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::as_strided(Tensor(a) self, SymInt[] size, SymInt[] stride, SymInt? storage_offset=None) -> Tensor(a)",
+      "inputs": [[231,250,0,1048576,4,"cuda:0"],[1024,1024],[1,1024],"<None>"], "input_shapes": [[1024,1024],[[],[]],[[],[]],[]], "input_types": ["Tensor(float)","GenericList[Int,Int]","GenericList[Int,Int]","None"],
+      "outputs": [[232,250,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::transpose", "id": 727, "rf_id": 468, "parent": 726, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::transpose.int(Tensor(a) self, int dim0, int dim1) -> Tensor(a)",
+      "inputs": [[231,250,0,1048576,4,"cuda:0"],0,1], "input_shapes": [[1024,1024],[],[]], "input_types": ["Tensor(float)","Int","Int"],
+      "outputs": [[232,250,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::t", "id": 726, "rf_id": 467, "parent": 717, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::t(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[231,250,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[232,250,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "AddmmBackward0", "id": 717, "rf_id": 458, "parent": 716, "fw_parent": 2, "seq_id": 703, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[277,504,0,524288,4,"cuda:0"]], "input_shapes": [[512,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::sum", "id": 729, "rf_id": 470, "parent": 716, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::sum.dim_IntList(Tensor self, int[1]? dim, bool keepdim=False, *, ScalarType? dtype=None) -> Tensor",
+      "inputs": [[277,504,0,524288,4,"cuda:0"],[0],true,"<None>"], "input_shapes": [[512,1024],[[]],[],[]], "input_types": ["Tensor(float)","GenericList[Int]","Bool","None"],
+      "outputs": [[262,17,0,1024,4,"cuda:0"]], "output_shapes": [[1,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::view", "id": 730, "rf_id": 471, "parent": 716, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::view(Tensor(a) self, SymInt[] size) -> Tensor(a)",
+      "inputs": [[262,17,0,1024,4,"cuda:0"],[1024]], "input_shapes": [[1,1024],[[]]], "input_types": ["Tensor(float)","GenericList[Int]"],
+      "outputs": [[292,17,0,1024,4,"cuda:0"]], "output_shapes": [[1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "autograd::engine::evaluate_function: AddmmBackward0", "id": 716, "rf_id": 457, "parent": 519, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::add_", "id": 733, "rf_id": 474, "parent": 732, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::add_.Tensor(Tensor(a!) self, Tensor other, *, Scalar alpha=1) -> Tensor(a!)",
+      "inputs": [[445,446,0,1024,4,"cuda:0"],[292,17,0,1024,4,"cuda:0"],1], "input_shapes": [[1024],[1024],[]], "input_types": ["Tensor(float)","Tensor(float)","Int"],
+      "outputs": [[445,446,0,1024,4,"cuda:0"]], "output_shapes": [[1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "torch::autograd::AccumulateGrad", "id": 732, "rf_id": 473, "parent": 731, "fw_parent": 2, "seq_id": -1, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[292,17,0,1024,4,"cuda:0"]], "input_shapes": [[1024]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: torch::autograd::AccumulateGrad", "id": 731, "rf_id": 472, "parent": 519, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::as_strided", "id": 738, "rf_id": 479, "parent": 737, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::as_strided(Tensor(a) self, SymInt[] size, SymInt[] stride, SymInt? storage_offset=None) -> Tensor(a)",
+      "inputs": [[232,250,0,1048576,4,"cuda:0"],[1024,1024],[1024,1],"<None>"], "input_shapes": [[1024,1024],[[],[]],[[],[]],[]], "input_types": ["Tensor(float)","GenericList[Int,Int]","GenericList[Int,Int]","None"],
+      "outputs": [[292,250,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::transpose", "id": 737, "rf_id": 478, "parent": 736, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::transpose.int(Tensor(a) self, int dim0, int dim1) -> Tensor(a)",
+      "inputs": [[232,250,0,1048576,4,"cuda:0"],0,1], "input_shapes": [[1024,1024],[],[]], "input_types": ["Tensor(float)","Int","Int"],
+      "outputs": [[292,250,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::t", "id": 736, "rf_id": 477, "parent": 735, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::t(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[232,250,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[292,250,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "TBackward0", "id": 735, "rf_id": 476, "parent": 734, "fw_parent": 2, "seq_id": 702, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[232,250,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: TBackward0", "id": 734, "rf_id": 475, "parent": 519, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::add_", "id": 741, "rf_id": 482, "parent": 740, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::add_.Tensor(Tensor(a!) self, Tensor other, *, Scalar alpha=1) -> Tensor(a!)",
+      "inputs": [[441,442,0,1048576,4,"cuda:0"],[292,250,0,1048576,4,"cuda:0"],1], "input_shapes": [[1024,1024],[1024,1024],[]], "input_types": ["Tensor(float)","Tensor(float)","Int"],
+      "outputs": [[441,442,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "torch::autograd::AccumulateGrad", "id": 740, "rf_id": 481, "parent": 739, "fw_parent": 2, "seq_id": -1, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[292,250,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: torch::autograd::AccumulateGrad", "id": 739, "rf_id": 480, "parent": 519, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::threshold_backward", "id": 744, "rf_id": 485, "parent": 743, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::threshold_backward(Tensor grad_output, Tensor self, Scalar threshold) -> Tensor",
+      "inputs": [[247,235,0,524288,4,"cuda:0"],[232,220,0,524288,4,"cuda:0"],0], "input_shapes": [[512,1024],[512,1024],[]], "input_types": ["Tensor(float)","Tensor(float)","Int"],
+      "outputs": [[262,504,0,524288,4,"cuda:0"]], "output_shapes": [[512,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "ReluBackward0", "id": 743, "rf_id": 484, "parent": 742, "fw_parent": 2, "seq_id": 701, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[247,235,0,524288,4,"cuda:0"]], "input_shapes": [[512,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: ReluBackward0", "id": 742, "rf_id": 483, "parent": 519, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::as_strided", "id": 749, "rf_id": 490, "parent": 748, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::as_strided(Tensor(a) self, SymInt[] size, SymInt[] stride, SymInt? storage_offset=None) -> Tensor(a)",
+      "inputs": [[202,207,0,1048576,4,"cuda:0"],[1024,1024],[1024,1],"<None>"], "input_shapes": [[1024,1024],[[],[]],[[],[]],[]], "input_types": ["Tensor(float)","GenericList[Int,Int]","GenericList[Int,Int]","None"],
+      "outputs": [[247,207,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::transpose", "id": 748, "rf_id": 489, "parent": 747, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::transpose.int(Tensor(a) self, int dim0, int dim1) -> Tensor(a)",
+      "inputs": [[202,207,0,1048576,4,"cuda:0"],0,1], "input_shapes": [[1024,1024],[],[]], "input_types": ["Tensor(float)","Int","Int"],
+      "outputs": [[247,207,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::t", "id": 747, "rf_id": 488, "parent": 746, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::t(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[202,207,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[247,207,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::mm", "id": 750, "rf_id": 491, "parent": 746, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::mm(Tensor self, Tensor mat2) -> Tensor",
+      "inputs": [[262,504,0,524288,4,"cuda:0"],[247,207,0,1048576,4,"cuda:0"]], "input_shapes": [[512,1024],[1024,1024]], "input_types": ["Tensor(float)","Tensor(float)"],
+      "outputs": [[232,220,0,524288,4,"cuda:0"]], "output_shapes": [[512,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::as_strided", "id": 753, "rf_id": 494, "parent": 752, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::as_strided(Tensor(a) self, SymInt[] size, SymInt[] stride, SymInt? storage_offset=None) -> Tensor(a)",
+      "inputs": [[262,504,0,524288,4,"cuda:0"],[1024,512],[1,1024],"<None>"], "input_shapes": [[512,1024],[[],[]],[[],[]],[]], "input_types": ["Tensor(float)","GenericList[Int,Int]","GenericList[Int,Int]","None"],
+      "outputs": [[247,504,0,524288,4,"cuda:0"]], "output_shapes": [[1024,512]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::transpose", "id": 752, "rf_id": 493, "parent": 751, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::transpose.int(Tensor(a) self, int dim0, int dim1) -> Tensor(a)",
+      "inputs": [[262,504,0,524288,4,"cuda:0"],0,1], "input_shapes": [[512,1024],[],[]], "input_types": ["Tensor(float)","Int","Int"],
+      "outputs": [[247,504,0,524288,4,"cuda:0"]], "output_shapes": [[1024,512]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::t", "id": 751, "rf_id": 492, "parent": 746, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::t(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[262,504,0,524288,4,"cuda:0"]], "input_shapes": [[512,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[247,504,0,524288,4,"cuda:0"]], "output_shapes": [[1024,512]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::mm", "id": 754, "rf_id": 495, "parent": 746, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::mm(Tensor self, Tensor mat2) -> Tensor",
+      "inputs": [[247,504,0,524288,4,"cuda:0"],[201,128,0,524288,4,"cuda:0"]], "input_shapes": [[1024,512],[512,1024]], "input_types": ["Tensor(float)","Tensor(float)"],
+      "outputs": [[216,235,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::as_strided", "id": 757, "rf_id": 498, "parent": 756, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::as_strided(Tensor(a) self, SymInt[] size, SymInt[] stride, SymInt? storage_offset=None) -> Tensor(a)",
+      "inputs": [[216,235,0,1048576,4,"cuda:0"],[1024,1024],[1,1024],"<None>"], "input_shapes": [[1024,1024],[[],[]],[[],[]],[]], "input_types": ["Tensor(float)","GenericList[Int,Int]","GenericList[Int,Int]","None"],
+      "outputs": [[217,235,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::transpose", "id": 756, "rf_id": 497, "parent": 755, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::transpose.int(Tensor(a) self, int dim0, int dim1) -> Tensor(a)",
+      "inputs": [[216,235,0,1048576,4,"cuda:0"],0,1], "input_shapes": [[1024,1024],[],[]], "input_types": ["Tensor(float)","Int","Int"],
+      "outputs": [[217,235,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::t", "id": 755, "rf_id": 496, "parent": 746, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::t(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[216,235,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[217,235,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "AddmmBackward0", "id": 746, "rf_id": 487, "parent": 745, "fw_parent": 2, "seq_id": 700, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[262,504,0,524288,4,"cuda:0"]], "input_shapes": [[512,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::sum", "id": 758, "rf_id": 499, "parent": 745, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::sum.dim_IntList(Tensor self, int[1]? dim, bool keepdim=False, *, ScalarType? dtype=None) -> Tensor",
+      "inputs": [[262,504,0,524288,4,"cuda:0"],[0],true,"<None>"], "input_shapes": [[512,1024],[[]],[],[]], "input_types": ["Tensor(float)","GenericList[Int]","Bool","None"],
+      "outputs": [[247,17,0,1024,4,"cuda:0"]], "output_shapes": [[1,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::view", "id": 759, "rf_id": 500, "parent": 745, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::view(Tensor(a) self, SymInt[] size) -> Tensor(a)",
+      "inputs": [[247,17,0,1024,4,"cuda:0"],[1024]], "input_shapes": [[1,1024],[[]]], "input_types": ["Tensor(float)","GenericList[Int]"],
+      "outputs": [[277,17,0,1024,4,"cuda:0"]], "output_shapes": [[1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "autograd::engine::evaluate_function: AddmmBackward0", "id": 745, "rf_id": 486, "parent": 519, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::add_", "id": 762, "rf_id": 503, "parent": 761, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::add_.Tensor(Tensor(a!) self, Tensor other, *, Scalar alpha=1) -> Tensor(a!)",
+      "inputs": [[437,438,0,1024,4,"cuda:0"],[277,17,0,1024,4,"cuda:0"],1], "input_shapes": [[1024],[1024],[]], "input_types": ["Tensor(float)","Tensor(float)","Int"],
+      "outputs": [[437,438,0,1024,4,"cuda:0"]], "output_shapes": [[1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "torch::autograd::AccumulateGrad", "id": 761, "rf_id": 502, "parent": 760, "fw_parent": 2, "seq_id": -1, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[277,17,0,1024,4,"cuda:0"]], "input_shapes": [[1024]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: torch::autograd::AccumulateGrad", "id": 760, "rf_id": 501, "parent": 519, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::as_strided", "id": 767, "rf_id": 508, "parent": 766, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::as_strided(Tensor(a) self, SymInt[] size, SymInt[] stride, SymInt? storage_offset=None) -> Tensor(a)",
+      "inputs": [[217,235,0,1048576,4,"cuda:0"],[1024,1024],[1024,1],"<None>"], "input_shapes": [[1024,1024],[[],[]],[[],[]],[]], "input_types": ["Tensor(float)","GenericList[Int,Int]","GenericList[Int,Int]","None"],
+      "outputs": [[277,235,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::transpose", "id": 766, "rf_id": 507, "parent": 765, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::transpose.int(Tensor(a) self, int dim0, int dim1) -> Tensor(a)",
+      "inputs": [[217,235,0,1048576,4,"cuda:0"],0,1], "input_shapes": [[1024,1024],[],[]], "input_types": ["Tensor(float)","Int","Int"],
+      "outputs": [[277,235,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::t", "id": 765, "rf_id": 506, "parent": 764, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::t(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[217,235,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[277,235,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "TBackward0", "id": 764, "rf_id": 505, "parent": 763, "fw_parent": 2, "seq_id": 699, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[217,235,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: TBackward0", "id": 763, "rf_id": 504, "parent": 519, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::add_", "id": 770, "rf_id": 511, "parent": 769, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::add_.Tensor(Tensor(a!) self, Tensor other, *, Scalar alpha=1) -> Tensor(a!)",
+      "inputs": [[433,434,0,1048576,4,"cuda:0"],[277,235,0,1048576,4,"cuda:0"],1], "input_shapes": [[1024,1024],[1024,1024],[]], "input_types": ["Tensor(float)","Tensor(float)","Int"],
+      "outputs": [[433,434,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "torch::autograd::AccumulateGrad", "id": 769, "rf_id": 510, "parent": 768, "fw_parent": 2, "seq_id": -1, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[277,235,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: torch::autograd::AccumulateGrad", "id": 768, "rf_id": 509, "parent": 519, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::threshold_backward", "id": 773, "rf_id": 514, "parent": 772, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::threshold_backward(Tensor grad_output, Tensor self, Scalar threshold) -> Tensor",
+      "inputs": [[232,220,0,524288,4,"cuda:0"],[217,128,0,524288,4,"cuda:0"],0], "input_shapes": [[512,1024],[512,1024],[]], "input_types": ["Tensor(float)","Tensor(float)","Int"],
+      "outputs": [[247,504,0,524288,4,"cuda:0"]], "output_shapes": [[512,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "ReluBackward0", "id": 772, "rf_id": 513, "parent": 771, "fw_parent": 2, "seq_id": 698, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[232,220,0,524288,4,"cuda:0"]], "input_shapes": [[512,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: ReluBackward0", "id": 771, "rf_id": 512, "parent": 519, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::as_strided", "id": 778, "rf_id": 519, "parent": 777, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::as_strided(Tensor(a) self, SymInt[] size, SymInt[] stride, SymInt? storage_offset=None) -> Tensor(a)",
+      "inputs": [[187,192,0,1048576,4,"cuda:0"],[1024,1024],[1024,1],"<None>"], "input_shapes": [[1024,1024],[[],[]],[[],[]],[]], "input_types": ["Tensor(float)","GenericList[Int,Int]","GenericList[Int,Int]","None"],
+      "outputs": [[232,192,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::transpose", "id": 777, "rf_id": 518, "parent": 776, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::transpose.int(Tensor(a) self, int dim0, int dim1) -> Tensor(a)",
+      "inputs": [[187,192,0,1048576,4,"cuda:0"],0,1], "input_shapes": [[1024,1024],[],[]], "input_types": ["Tensor(float)","Int","Int"],
+      "outputs": [[232,192,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::t", "id": 776, "rf_id": 517, "parent": 775, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::t(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[187,192,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[232,192,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::mm", "id": 779, "rf_id": 520, "parent": 775, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::mm(Tensor self, Tensor mat2) -> Tensor",
+      "inputs": [[247,504,0,524288,4,"cuda:0"],[232,192,0,1048576,4,"cuda:0"]], "input_shapes": [[512,1024],[1024,1024]], "input_types": ["Tensor(float)","Tensor(float)"],
+      "outputs": [[217,128,0,524288,4,"cuda:0"]], "output_shapes": [[512,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::as_strided", "id": 782, "rf_id": 523, "parent": 781, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::as_strided(Tensor(a) self, SymInt[] size, SymInt[] stride, SymInt? storage_offset=None) -> Tensor(a)",
+      "inputs": [[247,504,0,524288,4,"cuda:0"],[1024,512],[1,1024],"<None>"], "input_shapes": [[512,1024],[[],[]],[[],[]],[]], "input_types": ["Tensor(float)","GenericList[Int,Int]","GenericList[Int,Int]","None"],
+      "outputs": [[232,504,0,524288,4,"cuda:0"]], "output_shapes": [[1024,512]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::transpose", "id": 781, "rf_id": 522, "parent": 780, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::transpose.int(Tensor(a) self, int dim0, int dim1) -> Tensor(a)",
+      "inputs": [[247,504,0,524288,4,"cuda:0"],0,1], "input_shapes": [[512,1024],[],[]], "input_types": ["Tensor(float)","Int","Int"],
+      "outputs": [[232,504,0,524288,4,"cuda:0"]], "output_shapes": [[1024,512]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::t", "id": 780, "rf_id": 521, "parent": 775, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::t(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[247,504,0,524288,4,"cuda:0"]], "input_shapes": [[512,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[232,504,0,524288,4,"cuda:0"]], "output_shapes": [[1024,512]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::mm", "id": 783, "rf_id": 524, "parent": 775, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::mm(Tensor self, Tensor mat2) -> Tensor",
+      "inputs": [[232,504,0,524288,4,"cuda:0"],[186,190,0,524288,4,"cuda:0"]], "input_shapes": [[1024,512],[512,1024]], "input_types": ["Tensor(float)","Tensor(float)"],
+      "outputs": [[201,220,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::as_strided", "id": 786, "rf_id": 527, "parent": 785, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::as_strided(Tensor(a) self, SymInt[] size, SymInt[] stride, SymInt? storage_offset=None) -> Tensor(a)",
+      "inputs": [[201,220,0,1048576,4,"cuda:0"],[1024,1024],[1,1024],"<None>"], "input_shapes": [[1024,1024],[[],[]],[[],[]],[]], "input_types": ["Tensor(float)","GenericList[Int,Int]","GenericList[Int,Int]","None"],
+      "outputs": [[202,220,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::transpose", "id": 785, "rf_id": 526, "parent": 784, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::transpose.int(Tensor(a) self, int dim0, int dim1) -> Tensor(a)",
+      "inputs": [[201,220,0,1048576,4,"cuda:0"],0,1], "input_shapes": [[1024,1024],[],[]], "input_types": ["Tensor(float)","Int","Int"],
+      "outputs": [[202,220,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::t", "id": 784, "rf_id": 525, "parent": 775, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::t(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[201,220,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[202,220,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "AddmmBackward0", "id": 775, "rf_id": 516, "parent": 774, "fw_parent": 2, "seq_id": 697, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[247,504,0,524288,4,"cuda:0"]], "input_shapes": [[512,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::sum", "id": 787, "rf_id": 528, "parent": 774, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::sum.dim_IntList(Tensor self, int[1]? dim, bool keepdim=False, *, ScalarType? dtype=None) -> Tensor",
+      "inputs": [[247,504,0,524288,4,"cuda:0"],[0],true,"<None>"], "input_shapes": [[512,1024],[[]],[],[]], "input_types": ["Tensor(float)","GenericList[Int]","Bool","None"],
+      "outputs": [[232,17,0,1024,4,"cuda:0"]], "output_shapes": [[1,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::view", "id": 788, "rf_id": 529, "parent": 774, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::view(Tensor(a) self, SymInt[] size) -> Tensor(a)",
+      "inputs": [[232,17,0,1024,4,"cuda:0"],[1024]], "input_shapes": [[1,1024],[[]]], "input_types": ["Tensor(float)","GenericList[Int]"],
+      "outputs": [[262,17,0,1024,4,"cuda:0"]], "output_shapes": [[1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "autograd::engine::evaluate_function: AddmmBackward0", "id": 774, "rf_id": 515, "parent": 519, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::add_", "id": 791, "rf_id": 532, "parent": 790, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::add_.Tensor(Tensor(a!) self, Tensor other, *, Scalar alpha=1) -> Tensor(a!)",
+      "inputs": [[429,430,0,1024,4,"cuda:0"],[262,17,0,1024,4,"cuda:0"],1], "input_shapes": [[1024],[1024],[]], "input_types": ["Tensor(float)","Tensor(float)","Int"],
+      "outputs": [[429,430,0,1024,4,"cuda:0"]], "output_shapes": [[1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "torch::autograd::AccumulateGrad", "id": 790, "rf_id": 531, "parent": 789, "fw_parent": 2, "seq_id": -1, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[262,17,0,1024,4,"cuda:0"]], "input_shapes": [[1024]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: torch::autograd::AccumulateGrad", "id": 789, "rf_id": 530, "parent": 519, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::as_strided", "id": 796, "rf_id": 537, "parent": 795, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::as_strided(Tensor(a) self, SymInt[] size, SymInt[] stride, SymInt? storage_offset=None) -> Tensor(a)",
+      "inputs": [[202,220,0,1048576,4,"cuda:0"],[1024,1024],[1024,1],"<None>"], "input_shapes": [[1024,1024],[[],[]],[[],[]],[]], "input_types": ["Tensor(float)","GenericList[Int,Int]","GenericList[Int,Int]","None"],
+      "outputs": [[262,220,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::transpose", "id": 795, "rf_id": 536, "parent": 794, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::transpose.int(Tensor(a) self, int dim0, int dim1) -> Tensor(a)",
+      "inputs": [[202,220,0,1048576,4,"cuda:0"],0,1], "input_shapes": [[1024,1024],[],[]], "input_types": ["Tensor(float)","Int","Int"],
+      "outputs": [[262,220,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::t", "id": 794, "rf_id": 535, "parent": 793, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::t(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[202,220,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[262,220,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "TBackward0", "id": 793, "rf_id": 534, "parent": 792, "fw_parent": 2, "seq_id": 696, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[202,220,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: TBackward0", "id": 792, "rf_id": 533, "parent": 519, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::add_", "id": 799, "rf_id": 540, "parent": 798, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::add_.Tensor(Tensor(a!) self, Tensor other, *, Scalar alpha=1) -> Tensor(a!)",
+      "inputs": [[425,426,0,1048576,4,"cuda:0"],[262,220,0,1048576,4,"cuda:0"],1], "input_shapes": [[1024,1024],[1024,1024],[]], "input_types": ["Tensor(float)","Tensor(float)","Int"],
+      "outputs": [[425,426,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "torch::autograd::AccumulateGrad", "id": 798, "rf_id": 539, "parent": 797, "fw_parent": 2, "seq_id": -1, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[262,220,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: torch::autograd::AccumulateGrad", "id": 797, "rf_id": 538, "parent": 519, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::threshold_backward", "id": 802, "rf_id": 543, "parent": 801, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::threshold_backward(Tensor grad_output, Tensor self, Scalar threshold) -> Tensor",
+      "inputs": [[217,128,0,524288,4,"cuda:0"],[202,190,0,524288,4,"cuda:0"],0], "input_shapes": [[512,1024],[512,1024],[]], "input_types": ["Tensor(float)","Tensor(float)","Int"],
+      "outputs": [[232,504,0,524288,4,"cuda:0"]], "output_shapes": [[512,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "ReluBackward0", "id": 801, "rf_id": 542, "parent": 800, "fw_parent": 2, "seq_id": 695, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[217,128,0,524288,4,"cuda:0"]], "input_shapes": [[512,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: ReluBackward0", "id": 800, "rf_id": 541, "parent": 519, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::as_strided", "id": 807, "rf_id": 548, "parent": 806, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::as_strided(Tensor(a) self, SymInt[] size, SymInt[] stride, SymInt? storage_offset=None) -> Tensor(a)",
+      "inputs": [[172,177,0,1048576,4,"cuda:0"],[1024,1024],[1024,1],"<None>"], "input_shapes": [[1024,1024],[[],[]],[[],[]],[]], "input_types": ["Tensor(float)","GenericList[Int,Int]","GenericList[Int,Int]","None"],
+      "outputs": [[217,177,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::transpose", "id": 806, "rf_id": 547, "parent": 805, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::transpose.int(Tensor(a) self, int dim0, int dim1) -> Tensor(a)",
+      "inputs": [[172,177,0,1048576,4,"cuda:0"],0,1], "input_shapes": [[1024,1024],[],[]], "input_types": ["Tensor(float)","Int","Int"],
+      "outputs": [[217,177,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::t", "id": 805, "rf_id": 546, "parent": 804, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::t(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[172,177,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[217,177,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::mm", "id": 808, "rf_id": 549, "parent": 804, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::mm(Tensor self, Tensor mat2) -> Tensor",
+      "inputs": [[232,504,0,524288,4,"cuda:0"],[217,177,0,1048576,4,"cuda:0"]], "input_shapes": [[512,1024],[1024,1024]], "input_types": ["Tensor(float)","Tensor(float)"],
+      "outputs": [[202,190,0,524288,4,"cuda:0"]], "output_shapes": [[512,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::as_strided", "id": 811, "rf_id": 552, "parent": 810, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::as_strided(Tensor(a) self, SymInt[] size, SymInt[] stride, SymInt? storage_offset=None) -> Tensor(a)",
+      "inputs": [[232,504,0,524288,4,"cuda:0"],[1024,512],[1,1024],"<None>"], "input_shapes": [[512,1024],[[],[]],[[],[]],[]], "input_types": ["Tensor(float)","GenericList[Int,Int]","GenericList[Int,Int]","None"],
+      "outputs": [[217,504,0,524288,4,"cuda:0"]], "output_shapes": [[1024,512]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::transpose", "id": 810, "rf_id": 551, "parent": 809, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::transpose.int(Tensor(a) self, int dim0, int dim1) -> Tensor(a)",
+      "inputs": [[232,504,0,524288,4,"cuda:0"],0,1], "input_shapes": [[512,1024],[],[]], "input_types": ["Tensor(float)","Int","Int"],
+      "outputs": [[217,504,0,524288,4,"cuda:0"]], "output_shapes": [[1024,512]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::t", "id": 809, "rf_id": 550, "parent": 804, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::t(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[232,504,0,524288,4,"cuda:0"]], "input_shapes": [[512,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[217,504,0,524288,4,"cuda:0"]], "output_shapes": [[1024,512]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::mm", "id": 812, "rf_id": 553, "parent": 804, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::mm(Tensor self, Tensor mat2) -> Tensor",
+      "inputs": [[217,504,0,524288,4,"cuda:0"],[171,175,0,524288,4,"cuda:0"]], "input_shapes": [[1024,512],[512,1024]], "input_types": ["Tensor(float)","Tensor(float)"],
+      "outputs": [[186,220,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::as_strided", "id": 815, "rf_id": 556, "parent": 814, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::as_strided(Tensor(a) self, SymInt[] size, SymInt[] stride, SymInt? storage_offset=None) -> Tensor(a)",
+      "inputs": [[186,220,0,1048576,4,"cuda:0"],[1024,1024],[1,1024],"<None>"], "input_shapes": [[1024,1024],[[],[]],[[],[]],[]], "input_types": ["Tensor(float)","GenericList[Int,Int]","GenericList[Int,Int]","None"],
+      "outputs": [[187,220,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::transpose", "id": 814, "rf_id": 555, "parent": 813, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::transpose.int(Tensor(a) self, int dim0, int dim1) -> Tensor(a)",
+      "inputs": [[186,220,0,1048576,4,"cuda:0"],0,1], "input_shapes": [[1024,1024],[],[]], "input_types": ["Tensor(float)","Int","Int"],
+      "outputs": [[187,220,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::t", "id": 813, "rf_id": 554, "parent": 804, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::t(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[186,220,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[187,220,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "AddmmBackward0", "id": 804, "rf_id": 545, "parent": 803, "fw_parent": 2, "seq_id": 694, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[232,504,0,524288,4,"cuda:0"]], "input_shapes": [[512,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::sum", "id": 816, "rf_id": 557, "parent": 803, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::sum.dim_IntList(Tensor self, int[1]? dim, bool keepdim=False, *, ScalarType? dtype=None) -> Tensor",
+      "inputs": [[232,504,0,524288,4,"cuda:0"],[0],true,"<None>"], "input_shapes": [[512,1024],[[]],[],[]], "input_types": ["Tensor(float)","GenericList[Int]","Bool","None"],
+      "outputs": [[217,17,0,1024,4,"cuda:0"]], "output_shapes": [[1,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::view", "id": 817, "rf_id": 558, "parent": 803, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::view(Tensor(a) self, SymInt[] size) -> Tensor(a)",
+      "inputs": [[217,17,0,1024,4,"cuda:0"],[1024]], "input_shapes": [[1,1024],[[]]], "input_types": ["Tensor(float)","GenericList[Int]"],
+      "outputs": [[247,17,0,1024,4,"cuda:0"]], "output_shapes": [[1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "autograd::engine::evaluate_function: AddmmBackward0", "id": 803, "rf_id": 544, "parent": 519, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::add_", "id": 820, "rf_id": 561, "parent": 819, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::add_.Tensor(Tensor(a!) self, Tensor other, *, Scalar alpha=1) -> Tensor(a!)",
+      "inputs": [[421,422,0,1024,4,"cuda:0"],[247,17,0,1024,4,"cuda:0"],1], "input_shapes": [[1024],[1024],[]], "input_types": ["Tensor(float)","Tensor(float)","Int"],
+      "outputs": [[421,422,0,1024,4,"cuda:0"]], "output_shapes": [[1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "torch::autograd::AccumulateGrad", "id": 819, "rf_id": 560, "parent": 818, "fw_parent": 2, "seq_id": -1, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[247,17,0,1024,4,"cuda:0"]], "input_shapes": [[1024]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: torch::autograd::AccumulateGrad", "id": 818, "rf_id": 559, "parent": 519, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::as_strided", "id": 825, "rf_id": 566, "parent": 824, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::as_strided(Tensor(a) self, SymInt[] size, SymInt[] stride, SymInt? storage_offset=None) -> Tensor(a)",
+      "inputs": [[187,220,0,1048576,4,"cuda:0"],[1024,1024],[1024,1],"<None>"], "input_shapes": [[1024,1024],[[],[]],[[],[]],[]], "input_types": ["Tensor(float)","GenericList[Int,Int]","GenericList[Int,Int]","None"],
+      "outputs": [[247,220,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::transpose", "id": 824, "rf_id": 565, "parent": 823, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::transpose.int(Tensor(a) self, int dim0, int dim1) -> Tensor(a)",
+      "inputs": [[187,220,0,1048576,4,"cuda:0"],0,1], "input_shapes": [[1024,1024],[],[]], "input_types": ["Tensor(float)","Int","Int"],
+      "outputs": [[247,220,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::t", "id": 823, "rf_id": 564, "parent": 822, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::t(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[187,220,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[247,220,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "TBackward0", "id": 822, "rf_id": 563, "parent": 821, "fw_parent": 2, "seq_id": 693, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[187,220,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: TBackward0", "id": 821, "rf_id": 562, "parent": 519, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::add_", "id": 828, "rf_id": 569, "parent": 827, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::add_.Tensor(Tensor(a!) self, Tensor other, *, Scalar alpha=1) -> Tensor(a!)",
+      "inputs": [[417,418,0,1048576,4,"cuda:0"],[247,220,0,1048576,4,"cuda:0"],1], "input_shapes": [[1024,1024],[1024,1024],[]], "input_types": ["Tensor(float)","Tensor(float)","Int"],
+      "outputs": [[417,418,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "torch::autograd::AccumulateGrad", "id": 827, "rf_id": 568, "parent": 826, "fw_parent": 2, "seq_id": -1, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[247,220,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: torch::autograd::AccumulateGrad", "id": 826, "rf_id": 567, "parent": 519, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::threshold_backward", "id": 831, "rf_id": 572, "parent": 830, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::threshold_backward(Tensor grad_output, Tensor self, Scalar threshold) -> Tensor",
+      "inputs": [[202,190,0,524288,4,"cuda:0"],[187,175,0,524288,4,"cuda:0"],0], "input_shapes": [[512,1024],[512,1024],[]], "input_types": ["Tensor(float)","Tensor(float)","Int"],
+      "outputs": [[217,504,0,524288,4,"cuda:0"]], "output_shapes": [[512,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "ReluBackward0", "id": 830, "rf_id": 571, "parent": 829, "fw_parent": 2, "seq_id": 692, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[202,190,0,524288,4,"cuda:0"]], "input_shapes": [[512,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: ReluBackward0", "id": 829, "rf_id": 570, "parent": 519, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::as_strided", "id": 836, "rf_id": 577, "parent": 835, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::as_strided(Tensor(a) self, SymInt[] size, SymInt[] stride, SymInt? storage_offset=None) -> Tensor(a)",
+      "inputs": [[157,162,0,1048576,4,"cuda:0"],[1024,1024],[1024,1],"<None>"], "input_shapes": [[1024,1024],[[],[]],[[],[]],[]], "input_types": ["Tensor(float)","GenericList[Int,Int]","GenericList[Int,Int]","None"],
+      "outputs": [[202,162,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::transpose", "id": 835, "rf_id": 576, "parent": 834, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::transpose.int(Tensor(a) self, int dim0, int dim1) -> Tensor(a)",
+      "inputs": [[157,162,0,1048576,4,"cuda:0"],0,1], "input_shapes": [[1024,1024],[],[]], "input_types": ["Tensor(float)","Int","Int"],
+      "outputs": [[202,162,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::t", "id": 834, "rf_id": 575, "parent": 833, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::t(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[157,162,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[202,162,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::mm", "id": 837, "rf_id": 578, "parent": 833, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::mm(Tensor self, Tensor mat2) -> Tensor",
+      "inputs": [[217,504,0,524288,4,"cuda:0"],[202,162,0,1048576,4,"cuda:0"]], "input_shapes": [[512,1024],[1024,1024]], "input_types": ["Tensor(float)","Tensor(float)"],
+      "outputs": [[187,128,0,524288,4,"cuda:0"]], "output_shapes": [[512,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::as_strided", "id": 840, "rf_id": 581, "parent": 839, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::as_strided(Tensor(a) self, SymInt[] size, SymInt[] stride, SymInt? storage_offset=None) -> Tensor(a)",
+      "inputs": [[217,504,0,524288,4,"cuda:0"],[1024,512],[1,1024],"<None>"], "input_shapes": [[512,1024],[[],[]],[[],[]],[]], "input_types": ["Tensor(float)","GenericList[Int,Int]","GenericList[Int,Int]","None"],
+      "outputs": [[202,504,0,524288,4,"cuda:0"]], "output_shapes": [[1024,512]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::transpose", "id": 839, "rf_id": 580, "parent": 838, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::transpose.int(Tensor(a) self, int dim0, int dim1) -> Tensor(a)",
+      "inputs": [[217,504,0,524288,4,"cuda:0"],0,1], "input_shapes": [[512,1024],[],[]], "input_types": ["Tensor(float)","Int","Int"],
+      "outputs": [[202,504,0,524288,4,"cuda:0"]], "output_shapes": [[1024,512]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::t", "id": 838, "rf_id": 579, "parent": 833, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::t(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[217,504,0,524288,4,"cuda:0"]], "input_shapes": [[512,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[202,504,0,524288,4,"cuda:0"]], "output_shapes": [[1024,512]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::mm", "id": 841, "rf_id": 582, "parent": 833, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::mm(Tensor self, Tensor mat2) -> Tensor",
+      "inputs": [[202,504,0,524288,4,"cuda:0"],[156,160,0,524288,4,"cuda:0"]], "input_shapes": [[1024,512],[512,1024]], "input_types": ["Tensor(float)","Tensor(float)"],
+      "outputs": [[171,175,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::as_strided", "id": 844, "rf_id": 585, "parent": 843, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::as_strided(Tensor(a) self, SymInt[] size, SymInt[] stride, SymInt? storage_offset=None) -> Tensor(a)",
+      "inputs": [[171,175,0,1048576,4,"cuda:0"],[1024,1024],[1,1024],"<None>"], "input_shapes": [[1024,1024],[[],[]],[[],[]],[]], "input_types": ["Tensor(float)","GenericList[Int,Int]","GenericList[Int,Int]","None"],
+      "outputs": [[172,175,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::transpose", "id": 843, "rf_id": 584, "parent": 842, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::transpose.int(Tensor(a) self, int dim0, int dim1) -> Tensor(a)",
+      "inputs": [[171,175,0,1048576,4,"cuda:0"],0,1], "input_shapes": [[1024,1024],[],[]], "input_types": ["Tensor(float)","Int","Int"],
+      "outputs": [[172,175,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::t", "id": 842, "rf_id": 583, "parent": 833, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::t(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[171,175,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[172,175,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "AddmmBackward0", "id": 833, "rf_id": 574, "parent": 832, "fw_parent": 2, "seq_id": 691, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[217,504,0,524288,4,"cuda:0"]], "input_shapes": [[512,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::sum", "id": 845, "rf_id": 586, "parent": 832, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::sum.dim_IntList(Tensor self, int[1]? dim, bool keepdim=False, *, ScalarType? dtype=None) -> Tensor",
+      "inputs": [[217,504,0,524288,4,"cuda:0"],[0],true,"<None>"], "input_shapes": [[512,1024],[[]],[],[]], "input_types": ["Tensor(float)","GenericList[Int]","Bool","None"],
+      "outputs": [[202,17,0,1024,4,"cuda:0"]], "output_shapes": [[1,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::view", "id": 846, "rf_id": 587, "parent": 832, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::view(Tensor(a) self, SymInt[] size) -> Tensor(a)",
+      "inputs": [[202,17,0,1024,4,"cuda:0"],[1024]], "input_shapes": [[1,1024],[[]]], "input_types": ["Tensor(float)","GenericList[Int]"],
+      "outputs": [[232,17,0,1024,4,"cuda:0"]], "output_shapes": [[1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "autograd::engine::evaluate_function: AddmmBackward0", "id": 832, "rf_id": 573, "parent": 519, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::add_", "id": 849, "rf_id": 590, "parent": 848, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::add_.Tensor(Tensor(a!) self, Tensor other, *, Scalar alpha=1) -> Tensor(a!)",
+      "inputs": [[413,414,0,1024,4,"cuda:0"],[232,17,0,1024,4,"cuda:0"],1], "input_shapes": [[1024],[1024],[]], "input_types": ["Tensor(float)","Tensor(float)","Int"],
+      "outputs": [[413,414,0,1024,4,"cuda:0"]], "output_shapes": [[1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "torch::autograd::AccumulateGrad", "id": 848, "rf_id": 589, "parent": 847, "fw_parent": 2, "seq_id": -1, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[232,17,0,1024,4,"cuda:0"]], "input_shapes": [[1024]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: torch::autograd::AccumulateGrad", "id": 847, "rf_id": 588, "parent": 519, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::as_strided", "id": 854, "rf_id": 595, "parent": 853, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::as_strided(Tensor(a) self, SymInt[] size, SymInt[] stride, SymInt? storage_offset=None) -> Tensor(a)",
+      "inputs": [[172,175,0,1048576,4,"cuda:0"],[1024,1024],[1024,1],"<None>"], "input_shapes": [[1024,1024],[[],[]],[[],[]],[]], "input_types": ["Tensor(float)","GenericList[Int,Int]","GenericList[Int,Int]","None"],
+      "outputs": [[232,175,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::transpose", "id": 853, "rf_id": 594, "parent": 852, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::transpose.int(Tensor(a) self, int dim0, int dim1) -> Tensor(a)",
+      "inputs": [[172,175,0,1048576,4,"cuda:0"],0,1], "input_shapes": [[1024,1024],[],[]], "input_types": ["Tensor(float)","Int","Int"],
+      "outputs": [[232,175,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::t", "id": 852, "rf_id": 593, "parent": 851, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::t(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[172,175,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[232,175,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "TBackward0", "id": 851, "rf_id": 592, "parent": 850, "fw_parent": 2, "seq_id": 690, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[172,175,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: TBackward0", "id": 850, "rf_id": 591, "parent": 519, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::add_", "id": 857, "rf_id": 598, "parent": 856, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::add_.Tensor(Tensor(a!) self, Tensor other, *, Scalar alpha=1) -> Tensor(a!)",
+      "inputs": [[409,410,0,1048576,4,"cuda:0"],[232,175,0,1048576,4,"cuda:0"],1], "input_shapes": [[1024,1024],[1024,1024],[]], "input_types": ["Tensor(float)","Tensor(float)","Int"],
+      "outputs": [[409,410,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "torch::autograd::AccumulateGrad", "id": 856, "rf_id": 597, "parent": 855, "fw_parent": 2, "seq_id": -1, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[232,175,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: torch::autograd::AccumulateGrad", "id": 855, "rf_id": 596, "parent": 519, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::threshold_backward", "id": 860, "rf_id": 601, "parent": 859, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::threshold_backward(Tensor grad_output, Tensor self, Scalar threshold) -> Tensor",
+      "inputs": [[187,128,0,524288,4,"cuda:0"],[172,160,0,524288,4,"cuda:0"],0], "input_shapes": [[512,1024],[512,1024],[]], "input_types": ["Tensor(float)","Tensor(float)","Int"],
+      "outputs": [[202,504,0,524288,4,"cuda:0"]], "output_shapes": [[512,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "ReluBackward0", "id": 859, "rf_id": 600, "parent": 858, "fw_parent": 2, "seq_id": 689, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[187,128,0,524288,4,"cuda:0"]], "input_shapes": [[512,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: ReluBackward0", "id": 858, "rf_id": 599, "parent": 519, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::as_strided", "id": 865, "rf_id": 606, "parent": 864, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::as_strided(Tensor(a) self, SymInt[] size, SymInt[] stride, SymInt? storage_offset=None) -> Tensor(a)",
+      "inputs": [[142,147,0,1048576,4,"cuda:0"],[1024,1024],[1024,1],"<None>"], "input_shapes": [[1024,1024],[[],[]],[[],[]],[]], "input_types": ["Tensor(float)","GenericList[Int,Int]","GenericList[Int,Int]","None"],
+      "outputs": [[187,147,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::transpose", "id": 864, "rf_id": 605, "parent": 863, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::transpose.int(Tensor(a) self, int dim0, int dim1) -> Tensor(a)",
+      "inputs": [[142,147,0,1048576,4,"cuda:0"],0,1], "input_shapes": [[1024,1024],[],[]], "input_types": ["Tensor(float)","Int","Int"],
+      "outputs": [[187,147,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::t", "id": 863, "rf_id": 604, "parent": 862, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::t(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[142,147,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[187,147,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::mm", "id": 866, "rf_id": 607, "parent": 862, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::mm(Tensor self, Tensor mat2) -> Tensor",
+      "inputs": [[202,504,0,524288,4,"cuda:0"],[187,147,0,1048576,4,"cuda:0"]], "input_shapes": [[512,1024],[1024,1024]], "input_types": ["Tensor(float)","Tensor(float)"],
+      "outputs": [[172,128,0,524288,4,"cuda:0"]], "output_shapes": [[512,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::as_strided", "id": 869, "rf_id": 610, "parent": 868, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::as_strided(Tensor(a) self, SymInt[] size, SymInt[] stride, SymInt? storage_offset=None) -> Tensor(a)",
+      "inputs": [[202,504,0,524288,4,"cuda:0"],[1024,512],[1,1024],"<None>"], "input_shapes": [[512,1024],[[],[]],[[],[]],[]], "input_types": ["Tensor(float)","GenericList[Int,Int]","GenericList[Int,Int]","None"],
+      "outputs": [[187,504,0,524288,4,"cuda:0"]], "output_shapes": [[1024,512]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::transpose", "id": 868, "rf_id": 609, "parent": 867, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::transpose.int(Tensor(a) self, int dim0, int dim1) -> Tensor(a)",
+      "inputs": [[202,504,0,524288,4,"cuda:0"],0,1], "input_shapes": [[512,1024],[],[]], "input_types": ["Tensor(float)","Int","Int"],
+      "outputs": [[187,504,0,524288,4,"cuda:0"]], "output_shapes": [[1024,512]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::t", "id": 867, "rf_id": 608, "parent": 862, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::t(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[202,504,0,524288,4,"cuda:0"]], "input_shapes": [[512,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[187,504,0,524288,4,"cuda:0"]], "output_shapes": [[1024,512]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::mm", "id": 870, "rf_id": 611, "parent": 862, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::mm(Tensor self, Tensor mat2) -> Tensor",
+      "inputs": [[187,504,0,524288,4,"cuda:0"],[141,145,0,524288,4,"cuda:0"]], "input_shapes": [[1024,512],[512,1024]], "input_types": ["Tensor(float)","Tensor(float)"],
+      "outputs": [[156,175,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::as_strided", "id": 873, "rf_id": 614, "parent": 872, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::as_strided(Tensor(a) self, SymInt[] size, SymInt[] stride, SymInt? storage_offset=None) -> Tensor(a)",
+      "inputs": [[156,175,0,1048576,4,"cuda:0"],[1024,1024],[1,1024],"<None>"], "input_shapes": [[1024,1024],[[],[]],[[],[]],[]], "input_types": ["Tensor(float)","GenericList[Int,Int]","GenericList[Int,Int]","None"],
+      "outputs": [[157,175,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::transpose", "id": 872, "rf_id": 613, "parent": 871, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::transpose.int(Tensor(a) self, int dim0, int dim1) -> Tensor(a)",
+      "inputs": [[156,175,0,1048576,4,"cuda:0"],0,1], "input_shapes": [[1024,1024],[],[]], "input_types": ["Tensor(float)","Int","Int"],
+      "outputs": [[157,175,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::t", "id": 871, "rf_id": 612, "parent": 862, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::t(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[156,175,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[157,175,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "AddmmBackward0", "id": 862, "rf_id": 603, "parent": 861, "fw_parent": 2, "seq_id": 688, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[202,504,0,524288,4,"cuda:0"]], "input_shapes": [[512,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::sum", "id": 874, "rf_id": 615, "parent": 861, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::sum.dim_IntList(Tensor self, int[1]? dim, bool keepdim=False, *, ScalarType? dtype=None) -> Tensor",
+      "inputs": [[202,504,0,524288,4,"cuda:0"],[0],true,"<None>"], "input_shapes": [[512,1024],[[]],[],[]], "input_types": ["Tensor(float)","GenericList[Int]","Bool","None"],
+      "outputs": [[187,17,0,1024,4,"cuda:0"]], "output_shapes": [[1,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::view", "id": 875, "rf_id": 616, "parent": 861, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::view(Tensor(a) self, SymInt[] size) -> Tensor(a)",
+      "inputs": [[187,17,0,1024,4,"cuda:0"],[1024]], "input_shapes": [[1,1024],[[]]], "input_types": ["Tensor(float)","GenericList[Int]"],
+      "outputs": [[217,17,0,1024,4,"cuda:0"]], "output_shapes": [[1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "autograd::engine::evaluate_function: AddmmBackward0", "id": 861, "rf_id": 602, "parent": 519, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::add_", "id": 878, "rf_id": 619, "parent": 877, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::add_.Tensor(Tensor(a!) self, Tensor other, *, Scalar alpha=1) -> Tensor(a!)",
+      "inputs": [[405,406,0,1024,4,"cuda:0"],[217,17,0,1024,4,"cuda:0"],1], "input_shapes": [[1024],[1024],[]], "input_types": ["Tensor(float)","Tensor(float)","Int"],
+      "outputs": [[405,406,0,1024,4,"cuda:0"]], "output_shapes": [[1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "torch::autograd::AccumulateGrad", "id": 877, "rf_id": 618, "parent": 876, "fw_parent": 2, "seq_id": -1, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[217,17,0,1024,4,"cuda:0"]], "input_shapes": [[1024]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: torch::autograd::AccumulateGrad", "id": 876, "rf_id": 617, "parent": 519, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::as_strided", "id": 883, "rf_id": 624, "parent": 882, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::as_strided(Tensor(a) self, SymInt[] size, SymInt[] stride, SymInt? storage_offset=None) -> Tensor(a)",
+      "inputs": [[157,175,0,1048576,4,"cuda:0"],[1024,1024],[1024,1],"<None>"], "input_shapes": [[1024,1024],[[],[]],[[],[]],[]], "input_types": ["Tensor(float)","GenericList[Int,Int]","GenericList[Int,Int]","None"],
+      "outputs": [[217,175,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::transpose", "id": 882, "rf_id": 623, "parent": 881, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::transpose.int(Tensor(a) self, int dim0, int dim1) -> Tensor(a)",
+      "inputs": [[157,175,0,1048576,4,"cuda:0"],0,1], "input_shapes": [[1024,1024],[],[]], "input_types": ["Tensor(float)","Int","Int"],
+      "outputs": [[217,175,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::t", "id": 881, "rf_id": 622, "parent": 880, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::t(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[157,175,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[217,175,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "TBackward0", "id": 880, "rf_id": 621, "parent": 879, "fw_parent": 2, "seq_id": 687, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[157,175,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: TBackward0", "id": 879, "rf_id": 620, "parent": 519, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::add_", "id": 886, "rf_id": 627, "parent": 885, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::add_.Tensor(Tensor(a!) self, Tensor other, *, Scalar alpha=1) -> Tensor(a!)",
+      "inputs": [[401,402,0,1048576,4,"cuda:0"],[217,175,0,1048576,4,"cuda:0"],1], "input_shapes": [[1024,1024],[1024,1024],[]], "input_types": ["Tensor(float)","Tensor(float)","Int"],
+      "outputs": [[401,402,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "torch::autograd::AccumulateGrad", "id": 885, "rf_id": 626, "parent": 884, "fw_parent": 2, "seq_id": -1, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[217,175,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: torch::autograd::AccumulateGrad", "id": 884, "rf_id": 625, "parent": 519, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::threshold_backward", "id": 889, "rf_id": 630, "parent": 888, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::threshold_backward(Tensor grad_output, Tensor self, Scalar threshold) -> Tensor",
+      "inputs": [[172,128,0,524288,4,"cuda:0"],[157,145,0,524288,4,"cuda:0"],0], "input_shapes": [[512,1024],[512,1024],[]], "input_types": ["Tensor(float)","Tensor(float)","Int"],
+      "outputs": [[187,504,0,524288,4,"cuda:0"]], "output_shapes": [[512,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "ReluBackward0", "id": 888, "rf_id": 629, "parent": 887, "fw_parent": 2, "seq_id": 686, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[172,128,0,524288,4,"cuda:0"]], "input_shapes": [[512,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: ReluBackward0", "id": 887, "rf_id": 628, "parent": 519, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::as_strided", "id": 894, "rf_id": 635, "parent": 893, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::as_strided(Tensor(a) self, SymInt[] size, SymInt[] stride, SymInt? storage_offset=None) -> Tensor(a)",
+      "inputs": [[127,132,0,1048576,4,"cuda:0"],[1024,1024],[1024,1],"<None>"], "input_shapes": [[1024,1024],[[],[]],[[],[]],[]], "input_types": ["Tensor(float)","GenericList[Int,Int]","GenericList[Int,Int]","None"],
+      "outputs": [[172,132,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::transpose", "id": 893, "rf_id": 634, "parent": 892, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::transpose.int(Tensor(a) self, int dim0, int dim1) -> Tensor(a)",
+      "inputs": [[127,132,0,1048576,4,"cuda:0"],0,1], "input_shapes": [[1024,1024],[],[]], "input_types": ["Tensor(float)","Int","Int"],
+      "outputs": [[172,132,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::t", "id": 892, "rf_id": 633, "parent": 891, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::t(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[127,132,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[172,132,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::mm", "id": 895, "rf_id": 636, "parent": 891, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::mm(Tensor self, Tensor mat2) -> Tensor",
+      "inputs": [[187,504,0,524288,4,"cuda:0"],[172,132,0,1048576,4,"cuda:0"]], "input_shapes": [[512,1024],[1024,1024]], "input_types": ["Tensor(float)","Tensor(float)"],
+      "outputs": [[157,128,0,524288,4,"cuda:0"]], "output_shapes": [[512,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::as_strided", "id": 898, "rf_id": 639, "parent": 897, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::as_strided(Tensor(a) self, SymInt[] size, SymInt[] stride, SymInt? storage_offset=None) -> Tensor(a)",
+      "inputs": [[187,504,0,524288,4,"cuda:0"],[1024,512],[1,1024],"<None>"], "input_shapes": [[512,1024],[[],[]],[[],[]],[]], "input_types": ["Tensor(float)","GenericList[Int,Int]","GenericList[Int,Int]","None"],
+      "outputs": [[172,504,0,524288,4,"cuda:0"]], "output_shapes": [[1024,512]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::transpose", "id": 897, "rf_id": 638, "parent": 896, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::transpose.int(Tensor(a) self, int dim0, int dim1) -> Tensor(a)",
+      "inputs": [[187,504,0,524288,4,"cuda:0"],0,1], "input_shapes": [[512,1024],[],[]], "input_types": ["Tensor(float)","Int","Int"],
+      "outputs": [[172,504,0,524288,4,"cuda:0"]], "output_shapes": [[1024,512]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::t", "id": 896, "rf_id": 637, "parent": 891, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::t(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[187,504,0,524288,4,"cuda:0"]], "input_shapes": [[512,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[172,504,0,524288,4,"cuda:0"]], "output_shapes": [[1024,512]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::mm", "id": 899, "rf_id": 640, "parent": 891, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::mm(Tensor self, Tensor mat2) -> Tensor",
+      "inputs": [[172,504,0,524288,4,"cuda:0"],[126,19,0,524288,4,"cuda:0"]], "input_shapes": [[1024,512],[512,1024]], "input_types": ["Tensor(float)","Tensor(float)"],
+      "outputs": [[141,175,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::as_strided", "id": 902, "rf_id": 643, "parent": 901, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::as_strided(Tensor(a) self, SymInt[] size, SymInt[] stride, SymInt? storage_offset=None) -> Tensor(a)",
+      "inputs": [[141,175,0,1048576,4,"cuda:0"],[1024,1024],[1,1024],"<None>"], "input_shapes": [[1024,1024],[[],[]],[[],[]],[]], "input_types": ["Tensor(float)","GenericList[Int,Int]","GenericList[Int,Int]","None"],
+      "outputs": [[142,175,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::transpose", "id": 901, "rf_id": 642, "parent": 900, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::transpose.int(Tensor(a) self, int dim0, int dim1) -> Tensor(a)",
+      "inputs": [[141,175,0,1048576,4,"cuda:0"],0,1], "input_shapes": [[1024,1024],[],[]], "input_types": ["Tensor(float)","Int","Int"],
+      "outputs": [[142,175,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::t", "id": 900, "rf_id": 641, "parent": 891, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::t(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[141,175,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[142,175,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "AddmmBackward0", "id": 891, "rf_id": 632, "parent": 890, "fw_parent": 2, "seq_id": 685, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[187,504,0,524288,4,"cuda:0"]], "input_shapes": [[512,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::sum", "id": 903, "rf_id": 644, "parent": 890, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::sum.dim_IntList(Tensor self, int[1]? dim, bool keepdim=False, *, ScalarType? dtype=None) -> Tensor",
+      "inputs": [[187,504,0,524288,4,"cuda:0"],[0],true,"<None>"], "input_shapes": [[512,1024],[[]],[],[]], "input_types": ["Tensor(float)","GenericList[Int]","Bool","None"],
+      "outputs": [[172,17,0,1024,4,"cuda:0"]], "output_shapes": [[1,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::view", "id": 904, "rf_id": 645, "parent": 890, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::view(Tensor(a) self, SymInt[] size) -> Tensor(a)",
+      "inputs": [[172,17,0,1024,4,"cuda:0"],[1024]], "input_shapes": [[1,1024],[[]]], "input_types": ["Tensor(float)","GenericList[Int]"],
+      "outputs": [[202,17,0,1024,4,"cuda:0"]], "output_shapes": [[1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "autograd::engine::evaluate_function: AddmmBackward0", "id": 890, "rf_id": 631, "parent": 519, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::add_", "id": 907, "rf_id": 648, "parent": 906, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::add_.Tensor(Tensor(a!) self, Tensor other, *, Scalar alpha=1) -> Tensor(a!)",
+      "inputs": [[397,398,0,1024,4,"cuda:0"],[202,17,0,1024,4,"cuda:0"],1], "input_shapes": [[1024],[1024],[]], "input_types": ["Tensor(float)","Tensor(float)","Int"],
+      "outputs": [[397,398,0,1024,4,"cuda:0"]], "output_shapes": [[1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "torch::autograd::AccumulateGrad", "id": 906, "rf_id": 647, "parent": 905, "fw_parent": 2, "seq_id": -1, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[202,17,0,1024,4,"cuda:0"]], "input_shapes": [[1024]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: torch::autograd::AccumulateGrad", "id": 905, "rf_id": 646, "parent": 519, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::as_strided", "id": 912, "rf_id": 653, "parent": 911, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::as_strided(Tensor(a) self, SymInt[] size, SymInt[] stride, SymInt? storage_offset=None) -> Tensor(a)",
+      "inputs": [[142,175,0,1048576,4,"cuda:0"],[1024,1024],[1024,1],"<None>"], "input_shapes": [[1024,1024],[[],[]],[[],[]],[]], "input_types": ["Tensor(float)","GenericList[Int,Int]","GenericList[Int,Int]","None"],
+      "outputs": [[202,175,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::transpose", "id": 911, "rf_id": 652, "parent": 910, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::transpose.int(Tensor(a) self, int dim0, int dim1) -> Tensor(a)",
+      "inputs": [[142,175,0,1048576,4,"cuda:0"],0,1], "input_shapes": [[1024,1024],[],[]], "input_types": ["Tensor(float)","Int","Int"],
+      "outputs": [[202,175,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::t", "id": 910, "rf_id": 651, "parent": 909, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::t(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[142,175,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[202,175,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "TBackward0", "id": 909, "rf_id": 650, "parent": 908, "fw_parent": 2, "seq_id": 684, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[142,175,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: TBackward0", "id": 908, "rf_id": 649, "parent": 519, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::add_", "id": 915, "rf_id": 656, "parent": 914, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::add_.Tensor(Tensor(a!) self, Tensor other, *, Scalar alpha=1) -> Tensor(a!)",
+      "inputs": [[393,394,0,1048576,4,"cuda:0"],[202,175,0,1048576,4,"cuda:0"],1], "input_shapes": [[1024,1024],[1024,1024],[]], "input_types": ["Tensor(float)","Tensor(float)","Int"],
+      "outputs": [[393,394,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "torch::autograd::AccumulateGrad", "id": 914, "rf_id": 655, "parent": 913, "fw_parent": 2, "seq_id": -1, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[202,175,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: torch::autograd::AccumulateGrad", "id": 913, "rf_id": 654, "parent": 519, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::threshold_backward", "id": 918, "rf_id": 659, "parent": 917, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::threshold_backward(Tensor grad_output, Tensor self, Scalar threshold) -> Tensor",
+      "inputs": [[157,128,0,524288,4,"cuda:0"],[142,19,0,524288,4,"cuda:0"],0], "input_shapes": [[512,1024],[512,1024],[]], "input_types": ["Tensor(float)","Tensor(float)","Int"],
+      "outputs": [[172,504,0,524288,4,"cuda:0"]], "output_shapes": [[512,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "ReluBackward0", "id": 917, "rf_id": 658, "parent": 916, "fw_parent": 2, "seq_id": 683, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[157,128,0,524288,4,"cuda:0"]], "input_shapes": [[512,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: ReluBackward0", "id": 916, "rf_id": 657, "parent": 519, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::as_strided", "id": 923, "rf_id": 664, "parent": 922, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::as_strided(Tensor(a) self, SymInt[] size, SymInt[] stride, SymInt? storage_offset=None) -> Tensor(a)",
+      "inputs": [[112,117,0,1048576,4,"cuda:0"],[1024,1024],[1024,1],"<None>"], "input_shapes": [[1024,1024],[[],[]],[[],[]],[]], "input_types": ["Tensor(float)","GenericList[Int,Int]","GenericList[Int,Int]","None"],
+      "outputs": [[157,117,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::transpose", "id": 922, "rf_id": 663, "parent": 921, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::transpose.int(Tensor(a) self, int dim0, int dim1) -> Tensor(a)",
+      "inputs": [[112,117,0,1048576,4,"cuda:0"],0,1], "input_shapes": [[1024,1024],[],[]], "input_types": ["Tensor(float)","Int","Int"],
+      "outputs": [[157,117,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::t", "id": 921, "rf_id": 662, "parent": 920, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::t(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[112,117,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[157,117,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::mm", "id": 924, "rf_id": 665, "parent": 920, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::mm(Tensor self, Tensor mat2) -> Tensor",
+      "inputs": [[172,504,0,524288,4,"cuda:0"],[157,117,0,1048576,4,"cuda:0"]], "input_shapes": [[512,1024],[1024,1024]], "input_types": ["Tensor(float)","Tensor(float)"],
+      "outputs": [[142,128,0,524288,4,"cuda:0"]], "output_shapes": [[512,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::as_strided", "id": 927, "rf_id": 668, "parent": 926, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::as_strided(Tensor(a) self, SymInt[] size, SymInt[] stride, SymInt? storage_offset=None) -> Tensor(a)",
+      "inputs": [[172,504,0,524288,4,"cuda:0"],[1024,512],[1,1024],"<None>"], "input_shapes": [[512,1024],[[],[]],[[],[]],[]], "input_types": ["Tensor(float)","GenericList[Int,Int]","GenericList[Int,Int]","None"],
+      "outputs": [[157,504,0,524288,4,"cuda:0"]], "output_shapes": [[1024,512]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::transpose", "id": 926, "rf_id": 667, "parent": 925, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::transpose.int(Tensor(a) self, int dim0, int dim1) -> Tensor(a)",
+      "inputs": [[172,504,0,524288,4,"cuda:0"],0,1], "input_shapes": [[512,1024],[],[]], "input_types": ["Tensor(float)","Int","Int"],
+      "outputs": [[157,504,0,524288,4,"cuda:0"]], "output_shapes": [[1024,512]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::t", "id": 925, "rf_id": 666, "parent": 920, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::t(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[172,504,0,524288,4,"cuda:0"]], "input_shapes": [[512,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[157,504,0,524288,4,"cuda:0"]], "output_shapes": [[1024,512]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::mm", "id": 928, "rf_id": 669, "parent": 920, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::mm(Tensor self, Tensor mat2) -> Tensor",
+      "inputs": [[157,504,0,524288,4,"cuda:0"],[111,115,0,524288,4,"cuda:0"]], "input_shapes": [[1024,512],[512,1024]], "input_types": ["Tensor(float)","Tensor(float)"],
+      "outputs": [[126,175,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::as_strided", "id": 931, "rf_id": 672, "parent": 930, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::as_strided(Tensor(a) self, SymInt[] size, SymInt[] stride, SymInt? storage_offset=None) -> Tensor(a)",
+      "inputs": [[126,175,0,1048576,4,"cuda:0"],[1024,1024],[1,1024],"<None>"], "input_shapes": [[1024,1024],[[],[]],[[],[]],[]], "input_types": ["Tensor(float)","GenericList[Int,Int]","GenericList[Int,Int]","None"],
+      "outputs": [[127,175,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::transpose", "id": 930, "rf_id": 671, "parent": 929, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::transpose.int(Tensor(a) self, int dim0, int dim1) -> Tensor(a)",
+      "inputs": [[126,175,0,1048576,4,"cuda:0"],0,1], "input_shapes": [[1024,1024],[],[]], "input_types": ["Tensor(float)","Int","Int"],
+      "outputs": [[127,175,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::t", "id": 929, "rf_id": 670, "parent": 920, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::t(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[126,175,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[127,175,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "AddmmBackward0", "id": 920, "rf_id": 661, "parent": 919, "fw_parent": 2, "seq_id": 682, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[172,504,0,524288,4,"cuda:0"]], "input_shapes": [[512,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::sum", "id": 932, "rf_id": 673, "parent": 919, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::sum.dim_IntList(Tensor self, int[1]? dim, bool keepdim=False, *, ScalarType? dtype=None) -> Tensor",
+      "inputs": [[172,504,0,524288,4,"cuda:0"],[0],true,"<None>"], "input_shapes": [[512,1024],[[]],[],[]], "input_types": ["Tensor(float)","GenericList[Int]","Bool","None"],
+      "outputs": [[157,17,0,1024,4,"cuda:0"]], "output_shapes": [[1,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::view", "id": 933, "rf_id": 674, "parent": 919, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::view(Tensor(a) self, SymInt[] size) -> Tensor(a)",
+      "inputs": [[157,17,0,1024,4,"cuda:0"],[1024]], "input_shapes": [[1,1024],[[]]], "input_types": ["Tensor(float)","GenericList[Int]"],
+      "outputs": [[187,17,0,1024,4,"cuda:0"]], "output_shapes": [[1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "autograd::engine::evaluate_function: AddmmBackward0", "id": 919, "rf_id": 660, "parent": 519, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::add_", "id": 936, "rf_id": 677, "parent": 935, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::add_.Tensor(Tensor(a!) self, Tensor other, *, Scalar alpha=1) -> Tensor(a!)",
+      "inputs": [[389,390,0,1024,4,"cuda:0"],[187,17,0,1024,4,"cuda:0"],1], "input_shapes": [[1024],[1024],[]], "input_types": ["Tensor(float)","Tensor(float)","Int"],
+      "outputs": [[389,390,0,1024,4,"cuda:0"]], "output_shapes": [[1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "torch::autograd::AccumulateGrad", "id": 935, "rf_id": 676, "parent": 934, "fw_parent": 2, "seq_id": -1, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[187,17,0,1024,4,"cuda:0"]], "input_shapes": [[1024]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: torch::autograd::AccumulateGrad", "id": 934, "rf_id": 675, "parent": 519, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::as_strided", "id": 941, "rf_id": 682, "parent": 940, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::as_strided(Tensor(a) self, SymInt[] size, SymInt[] stride, SymInt? storage_offset=None) -> Tensor(a)",
+      "inputs": [[127,175,0,1048576,4,"cuda:0"],[1024,1024],[1024,1],"<None>"], "input_shapes": [[1024,1024],[[],[]],[[],[]],[]], "input_types": ["Tensor(float)","GenericList[Int,Int]","GenericList[Int,Int]","None"],
+      "outputs": [[187,175,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::transpose", "id": 940, "rf_id": 681, "parent": 939, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::transpose.int(Tensor(a) self, int dim0, int dim1) -> Tensor(a)",
+      "inputs": [[127,175,0,1048576,4,"cuda:0"],0,1], "input_shapes": [[1024,1024],[],[]], "input_types": ["Tensor(float)","Int","Int"],
+      "outputs": [[187,175,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::t", "id": 939, "rf_id": 680, "parent": 938, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::t(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[127,175,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[187,175,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "TBackward0", "id": 938, "rf_id": 679, "parent": 937, "fw_parent": 2, "seq_id": 681, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[127,175,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: TBackward0", "id": 937, "rf_id": 678, "parent": 519, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::add_", "id": 944, "rf_id": 685, "parent": 943, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::add_.Tensor(Tensor(a!) self, Tensor other, *, Scalar alpha=1) -> Tensor(a!)",
+      "inputs": [[385,386,0,1048576,4,"cuda:0"],[187,175,0,1048576,4,"cuda:0"],1], "input_shapes": [[1024,1024],[1024,1024],[]], "input_types": ["Tensor(float)","Tensor(float)","Int"],
+      "outputs": [[385,386,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "torch::autograd::AccumulateGrad", "id": 943, "rf_id": 684, "parent": 942, "fw_parent": 2, "seq_id": -1, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[187,175,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: torch::autograd::AccumulateGrad", "id": 942, "rf_id": 683, "parent": 519, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::threshold_backward", "id": 947, "rf_id": 688, "parent": 946, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::threshold_backward(Tensor grad_output, Tensor self, Scalar threshold) -> Tensor",
+      "inputs": [[142,128,0,524288,4,"cuda:0"],[127,115,0,524288,4,"cuda:0"],0], "input_shapes": [[512,1024],[512,1024],[]], "input_types": ["Tensor(float)","Tensor(float)","Int"],
+      "outputs": [[157,504,0,524288,4,"cuda:0"]], "output_shapes": [[512,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "ReluBackward0", "id": 946, "rf_id": 687, "parent": 945, "fw_parent": 2, "seq_id": 680, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[142,128,0,524288,4,"cuda:0"]], "input_shapes": [[512,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: ReluBackward0", "id": 945, "rf_id": 686, "parent": 519, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::as_strided", "id": 952, "rf_id": 693, "parent": 951, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::as_strided(Tensor(a) self, SymInt[] size, SymInt[] stride, SymInt? storage_offset=None) -> Tensor(a)",
+      "inputs": [[108,101,0,1048576,4,"cuda:0"],[1024,1024],[1024,1],"<None>"], "input_shapes": [[1024,1024],[[],[]],[[],[]],[]], "input_types": ["Tensor(float)","GenericList[Int,Int]","GenericList[Int,Int]","None"],
+      "outputs": [[142,101,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::transpose", "id": 951, "rf_id": 692, "parent": 950, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::transpose.int(Tensor(a) self, int dim0, int dim1) -> Tensor(a)",
+      "inputs": [[108,101,0,1048576,4,"cuda:0"],0,1], "input_shapes": [[1024,1024],[],[]], "input_types": ["Tensor(float)","Int","Int"],
+      "outputs": [[142,101,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::t", "id": 950, "rf_id": 691, "parent": 949, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::t(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[108,101,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[142,101,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::mm", "id": 953, "rf_id": 694, "parent": 949, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::mm(Tensor self, Tensor mat2) -> Tensor",
+      "inputs": [[157,504,0,524288,4,"cuda:0"],[142,101,0,1048576,4,"cuda:0"]], "input_shapes": [[512,1024],[1024,1024]], "input_types": ["Tensor(float)","Tensor(float)"],
+      "outputs": [[127,19,0,524288,4,"cuda:0"]], "output_shapes": [[512,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::as_strided", "id": 956, "rf_id": 697, "parent": 955, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::as_strided(Tensor(a) self, SymInt[] size, SymInt[] stride, SymInt? storage_offset=None) -> Tensor(a)",
+      "inputs": [[157,504,0,524288,4,"cuda:0"],[1024,512],[1,1024],"<None>"], "input_shapes": [[512,1024],[[],[]],[[],[]],[]], "input_types": ["Tensor(float)","GenericList[Int,Int]","GenericList[Int,Int]","None"],
+      "outputs": [[142,504,0,524288,4,"cuda:0"]], "output_shapes": [[1024,512]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::transpose", "id": 955, "rf_id": 696, "parent": 954, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::transpose.int(Tensor(a) self, int dim0, int dim1) -> Tensor(a)",
+      "inputs": [[157,504,0,524288,4,"cuda:0"],0,1], "input_shapes": [[512,1024],[],[]], "input_types": ["Tensor(float)","Int","Int"],
+      "outputs": [[142,504,0,524288,4,"cuda:0"]], "output_shapes": [[1024,512]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::t", "id": 954, "rf_id": 695, "parent": 949, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::t(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[157,504,0,524288,4,"cuda:0"]], "input_shapes": [[512,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[142,504,0,524288,4,"cuda:0"]], "output_shapes": [[1024,512]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::mm", "id": 957, "rf_id": 698, "parent": 949, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::mm(Tensor self, Tensor mat2) -> Tensor",
+      "inputs": [[142,504,0,524288,4,"cuda:0"],[95,99,0,524288,4,"cuda:0"]], "input_shapes": [[1024,512],[512,1024]], "input_types": ["Tensor(float)","Tensor(float)"],
+      "outputs": [[111,175,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::as_strided", "id": 960, "rf_id": 701, "parent": 959, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::as_strided(Tensor(a) self, SymInt[] size, SymInt[] stride, SymInt? storage_offset=None) -> Tensor(a)",
+      "inputs": [[111,175,0,1048576,4,"cuda:0"],[1024,1024],[1,1024],"<None>"], "input_shapes": [[1024,1024],[[],[]],[[],[]],[]], "input_types": ["Tensor(float)","GenericList[Int,Int]","GenericList[Int,Int]","None"],
+      "outputs": [[112,175,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::transpose", "id": 959, "rf_id": 700, "parent": 958, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::transpose.int(Tensor(a) self, int dim0, int dim1) -> Tensor(a)",
+      "inputs": [[111,175,0,1048576,4,"cuda:0"],0,1], "input_shapes": [[1024,1024],[],[]], "input_types": ["Tensor(float)","Int","Int"],
+      "outputs": [[112,175,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::t", "id": 958, "rf_id": 699, "parent": 949, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::t(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[111,175,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[112,175,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "AddmmBackward0", "id": 949, "rf_id": 690, "parent": 948, "fw_parent": 2, "seq_id": 679, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[157,504,0,524288,4,"cuda:0"]], "input_shapes": [[512,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::sum", "id": 961, "rf_id": 702, "parent": 948, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::sum.dim_IntList(Tensor self, int[1]? dim, bool keepdim=False, *, ScalarType? dtype=None) -> Tensor",
+      "inputs": [[157,504,0,524288,4,"cuda:0"],[0],true,"<None>"], "input_shapes": [[512,1024],[[]],[],[]], "input_types": ["Tensor(float)","GenericList[Int]","Bool","None"],
+      "outputs": [[142,17,0,1024,4,"cuda:0"]], "output_shapes": [[1,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::view", "id": 962, "rf_id": 703, "parent": 948, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::view(Tensor(a) self, SymInt[] size) -> Tensor(a)",
+      "inputs": [[142,17,0,1024,4,"cuda:0"],[1024]], "input_shapes": [[1,1024],[[]]], "input_types": ["Tensor(float)","GenericList[Int]"],
+      "outputs": [[172,17,0,1024,4,"cuda:0"]], "output_shapes": [[1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "autograd::engine::evaluate_function: AddmmBackward0", "id": 948, "rf_id": 689, "parent": 519, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::add_", "id": 965, "rf_id": 706, "parent": 964, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::add_.Tensor(Tensor(a!) self, Tensor other, *, Scalar alpha=1) -> Tensor(a!)",
+      "inputs": [[381,382,0,1024,4,"cuda:0"],[172,17,0,1024,4,"cuda:0"],1], "input_shapes": [[1024],[1024],[]], "input_types": ["Tensor(float)","Tensor(float)","Int"],
+      "outputs": [[381,382,0,1024,4,"cuda:0"]], "output_shapes": [[1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "torch::autograd::AccumulateGrad", "id": 964, "rf_id": 705, "parent": 963, "fw_parent": 2, "seq_id": -1, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[172,17,0,1024,4,"cuda:0"]], "input_shapes": [[1024]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: torch::autograd::AccumulateGrad", "id": 963, "rf_id": 704, "parent": 519, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::as_strided", "id": 970, "rf_id": 711, "parent": 969, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::as_strided(Tensor(a) self, SymInt[] size, SymInt[] stride, SymInt? storage_offset=None) -> Tensor(a)",
+      "inputs": [[112,175,0,1048576,4,"cuda:0"],[1024,1024],[1024,1],"<None>"], "input_shapes": [[1024,1024],[[],[]],[[],[]],[]], "input_types": ["Tensor(float)","GenericList[Int,Int]","GenericList[Int,Int]","None"],
+      "outputs": [[172,175,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::transpose", "id": 969, "rf_id": 710, "parent": 968, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::transpose.int(Tensor(a) self, int dim0, int dim1) -> Tensor(a)",
+      "inputs": [[112,175,0,1048576,4,"cuda:0"],0,1], "input_shapes": [[1024,1024],[],[]], "input_types": ["Tensor(float)","Int","Int"],
+      "outputs": [[172,175,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::t", "id": 968, "rf_id": 709, "parent": 967, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::t(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[112,175,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[172,175,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "TBackward0", "id": 967, "rf_id": 708, "parent": 966, "fw_parent": 2, "seq_id": 678, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[112,175,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: TBackward0", "id": 966, "rf_id": 707, "parent": 519, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::add_", "id": 973, "rf_id": 714, "parent": 972, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::add_.Tensor(Tensor(a!) self, Tensor other, *, Scalar alpha=1) -> Tensor(a!)",
+      "inputs": [[377,378,0,1048576,4,"cuda:0"],[172,175,0,1048576,4,"cuda:0"],1], "input_shapes": [[1024,1024],[1024,1024],[]], "input_types": ["Tensor(float)","Tensor(float)","Int"],
+      "outputs": [[377,378,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "torch::autograd::AccumulateGrad", "id": 972, "rf_id": 713, "parent": 971, "fw_parent": 2, "seq_id": -1, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[172,175,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: torch::autograd::AccumulateGrad", "id": 971, "rf_id": 712, "parent": 519, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::threshold_backward", "id": 976, "rf_id": 717, "parent": 975, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::threshold_backward(Tensor grad_output, Tensor self, Scalar threshold) -> Tensor",
+      "inputs": [[127,19,0,524288,4,"cuda:0"],[112,99,0,524288,4,"cuda:0"],0], "input_shapes": [[512,1024],[512,1024],[]], "input_types": ["Tensor(float)","Tensor(float)","Int"],
+      "outputs": [[142,175,0,524288,4,"cuda:0"]], "output_shapes": [[512,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "ReluBackward0", "id": 975, "rf_id": 716, "parent": 974, "fw_parent": 2, "seq_id": 677, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[127,19,0,524288,4,"cuda:0"]], "input_shapes": [[512,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: ReluBackward0", "id": 974, "rf_id": 715, "parent": 519, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::as_strided", "id": 981, "rf_id": 722, "parent": 980, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::as_strided(Tensor(a) self, SymInt[] size, SymInt[] stride, SymInt? storage_offset=None) -> Tensor(a)",
+      "inputs": [[81,86,0,1048576,4,"cuda:0"],[1024,1024],[1024,1],"<None>"], "input_shapes": [[1024,1024],[[],[]],[[],[]],[]], "input_types": ["Tensor(float)","GenericList[Int,Int]","GenericList[Int,Int]","None"],
+      "outputs": [[127,86,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::transpose", "id": 980, "rf_id": 721, "parent": 979, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::transpose.int(Tensor(a) self, int dim0, int dim1) -> Tensor(a)",
+      "inputs": [[81,86,0,1048576,4,"cuda:0"],0,1], "input_shapes": [[1024,1024],[],[]], "input_types": ["Tensor(float)","Int","Int"],
+      "outputs": [[127,86,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::t", "id": 979, "rf_id": 720, "parent": 978, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::t(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[81,86,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[127,86,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::mm", "id": 982, "rf_id": 723, "parent": 978, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::mm(Tensor self, Tensor mat2) -> Tensor",
+      "inputs": [[142,175,0,524288,4,"cuda:0"],[127,86,0,1048576,4,"cuda:0"]], "input_shapes": [[512,1024],[1024,1024]], "input_types": ["Tensor(float)","Tensor(float)"],
+      "outputs": [[112,190,0,524288,4,"cuda:0"]], "output_shapes": [[512,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::as_strided", "id": 985, "rf_id": 726, "parent": 984, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::as_strided(Tensor(a) self, SymInt[] size, SymInt[] stride, SymInt? storage_offset=None) -> Tensor(a)",
+      "inputs": [[142,175,0,524288,4,"cuda:0"],[1024,512],[1,1024],"<None>"], "input_shapes": [[512,1024],[[],[]],[[],[]],[]], "input_types": ["Tensor(float)","GenericList[Int,Int]","GenericList[Int,Int]","None"],
+      "outputs": [[127,175,0,524288,4,"cuda:0"]], "output_shapes": [[1024,512]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::transpose", "id": 984, "rf_id": 725, "parent": 983, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::transpose.int(Tensor(a) self, int dim0, int dim1) -> Tensor(a)",
+      "inputs": [[142,175,0,524288,4,"cuda:0"],0,1], "input_shapes": [[512,1024],[],[]], "input_types": ["Tensor(float)","Int","Int"],
+      "outputs": [[127,175,0,524288,4,"cuda:0"]], "output_shapes": [[1024,512]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::t", "id": 983, "rf_id": 724, "parent": 978, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::t(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[142,175,0,524288,4,"cuda:0"]], "input_shapes": [[512,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[127,175,0,524288,4,"cuda:0"]], "output_shapes": [[1024,512]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::mm", "id": 986, "rf_id": 727, "parent": 978, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::mm(Tensor self, Tensor mat2) -> Tensor",
+      "inputs": [[127,175,0,524288,4,"cuda:0"],[80,84,0,524288,4,"cuda:0"]], "input_shapes": [[1024,512],[512,1024]], "input_types": ["Tensor(float)","Tensor(float)"],
+      "outputs": [[95,145,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::as_strided", "id": 989, "rf_id": 730, "parent": 988, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::as_strided(Tensor(a) self, SymInt[] size, SymInt[] stride, SymInt? storage_offset=None) -> Tensor(a)",
+      "inputs": [[95,145,0,1048576,4,"cuda:0"],[1024,1024],[1,1024],"<None>"], "input_shapes": [[1024,1024],[[],[]],[[],[]],[]], "input_types": ["Tensor(float)","GenericList[Int,Int]","GenericList[Int,Int]","None"],
+      "outputs": [[108,145,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::transpose", "id": 988, "rf_id": 729, "parent": 987, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::transpose.int(Tensor(a) self, int dim0, int dim1) -> Tensor(a)",
+      "inputs": [[95,145,0,1048576,4,"cuda:0"],0,1], "input_shapes": [[1024,1024],[],[]], "input_types": ["Tensor(float)","Int","Int"],
+      "outputs": [[108,145,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::t", "id": 987, "rf_id": 728, "parent": 978, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::t(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[95,145,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[108,145,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "AddmmBackward0", "id": 978, "rf_id": 719, "parent": 977, "fw_parent": 2, "seq_id": 676, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[142,175,0,524288,4,"cuda:0"]], "input_shapes": [[512,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::sum", "id": 990, "rf_id": 731, "parent": 977, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::sum.dim_IntList(Tensor self, int[1]? dim, bool keepdim=False, *, ScalarType? dtype=None) -> Tensor",
+      "inputs": [[142,175,0,524288,4,"cuda:0"],[0],true,"<None>"], "input_shapes": [[512,1024],[[]],[],[]], "input_types": ["Tensor(float)","GenericList[Int]","Bool","None"],
+      "outputs": [[127,17,0,1024,4,"cuda:0"]], "output_shapes": [[1,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::view", "id": 991, "rf_id": 732, "parent": 977, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::view(Tensor(a) self, SymInt[] size) -> Tensor(a)",
+      "inputs": [[127,17,0,1024,4,"cuda:0"],[1024]], "input_shapes": [[1,1024],[[]]], "input_types": ["Tensor(float)","GenericList[Int]"],
+      "outputs": [[157,17,0,1024,4,"cuda:0"]], "output_shapes": [[1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "autograd::engine::evaluate_function: AddmmBackward0", "id": 977, "rf_id": 718, "parent": 519, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::add_", "id": 994, "rf_id": 735, "parent": 993, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::add_.Tensor(Tensor(a!) self, Tensor other, *, Scalar alpha=1) -> Tensor(a!)",
+      "inputs": [[373,374,0,1024,4,"cuda:0"],[157,17,0,1024,4,"cuda:0"],1], "input_shapes": [[1024],[1024],[]], "input_types": ["Tensor(float)","Tensor(float)","Int"],
+      "outputs": [[373,374,0,1024,4,"cuda:0"]], "output_shapes": [[1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "torch::autograd::AccumulateGrad", "id": 993, "rf_id": 734, "parent": 992, "fw_parent": 2, "seq_id": -1, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[157,17,0,1024,4,"cuda:0"]], "input_shapes": [[1024]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: torch::autograd::AccumulateGrad", "id": 992, "rf_id": 733, "parent": 519, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::as_strided", "id": 999, "rf_id": 740, "parent": 998, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::as_strided(Tensor(a) self, SymInt[] size, SymInt[] stride, SymInt? storage_offset=None) -> Tensor(a)",
+      "inputs": [[108,145,0,1048576,4,"cuda:0"],[1024,1024],[1024,1],"<None>"], "input_shapes": [[1024,1024],[[],[]],[[],[]],[]], "input_types": ["Tensor(float)","GenericList[Int,Int]","GenericList[Int,Int]","None"],
+      "outputs": [[157,145,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::transpose", "id": 998, "rf_id": 739, "parent": 997, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::transpose.int(Tensor(a) self, int dim0, int dim1) -> Tensor(a)",
+      "inputs": [[108,145,0,1048576,4,"cuda:0"],0,1], "input_shapes": [[1024,1024],[],[]], "input_types": ["Tensor(float)","Int","Int"],
+      "outputs": [[157,145,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::t", "id": 997, "rf_id": 738, "parent": 996, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::t(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[108,145,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[157,145,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "TBackward0", "id": 996, "rf_id": 737, "parent": 995, "fw_parent": 2, "seq_id": 675, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[108,145,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: TBackward0", "id": 995, "rf_id": 736, "parent": 519, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::add_", "id": 1002, "rf_id": 743, "parent": 1001, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::add_.Tensor(Tensor(a!) self, Tensor other, *, Scalar alpha=1) -> Tensor(a!)",
+      "inputs": [[369,370,0,1048576,4,"cuda:0"],[157,145,0,1048576,4,"cuda:0"],1], "input_shapes": [[1024,1024],[1024,1024],[]], "input_types": ["Tensor(float)","Tensor(float)","Int"],
+      "outputs": [[369,370,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "torch::autograd::AccumulateGrad", "id": 1001, "rf_id": 742, "parent": 1000, "fw_parent": 2, "seq_id": -1, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[157,145,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: torch::autograd::AccumulateGrad", "id": 1000, "rf_id": 741, "parent": 519, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::threshold_backward", "id": 1005, "rf_id": 746, "parent": 1004, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::threshold_backward(Tensor grad_output, Tensor self, Scalar threshold) -> Tensor",
+      "inputs": [[112,190,0,524288,4,"cuda:0"],[108,84,0,524288,4,"cuda:0"],0], "input_shapes": [[512,1024],[512,1024],[]], "input_types": ["Tensor(float)","Tensor(float)","Int"],
+      "outputs": [[127,175,0,524288,4,"cuda:0"]], "output_shapes": [[512,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "ReluBackward0", "id": 1004, "rf_id": 745, "parent": 1003, "fw_parent": 2, "seq_id": 674, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[112,190,0,524288,4,"cuda:0"]], "input_shapes": [[512,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: ReluBackward0", "id": 1003, "rf_id": 744, "parent": 519, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::as_strided", "id": 1010, "rf_id": 751, "parent": 1009, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::as_strided(Tensor(a) self, SymInt[] size, SymInt[] stride, SymInt? storage_offset=None) -> Tensor(a)",
+      "inputs": [[66,71,0,1048576,4,"cuda:0"],[1024,1024],[1024,1],"<None>"], "input_shapes": [[1024,1024],[[],[]],[[],[]],[]], "input_types": ["Tensor(float)","GenericList[Int,Int]","GenericList[Int,Int]","None"],
+      "outputs": [[112,71,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::transpose", "id": 1009, "rf_id": 750, "parent": 1008, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::transpose.int(Tensor(a) self, int dim0, int dim1) -> Tensor(a)",
+      "inputs": [[66,71,0,1048576,4,"cuda:0"],0,1], "input_shapes": [[1024,1024],[],[]], "input_types": ["Tensor(float)","Int","Int"],
+      "outputs": [[112,71,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::t", "id": 1008, "rf_id": 749, "parent": 1007, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::t(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[66,71,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[112,71,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::mm", "id": 1011, "rf_id": 752, "parent": 1007, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::mm(Tensor self, Tensor mat2) -> Tensor",
+      "inputs": [[127,175,0,524288,4,"cuda:0"],[112,71,0,1048576,4,"cuda:0"]], "input_shapes": [[512,1024],[1024,1024]], "input_types": ["Tensor(float)","Tensor(float)"],
+      "outputs": [[108,190,0,524288,4,"cuda:0"]], "output_shapes": [[512,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::as_strided", "id": 1014, "rf_id": 755, "parent": 1013, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::as_strided(Tensor(a) self, SymInt[] size, SymInt[] stride, SymInt? storage_offset=None) -> Tensor(a)",
+      "inputs": [[127,175,0,524288,4,"cuda:0"],[1024,512],[1,1024],"<None>"], "input_shapes": [[512,1024],[[],[]],[[],[]],[]], "input_types": ["Tensor(float)","GenericList[Int,Int]","GenericList[Int,Int]","None"],
+      "outputs": [[112,175,0,524288,4,"cuda:0"]], "output_shapes": [[1024,512]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::transpose", "id": 1013, "rf_id": 754, "parent": 1012, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::transpose.int(Tensor(a) self, int dim0, int dim1) -> Tensor(a)",
+      "inputs": [[127,175,0,524288,4,"cuda:0"],0,1], "input_shapes": [[512,1024],[],[]], "input_types": ["Tensor(float)","Int","Int"],
+      "outputs": [[112,175,0,524288,4,"cuda:0"]], "output_shapes": [[1024,512]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::t", "id": 1012, "rf_id": 753, "parent": 1007, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::t(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[127,175,0,524288,4,"cuda:0"]], "input_shapes": [[512,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[112,175,0,524288,4,"cuda:0"]], "output_shapes": [[1024,512]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::mm", "id": 1015, "rf_id": 756, "parent": 1007, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::mm(Tensor self, Tensor mat2) -> Tensor",
+      "inputs": [[112,175,0,524288,4,"cuda:0"],[65,69,0,524288,4,"cuda:0"]], "input_shapes": [[1024,512],[512,1024]], "input_types": ["Tensor(float)","Tensor(float)"],
+      "outputs": [[80,145,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::as_strided", "id": 1018, "rf_id": 759, "parent": 1017, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::as_strided(Tensor(a) self, SymInt[] size, SymInt[] stride, SymInt? storage_offset=None) -> Tensor(a)",
+      "inputs": [[80,145,0,1048576,4,"cuda:0"],[1024,1024],[1,1024],"<None>"], "input_shapes": [[1024,1024],[[],[]],[[],[]],[]], "input_types": ["Tensor(float)","GenericList[Int,Int]","GenericList[Int,Int]","None"],
+      "outputs": [[81,145,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::transpose", "id": 1017, "rf_id": 758, "parent": 1016, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::transpose.int(Tensor(a) self, int dim0, int dim1) -> Tensor(a)",
+      "inputs": [[80,145,0,1048576,4,"cuda:0"],0,1], "input_shapes": [[1024,1024],[],[]], "input_types": ["Tensor(float)","Int","Int"],
+      "outputs": [[81,145,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::t", "id": 1016, "rf_id": 757, "parent": 1007, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::t(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[80,145,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[81,145,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "AddmmBackward0", "id": 1007, "rf_id": 748, "parent": 1006, "fw_parent": 2, "seq_id": 673, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[127,175,0,524288,4,"cuda:0"]], "input_shapes": [[512,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::sum", "id": 1019, "rf_id": 760, "parent": 1006, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::sum.dim_IntList(Tensor self, int[1]? dim, bool keepdim=False, *, ScalarType? dtype=None) -> Tensor",
+      "inputs": [[127,175,0,524288,4,"cuda:0"],[0],true,"<None>"], "input_shapes": [[512,1024],[[]],[],[]], "input_types": ["Tensor(float)","GenericList[Int]","Bool","None"],
+      "outputs": [[112,17,0,1024,4,"cuda:0"]], "output_shapes": [[1,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::view", "id": 1020, "rf_id": 761, "parent": 1006, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::view(Tensor(a) self, SymInt[] size) -> Tensor(a)",
+      "inputs": [[112,17,0,1024,4,"cuda:0"],[1024]], "input_shapes": [[1,1024],[[]]], "input_types": ["Tensor(float)","GenericList[Int]"],
+      "outputs": [[142,17,0,1024,4,"cuda:0"]], "output_shapes": [[1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "autograd::engine::evaluate_function: AddmmBackward0", "id": 1006, "rf_id": 747, "parent": 519, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::add_", "id": 1023, "rf_id": 764, "parent": 1022, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::add_.Tensor(Tensor(a!) self, Tensor other, *, Scalar alpha=1) -> Tensor(a!)",
+      "inputs": [[365,366,0,1024,4,"cuda:0"],[142,17,0,1024,4,"cuda:0"],1], "input_shapes": [[1024],[1024],[]], "input_types": ["Tensor(float)","Tensor(float)","Int"],
+      "outputs": [[365,366,0,1024,4,"cuda:0"]], "output_shapes": [[1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "torch::autograd::AccumulateGrad", "id": 1022, "rf_id": 763, "parent": 1021, "fw_parent": 2, "seq_id": -1, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[142,17,0,1024,4,"cuda:0"]], "input_shapes": [[1024]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: torch::autograd::AccumulateGrad", "id": 1021, "rf_id": 762, "parent": 519, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::as_strided", "id": 1028, "rf_id": 769, "parent": 1027, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::as_strided(Tensor(a) self, SymInt[] size, SymInt[] stride, SymInt? storage_offset=None) -> Tensor(a)",
+      "inputs": [[81,145,0,1048576,4,"cuda:0"],[1024,1024],[1024,1],"<None>"], "input_shapes": [[1024,1024],[[],[]],[[],[]],[]], "input_types": ["Tensor(float)","GenericList[Int,Int]","GenericList[Int,Int]","None"],
+      "outputs": [[142,145,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::transpose", "id": 1027, "rf_id": 768, "parent": 1026, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::transpose.int(Tensor(a) self, int dim0, int dim1) -> Tensor(a)",
+      "inputs": [[81,145,0,1048576,4,"cuda:0"],0,1], "input_shapes": [[1024,1024],[],[]], "input_types": ["Tensor(float)","Int","Int"],
+      "outputs": [[142,145,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::t", "id": 1026, "rf_id": 767, "parent": 1025, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::t(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[81,145,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[142,145,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "TBackward0", "id": 1025, "rf_id": 766, "parent": 1024, "fw_parent": 2, "seq_id": 672, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[81,145,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: TBackward0", "id": 1024, "rf_id": 765, "parent": 519, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::add_", "id": 1031, "rf_id": 772, "parent": 1030, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::add_.Tensor(Tensor(a!) self, Tensor other, *, Scalar alpha=1) -> Tensor(a!)",
+      "inputs": [[361,362,0,1048576,4,"cuda:0"],[142,145,0,1048576,4,"cuda:0"],1], "input_shapes": [[1024,1024],[1024,1024],[]], "input_types": ["Tensor(float)","Tensor(float)","Int"],
+      "outputs": [[361,362,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "torch::autograd::AccumulateGrad", "id": 1030, "rf_id": 771, "parent": 1029, "fw_parent": 2, "seq_id": -1, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[142,145,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: torch::autograd::AccumulateGrad", "id": 1029, "rf_id": 770, "parent": 519, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::threshold_backward", "id": 1034, "rf_id": 775, "parent": 1033, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::threshold_backward(Tensor grad_output, Tensor self, Scalar threshold) -> Tensor",
+      "inputs": [[108,190,0,524288,4,"cuda:0"],[81,69,0,524288,4,"cuda:0"],0], "input_shapes": [[512,1024],[512,1024],[]], "input_types": ["Tensor(float)","Tensor(float)","Int"],
+      "outputs": [[112,175,0,524288,4,"cuda:0"]], "output_shapes": [[512,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "ReluBackward0", "id": 1033, "rf_id": 774, "parent": 1032, "fw_parent": 2, "seq_id": 671, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[108,190,0,524288,4,"cuda:0"]], "input_shapes": [[512,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: ReluBackward0", "id": 1032, "rf_id": 773, "parent": 519, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::as_strided", "id": 1039, "rf_id": 780, "parent": 1038, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::as_strided(Tensor(a) self, SymInt[] size, SymInt[] stride, SymInt? storage_offset=None) -> Tensor(a)",
+      "inputs": [[62,55,0,1048576,4,"cuda:0"],[1024,1024],[1024,1],"<None>"], "input_shapes": [[1024,1024],[[],[]],[[],[]],[]], "input_types": ["Tensor(float)","GenericList[Int,Int]","GenericList[Int,Int]","None"],
+      "outputs": [[108,55,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::transpose", "id": 1038, "rf_id": 779, "parent": 1037, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::transpose.int(Tensor(a) self, int dim0, int dim1) -> Tensor(a)",
+      "inputs": [[62,55,0,1048576,4,"cuda:0"],0,1], "input_shapes": [[1024,1024],[],[]], "input_types": ["Tensor(float)","Int","Int"],
+      "outputs": [[108,55,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::t", "id": 1037, "rf_id": 778, "parent": 1036, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::t(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[62,55,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[108,55,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::mm", "id": 1040, "rf_id": 781, "parent": 1036, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::mm(Tensor self, Tensor mat2) -> Tensor",
+      "inputs": [[112,175,0,524288,4,"cuda:0"],[108,55,0,1048576,4,"cuda:0"]], "input_shapes": [[512,1024],[1024,1024]], "input_types": ["Tensor(float)","Tensor(float)"],
+      "outputs": [[81,190,0,524288,4,"cuda:0"]], "output_shapes": [[512,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::as_strided", "id": 1043, "rf_id": 784, "parent": 1042, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::as_strided(Tensor(a) self, SymInt[] size, SymInt[] stride, SymInt? storage_offset=None) -> Tensor(a)",
+      "inputs": [[112,175,0,524288,4,"cuda:0"],[1024,512],[1,1024],"<None>"], "input_shapes": [[512,1024],[[],[]],[[],[]],[]], "input_types": ["Tensor(float)","GenericList[Int,Int]","GenericList[Int,Int]","None"],
+      "outputs": [[108,175,0,524288,4,"cuda:0"]], "output_shapes": [[1024,512]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::transpose", "id": 1042, "rf_id": 783, "parent": 1041, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::transpose.int(Tensor(a) self, int dim0, int dim1) -> Tensor(a)",
+      "inputs": [[112,175,0,524288,4,"cuda:0"],0,1], "input_shapes": [[512,1024],[],[]], "input_types": ["Tensor(float)","Int","Int"],
+      "outputs": [[108,175,0,524288,4,"cuda:0"]], "output_shapes": [[1024,512]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::t", "id": 1041, "rf_id": 782, "parent": 1036, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::t(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[112,175,0,524288,4,"cuda:0"]], "input_shapes": [[512,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[108,175,0,524288,4,"cuda:0"]], "output_shapes": [[1024,512]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::mm", "id": 1044, "rf_id": 785, "parent": 1036, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::mm(Tensor self, Tensor mat2) -> Tensor",
+      "inputs": [[108,175,0,524288,4,"cuda:0"],[49,53,0,524288,4,"cuda:0"]], "input_shapes": [[1024,512],[512,1024]], "input_types": ["Tensor(float)","Tensor(float)"],
+      "outputs": [[65,145,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::as_strided", "id": 1047, "rf_id": 788, "parent": 1046, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::as_strided(Tensor(a) self, SymInt[] size, SymInt[] stride, SymInt? storage_offset=None) -> Tensor(a)",
+      "inputs": [[65,145,0,1048576,4,"cuda:0"],[1024,1024],[1,1024],"<None>"], "input_shapes": [[1024,1024],[[],[]],[[],[]],[]], "input_types": ["Tensor(float)","GenericList[Int,Int]","GenericList[Int,Int]","None"],
+      "outputs": [[66,145,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::transpose", "id": 1046, "rf_id": 787, "parent": 1045, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::transpose.int(Tensor(a) self, int dim0, int dim1) -> Tensor(a)",
+      "inputs": [[65,145,0,1048576,4,"cuda:0"],0,1], "input_shapes": [[1024,1024],[],[]], "input_types": ["Tensor(float)","Int","Int"],
+      "outputs": [[66,145,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::t", "id": 1045, "rf_id": 786, "parent": 1036, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::t(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[65,145,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[66,145,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "AddmmBackward0", "id": 1036, "rf_id": 777, "parent": 1035, "fw_parent": 2, "seq_id": 670, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[112,175,0,524288,4,"cuda:0"]], "input_shapes": [[512,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::sum", "id": 1048, "rf_id": 789, "parent": 1035, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::sum.dim_IntList(Tensor self, int[1]? dim, bool keepdim=False, *, ScalarType? dtype=None) -> Tensor",
+      "inputs": [[112,175,0,524288,4,"cuda:0"],[0],true,"<None>"], "input_shapes": [[512,1024],[[]],[],[]], "input_types": ["Tensor(float)","GenericList[Int]","Bool","None"],
+      "outputs": [[108,17,0,1024,4,"cuda:0"]], "output_shapes": [[1,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::view", "id": 1049, "rf_id": 790, "parent": 1035, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::view(Tensor(a) self, SymInt[] size) -> Tensor(a)",
+      "inputs": [[108,17,0,1024,4,"cuda:0"],[1024]], "input_shapes": [[1,1024],[[]]], "input_types": ["Tensor(float)","GenericList[Int]"],
+      "outputs": [[127,17,0,1024,4,"cuda:0"]], "output_shapes": [[1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "autograd::engine::evaluate_function: AddmmBackward0", "id": 1035, "rf_id": 776, "parent": 519, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::add_", "id": 1052, "rf_id": 793, "parent": 1051, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::add_.Tensor(Tensor(a!) self, Tensor other, *, Scalar alpha=1) -> Tensor(a!)",
+      "inputs": [[357,358,0,1024,4,"cuda:0"],[127,17,0,1024,4,"cuda:0"],1], "input_shapes": [[1024],[1024],[]], "input_types": ["Tensor(float)","Tensor(float)","Int"],
+      "outputs": [[357,358,0,1024,4,"cuda:0"]], "output_shapes": [[1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "torch::autograd::AccumulateGrad", "id": 1051, "rf_id": 792, "parent": 1050, "fw_parent": 2, "seq_id": -1, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[127,17,0,1024,4,"cuda:0"]], "input_shapes": [[1024]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: torch::autograd::AccumulateGrad", "id": 1050, "rf_id": 791, "parent": 519, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::as_strided", "id": 1057, "rf_id": 798, "parent": 1056, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::as_strided(Tensor(a) self, SymInt[] size, SymInt[] stride, SymInt? storage_offset=None) -> Tensor(a)",
+      "inputs": [[66,145,0,1048576,4,"cuda:0"],[1024,1024],[1024,1],"<None>"], "input_shapes": [[1024,1024],[[],[]],[[],[]],[]], "input_types": ["Tensor(float)","GenericList[Int,Int]","GenericList[Int,Int]","None"],
+      "outputs": [[127,145,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::transpose", "id": 1056, "rf_id": 797, "parent": 1055, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::transpose.int(Tensor(a) self, int dim0, int dim1) -> Tensor(a)",
+      "inputs": [[66,145,0,1048576,4,"cuda:0"],0,1], "input_shapes": [[1024,1024],[],[]], "input_types": ["Tensor(float)","Int","Int"],
+      "outputs": [[127,145,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::t", "id": 1055, "rf_id": 796, "parent": 1054, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::t(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[66,145,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[127,145,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "TBackward0", "id": 1054, "rf_id": 795, "parent": 1053, "fw_parent": 2, "seq_id": 669, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[66,145,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: TBackward0", "id": 1053, "rf_id": 794, "parent": 519, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::add_", "id": 1060, "rf_id": 801, "parent": 1059, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::add_.Tensor(Tensor(a!) self, Tensor other, *, Scalar alpha=1) -> Tensor(a!)",
+      "inputs": [[353,354,0,1048576,4,"cuda:0"],[127,145,0,1048576,4,"cuda:0"],1], "input_shapes": [[1024,1024],[1024,1024],[]], "input_types": ["Tensor(float)","Tensor(float)","Int"],
+      "outputs": [[353,354,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "torch::autograd::AccumulateGrad", "id": 1059, "rf_id": 800, "parent": 1058, "fw_parent": 2, "seq_id": -1, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[127,145,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: torch::autograd::AccumulateGrad", "id": 1058, "rf_id": 799, "parent": 519, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::threshold_backward", "id": 1063, "rf_id": 804, "parent": 1062, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::threshold_backward(Tensor grad_output, Tensor self, Scalar threshold) -> Tensor",
+      "inputs": [[81,190,0,524288,4,"cuda:0"],[66,53,0,524288,4,"cuda:0"],0], "input_shapes": [[512,1024],[512,1024],[]], "input_types": ["Tensor(float)","Tensor(float)","Int"],
+      "outputs": [[108,175,0,524288,4,"cuda:0"]], "output_shapes": [[512,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "ReluBackward0", "id": 1062, "rf_id": 803, "parent": 1061, "fw_parent": 2, "seq_id": 668, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[81,190,0,524288,4,"cuda:0"]], "input_shapes": [[512,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: ReluBackward0", "id": 1061, "rf_id": 802, "parent": 519, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::as_strided", "id": 1068, "rf_id": 809, "parent": 1067, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::as_strided(Tensor(a) self, SymInt[] size, SymInt[] stride, SymInt? storage_offset=None) -> Tensor(a)",
+      "inputs": [[35,40,0,1048576,4,"cuda:0"],[1024,1024],[1024,1],"<None>"], "input_shapes": [[1024,1024],[[],[]],[[],[]],[]], "input_types": ["Tensor(float)","GenericList[Int,Int]","GenericList[Int,Int]","None"],
+      "outputs": [[81,40,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::transpose", "id": 1067, "rf_id": 808, "parent": 1066, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::transpose.int(Tensor(a) self, int dim0, int dim1) -> Tensor(a)",
+      "inputs": [[35,40,0,1048576,4,"cuda:0"],0,1], "input_shapes": [[1024,1024],[],[]], "input_types": ["Tensor(float)","Int","Int"],
+      "outputs": [[81,40,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::t", "id": 1066, "rf_id": 807, "parent": 1065, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::t(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[35,40,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[81,40,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::mm", "id": 1069, "rf_id": 810, "parent": 1065, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::mm(Tensor self, Tensor mat2) -> Tensor",
+      "inputs": [[108,175,0,524288,4,"cuda:0"],[81,40,0,1048576,4,"cuda:0"]], "input_shapes": [[512,1024],[1024,1024]], "input_types": ["Tensor(float)","Tensor(float)"],
+      "outputs": [[66,190,0,524288,4,"cuda:0"]], "output_shapes": [[512,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::as_strided", "id": 1072, "rf_id": 813, "parent": 1071, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::as_strided(Tensor(a) self, SymInt[] size, SymInt[] stride, SymInt? storage_offset=None) -> Tensor(a)",
+      "inputs": [[108,175,0,524288,4,"cuda:0"],[1024,512],[1,1024],"<None>"], "input_shapes": [[512,1024],[[],[]],[[],[]],[]], "input_types": ["Tensor(float)","GenericList[Int,Int]","GenericList[Int,Int]","None"],
+      "outputs": [[81,175,0,524288,4,"cuda:0"]], "output_shapes": [[1024,512]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::transpose", "id": 1071, "rf_id": 812, "parent": 1070, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::transpose.int(Tensor(a) self, int dim0, int dim1) -> Tensor(a)",
+      "inputs": [[108,175,0,524288,4,"cuda:0"],0,1], "input_shapes": [[512,1024],[],[]], "input_types": ["Tensor(float)","Int","Int"],
+      "outputs": [[81,175,0,524288,4,"cuda:0"]], "output_shapes": [[1024,512]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::t", "id": 1070, "rf_id": 811, "parent": 1065, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::t(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[108,175,0,524288,4,"cuda:0"]], "input_shapes": [[512,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[81,175,0,524288,4,"cuda:0"]], "output_shapes": [[1024,512]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::mm", "id": 1073, "rf_id": 814, "parent": 1065, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::mm(Tensor self, Tensor mat2) -> Tensor",
+      "inputs": [[81,175,0,524288,4,"cuda:0"],[34,38,0,524288,4,"cuda:0"]], "input_shapes": [[1024,512],[512,1024]], "input_types": ["Tensor(float)","Tensor(float)"],
+      "outputs": [[49,145,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::as_strided", "id": 1076, "rf_id": 817, "parent": 1075, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::as_strided(Tensor(a) self, SymInt[] size, SymInt[] stride, SymInt? storage_offset=None) -> Tensor(a)",
+      "inputs": [[49,145,0,1048576,4,"cuda:0"],[1024,1024],[1,1024],"<None>"], "input_shapes": [[1024,1024],[[],[]],[[],[]],[]], "input_types": ["Tensor(float)","GenericList[Int,Int]","GenericList[Int,Int]","None"],
+      "outputs": [[62,145,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::transpose", "id": 1075, "rf_id": 816, "parent": 1074, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::transpose.int(Tensor(a) self, int dim0, int dim1) -> Tensor(a)",
+      "inputs": [[49,145,0,1048576,4,"cuda:0"],0,1], "input_shapes": [[1024,1024],[],[]], "input_types": ["Tensor(float)","Int","Int"],
+      "outputs": [[62,145,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::t", "id": 1074, "rf_id": 815, "parent": 1065, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::t(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[49,145,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[62,145,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "AddmmBackward0", "id": 1065, "rf_id": 806, "parent": 1064, "fw_parent": 2, "seq_id": 667, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[108,175,0,524288,4,"cuda:0"]], "input_shapes": [[512,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::sum", "id": 1077, "rf_id": 818, "parent": 1064, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::sum.dim_IntList(Tensor self, int[1]? dim, bool keepdim=False, *, ScalarType? dtype=None) -> Tensor",
+      "inputs": [[108,175,0,524288,4,"cuda:0"],[0],true,"<None>"], "input_shapes": [[512,1024],[[]],[],[]], "input_types": ["Tensor(float)","GenericList[Int]","Bool","None"],
+      "outputs": [[81,17,0,1024,4,"cuda:0"]], "output_shapes": [[1,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::view", "id": 1078, "rf_id": 819, "parent": 1064, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::view(Tensor(a) self, SymInt[] size) -> Tensor(a)",
+      "inputs": [[81,17,0,1024,4,"cuda:0"],[1024]], "input_shapes": [[1,1024],[[]]], "input_types": ["Tensor(float)","GenericList[Int]"],
+      "outputs": [[112,17,0,1024,4,"cuda:0"]], "output_shapes": [[1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "autograd::engine::evaluate_function: AddmmBackward0", "id": 1064, "rf_id": 805, "parent": 519, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::add_", "id": 1081, "rf_id": 822, "parent": 1080, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::add_.Tensor(Tensor(a!) self, Tensor other, *, Scalar alpha=1) -> Tensor(a!)",
+      "inputs": [[349,350,0,1024,4,"cuda:0"],[112,17,0,1024,4,"cuda:0"],1], "input_shapes": [[1024],[1024],[]], "input_types": ["Tensor(float)","Tensor(float)","Int"],
+      "outputs": [[349,350,0,1024,4,"cuda:0"]], "output_shapes": [[1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "torch::autograd::AccumulateGrad", "id": 1080, "rf_id": 821, "parent": 1079, "fw_parent": 2, "seq_id": -1, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[112,17,0,1024,4,"cuda:0"]], "input_shapes": [[1024]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: torch::autograd::AccumulateGrad", "id": 1079, "rf_id": 820, "parent": 519, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::as_strided", "id": 1086, "rf_id": 827, "parent": 1085, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::as_strided(Tensor(a) self, SymInt[] size, SymInt[] stride, SymInt? storage_offset=None) -> Tensor(a)",
+      "inputs": [[62,145,0,1048576,4,"cuda:0"],[1024,1024],[1024,1],"<None>"], "input_shapes": [[1024,1024],[[],[]],[[],[]],[]], "input_types": ["Tensor(float)","GenericList[Int,Int]","GenericList[Int,Int]","None"],
+      "outputs": [[112,145,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::transpose", "id": 1085, "rf_id": 826, "parent": 1084, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::transpose.int(Tensor(a) self, int dim0, int dim1) -> Tensor(a)",
+      "inputs": [[62,145,0,1048576,4,"cuda:0"],0,1], "input_shapes": [[1024,1024],[],[]], "input_types": ["Tensor(float)","Int","Int"],
+      "outputs": [[112,145,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::t", "id": 1084, "rf_id": 825, "parent": 1083, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::t(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[62,145,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[112,145,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "TBackward0", "id": 1083, "rf_id": 824, "parent": 1082, "fw_parent": 2, "seq_id": 666, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[62,145,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: TBackward0", "id": 1082, "rf_id": 823, "parent": 519, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::add_", "id": 1089, "rf_id": 830, "parent": 1088, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::add_.Tensor(Tensor(a!) self, Tensor other, *, Scalar alpha=1) -> Tensor(a!)",
+      "inputs": [[345,346,0,1048576,4,"cuda:0"],[112,145,0,1048576,4,"cuda:0"],1], "input_shapes": [[1024,1024],[1024,1024],[]], "input_types": ["Tensor(float)","Tensor(float)","Int"],
+      "outputs": [[345,346,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "torch::autograd::AccumulateGrad", "id": 1088, "rf_id": 829, "parent": 1087, "fw_parent": 2, "seq_id": -1, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[112,145,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: torch::autograd::AccumulateGrad", "id": 1087, "rf_id": 828, "parent": 519, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::threshold_backward", "id": 1092, "rf_id": 833, "parent": 1091, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::threshold_backward(Tensor grad_output, Tensor self, Scalar threshold) -> Tensor",
+      "inputs": [[66,190,0,524288,4,"cuda:0"],[62,38,0,524288,4,"cuda:0"],0], "input_shapes": [[512,1024],[512,1024],[]], "input_types": ["Tensor(float)","Tensor(float)","Int"],
+      "outputs": [[81,175,0,524288,4,"cuda:0"]], "output_shapes": [[512,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "ReluBackward0", "id": 1091, "rf_id": 832, "parent": 1090, "fw_parent": 2, "seq_id": 665, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[66,190,0,524288,4,"cuda:0"]], "input_shapes": [[512,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: ReluBackward0", "id": 1090, "rf_id": 831, "parent": 519, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::as_strided", "id": 1097, "rf_id": 838, "parent": 1096, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::as_strided(Tensor(a) self, SymInt[] size, SymInt[] stride, SymInt? storage_offset=None) -> Tensor(a)",
+      "inputs": [[18,25,0,1048576,4,"cuda:0"],[1024,1024],[1024,1],"<None>"], "input_shapes": [[1024,1024],[[],[]],[[],[]],[]], "input_types": ["Tensor(float)","GenericList[Int,Int]","GenericList[Int,Int]","None"],
+      "outputs": [[66,25,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::transpose", "id": 1096, "rf_id": 837, "parent": 1095, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::transpose.int(Tensor(a) self, int dim0, int dim1) -> Tensor(a)",
+      "inputs": [[18,25,0,1048576,4,"cuda:0"],0,1], "input_shapes": [[1024,1024],[],[]], "input_types": ["Tensor(float)","Int","Int"],
+      "outputs": [[66,25,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::t", "id": 1095, "rf_id": 836, "parent": 1094, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::t(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[18,25,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[66,25,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::mm", "id": 1098, "rf_id": 839, "parent": 1094, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::mm(Tensor self, Tensor mat2) -> Tensor",
+      "inputs": [[81,175,0,524288,4,"cuda:0"],[66,25,0,1048576,4,"cuda:0"]], "input_shapes": [[512,1024],[1024,1024]], "input_types": ["Tensor(float)","Tensor(float)"],
+      "outputs": [[62,190,0,524288,4,"cuda:0"]], "output_shapes": [[512,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::as_strided", "id": 1101, "rf_id": 842, "parent": 1100, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::as_strided(Tensor(a) self, SymInt[] size, SymInt[] stride, SymInt? storage_offset=None) -> Tensor(a)",
+      "inputs": [[81,175,0,524288,4,"cuda:0"],[1024,512],[1,1024],"<None>"], "input_shapes": [[512,1024],[[],[]],[[],[]],[]], "input_types": ["Tensor(float)","GenericList[Int,Int]","GenericList[Int,Int]","None"],
+      "outputs": [[66,175,0,524288,4,"cuda:0"]], "output_shapes": [[1024,512]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::transpose", "id": 1100, "rf_id": 841, "parent": 1099, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::transpose.int(Tensor(a) self, int dim0, int dim1) -> Tensor(a)",
+      "inputs": [[81,175,0,524288,4,"cuda:0"],0,1], "input_shapes": [[512,1024],[],[]], "input_types": ["Tensor(float)","Int","Int"],
+      "outputs": [[66,175,0,524288,4,"cuda:0"]], "output_shapes": [[1024,512]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::t", "id": 1099, "rf_id": 840, "parent": 1094, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::t(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[81,175,0,524288,4,"cuda:0"]], "input_shapes": [[512,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[66,175,0,524288,4,"cuda:0"]], "output_shapes": [[1024,512]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::mm", "id": 1102, "rf_id": 843, "parent": 1094, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::mm(Tensor self, Tensor mat2) -> Tensor",
+      "inputs": [[66,175,0,524288,4,"cuda:0"],[22,23,0,524288,4,"cuda:0"]], "input_shapes": [[1024,512],[512,1024]], "input_types": ["Tensor(float)","Tensor(float)"],
+      "outputs": [[34,145,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::as_strided", "id": 1105, "rf_id": 846, "parent": 1104, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::as_strided(Tensor(a) self, SymInt[] size, SymInt[] stride, SymInt? storage_offset=None) -> Tensor(a)",
+      "inputs": [[34,145,0,1048576,4,"cuda:0"],[1024,1024],[1,1024],"<None>"], "input_shapes": [[1024,1024],[[],[]],[[],[]],[]], "input_types": ["Tensor(float)","GenericList[Int,Int]","GenericList[Int,Int]","None"],
+      "outputs": [[35,145,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::transpose", "id": 1104, "rf_id": 845, "parent": 1103, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::transpose.int(Tensor(a) self, int dim0, int dim1) -> Tensor(a)",
+      "inputs": [[34,145,0,1048576,4,"cuda:0"],0,1], "input_shapes": [[1024,1024],[],[]], "input_types": ["Tensor(float)","Int","Int"],
+      "outputs": [[35,145,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::t", "id": 1103, "rf_id": 844, "parent": 1094, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::t(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[34,145,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[35,145,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "AddmmBackward0", "id": 1094, "rf_id": 835, "parent": 1093, "fw_parent": 2, "seq_id": 664, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[81,175,0,524288,4,"cuda:0"]], "input_shapes": [[512,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::sum", "id": 1106, "rf_id": 847, "parent": 1093, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::sum.dim_IntList(Tensor self, int[1]? dim, bool keepdim=False, *, ScalarType? dtype=None) -> Tensor",
+      "inputs": [[81,175,0,524288,4,"cuda:0"],[0],true,"<None>"], "input_shapes": [[512,1024],[[]],[],[]], "input_types": ["Tensor(float)","GenericList[Int]","Bool","None"],
+      "outputs": [[66,17,0,1024,4,"cuda:0"]], "output_shapes": [[1,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::view", "id": 1107, "rf_id": 848, "parent": 1093, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::view(Tensor(a) self, SymInt[] size) -> Tensor(a)",
+      "inputs": [[66,17,0,1024,4,"cuda:0"],[1024]], "input_shapes": [[1,1024],[[]]], "input_types": ["Tensor(float)","GenericList[Int]"],
+      "outputs": [[108,17,0,1024,4,"cuda:0"]], "output_shapes": [[1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "autograd::engine::evaluate_function: AddmmBackward0", "id": 1093, "rf_id": 834, "parent": 519, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::add_", "id": 1110, "rf_id": 851, "parent": 1109, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::add_.Tensor(Tensor(a!) self, Tensor other, *, Scalar alpha=1) -> Tensor(a!)",
+      "inputs": [[341,342,0,1024,4,"cuda:0"],[108,17,0,1024,4,"cuda:0"],1], "input_shapes": [[1024],[1024],[]], "input_types": ["Tensor(float)","Tensor(float)","Int"],
+      "outputs": [[341,342,0,1024,4,"cuda:0"]], "output_shapes": [[1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "torch::autograd::AccumulateGrad", "id": 1109, "rf_id": 850, "parent": 1108, "fw_parent": 2, "seq_id": -1, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[108,17,0,1024,4,"cuda:0"]], "input_shapes": [[1024]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: torch::autograd::AccumulateGrad", "id": 1108, "rf_id": 849, "parent": 519, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::as_strided", "id": 1115, "rf_id": 856, "parent": 1114, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::as_strided(Tensor(a) self, SymInt[] size, SymInt[] stride, SymInt? storage_offset=None) -> Tensor(a)",
+      "inputs": [[35,145,0,1048576,4,"cuda:0"],[1024,1024],[1024,1],"<None>"], "input_shapes": [[1024,1024],[[],[]],[[],[]],[]], "input_types": ["Tensor(float)","GenericList[Int,Int]","GenericList[Int,Int]","None"],
+      "outputs": [[108,145,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::transpose", "id": 1114, "rf_id": 855, "parent": 1113, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::transpose.int(Tensor(a) self, int dim0, int dim1) -> Tensor(a)",
+      "inputs": [[35,145,0,1048576,4,"cuda:0"],0,1], "input_shapes": [[1024,1024],[],[]], "input_types": ["Tensor(float)","Int","Int"],
+      "outputs": [[108,145,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::t", "id": 1113, "rf_id": 854, "parent": 1112, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::t(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[35,145,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[108,145,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "TBackward0", "id": 1112, "rf_id": 853, "parent": 1111, "fw_parent": 2, "seq_id": 663, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[35,145,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: TBackward0", "id": 1111, "rf_id": 852, "parent": 519, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::add_", "id": 1118, "rf_id": 859, "parent": 1117, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::add_.Tensor(Tensor(a!) self, Tensor other, *, Scalar alpha=1) -> Tensor(a!)",
+      "inputs": [[337,338,0,1048576,4,"cuda:0"],[108,145,0,1048576,4,"cuda:0"],1], "input_shapes": [[1024,1024],[1024,1024],[]], "input_types": ["Tensor(float)","Tensor(float)","Int"],
+      "outputs": [[337,338,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "torch::autograd::AccumulateGrad", "id": 1117, "rf_id": 858, "parent": 1116, "fw_parent": 2, "seq_id": -1, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[108,145,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: torch::autograd::AccumulateGrad", "id": 1116, "rf_id": 857, "parent": 519, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::threshold_backward", "id": 1121, "rf_id": 862, "parent": 1120, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::threshold_backward(Tensor grad_output, Tensor self, Scalar threshold) -> Tensor",
+      "inputs": [[62,190,0,524288,4,"cuda:0"],[35,23,0,524288,4,"cuda:0"],0], "input_shapes": [[512,1024],[512,1024],[]], "input_types": ["Tensor(float)","Tensor(float)","Int"],
+      "outputs": [[66,175,0,524288,4,"cuda:0"]], "output_shapes": [[512,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "ReluBackward0", "id": 1120, "rf_id": 861, "parent": 1119, "fw_parent": 2, "seq_id": 662, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[62,190,0,524288,4,"cuda:0"]], "input_shapes": [[512,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: ReluBackward0", "id": 1119, "rf_id": 860, "parent": 519, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::as_strided", "id": 1126, "rf_id": 867, "parent": 1125, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::as_strided(Tensor(a) self, SymInt[] size, SymInt[] stride, SymInt? storage_offset=None) -> Tensor(a)",
+      "inputs": [[66,175,0,524288,4,"cuda:0"],[1024,512],[1,1024],"<None>"], "input_shapes": [[512,1024],[[],[]],[[],[]],[]], "input_types": ["Tensor(float)","GenericList[Int,Int]","GenericList[Int,Int]","None"],
+      "outputs": [[62,175,0,524288,4,"cuda:0"]], "output_shapes": [[1024,512]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::transpose", "id": 1125, "rf_id": 866, "parent": 1124, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::transpose.int(Tensor(a) self, int dim0, int dim1) -> Tensor(a)",
+      "inputs": [[66,175,0,524288,4,"cuda:0"],0,1], "input_shapes": [[512,1024],[],[]], "input_types": ["Tensor(float)","Int","Int"],
+      "outputs": [[62,175,0,524288,4,"cuda:0"]], "output_shapes": [[1024,512]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::t", "id": 1124, "rf_id": 865, "parent": 1123, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::t(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[66,175,0,524288,4,"cuda:0"]], "input_shapes": [[512,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[62,175,0,524288,4,"cuda:0"]], "output_shapes": [[1024,512]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::mm", "id": 1127, "rf_id": 868, "parent": 1123, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::mm(Tensor self, Tensor mat2) -> Tensor",
+      "inputs": [[62,175,0,524288,4,"cuda:0"],[3,4,0,524288,4,"cuda:0"]], "input_shapes": [[1024,512],[512,1024]], "input_types": ["Tensor(float)","Tensor(float)"],
+      "outputs": [[35,145,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::as_strided", "id": 1130, "rf_id": 871, "parent": 1129, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::as_strided(Tensor(a) self, SymInt[] size, SymInt[] stride, SymInt? storage_offset=None) -> Tensor(a)",
+      "inputs": [[35,145,0,1048576,4,"cuda:0"],[1024,1024],[1,1024],"<None>"], "input_shapes": [[1024,1024],[[],[]],[[],[]],[]], "input_types": ["Tensor(float)","GenericList[Int,Int]","GenericList[Int,Int]","None"],
+      "outputs": [[22,145,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::transpose", "id": 1129, "rf_id": 870, "parent": 1128, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::transpose.int(Tensor(a) self, int dim0, int dim1) -> Tensor(a)",
+      "inputs": [[35,145,0,1048576,4,"cuda:0"],0,1], "input_shapes": [[1024,1024],[],[]], "input_types": ["Tensor(float)","Int","Int"],
+      "outputs": [[22,145,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::t", "id": 1128, "rf_id": 869, "parent": 1123, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::t(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[35,145,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[22,145,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "AddmmBackward0", "id": 1123, "rf_id": 864, "parent": 1122, "fw_parent": 2, "seq_id": 661, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[66,175,0,524288,4,"cuda:0"]], "input_shapes": [[512,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::sum", "id": 1131, "rf_id": 872, "parent": 1122, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::sum.dim_IntList(Tensor self, int[1]? dim, bool keepdim=False, *, ScalarType? dtype=None) -> Tensor",
+      "inputs": [[66,175,0,524288,4,"cuda:0"],[0],true,"<None>"], "input_shapes": [[512,1024],[[]],[],[]], "input_types": ["Tensor(float)","GenericList[Int]","Bool","None"],
+      "outputs": [[62,17,0,1024,4,"cuda:0"]], "output_shapes": [[1,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::view", "id": 1132, "rf_id": 873, "parent": 1122, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::view(Tensor(a) self, SymInt[] size) -> Tensor(a)",
+      "inputs": [[62,17,0,1024,4,"cuda:0"],[1024]], "input_shapes": [[1,1024],[[]]], "input_types": ["Tensor(float)","GenericList[Int]"],
+      "outputs": [[18,17,0,1024,4,"cuda:0"]], "output_shapes": [[1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "autograd::engine::evaluate_function: AddmmBackward0", "id": 1122, "rf_id": 863, "parent": 519, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::add_", "id": 1135, "rf_id": 876, "parent": 1134, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::add_.Tensor(Tensor(a!) self, Tensor other, *, Scalar alpha=1) -> Tensor(a!)",
+      "inputs": [[333,334,0,1024,4,"cuda:0"],[18,17,0,1024,4,"cuda:0"],1], "input_shapes": [[1024],[1024],[]], "input_types": ["Tensor(float)","Tensor(float)","Int"],
+      "outputs": [[333,334,0,1024,4,"cuda:0"]], "output_shapes": [[1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "torch::autograd::AccumulateGrad", "id": 1134, "rf_id": 875, "parent": 1133, "fw_parent": 2, "seq_id": -1, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[18,17,0,1024,4,"cuda:0"]], "input_shapes": [[1024]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: torch::autograd::AccumulateGrad", "id": 1133, "rf_id": 874, "parent": 519, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::as_strided", "id": 1140, "rf_id": 881, "parent": 1139, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::as_strided(Tensor(a) self, SymInt[] size, SymInt[] stride, SymInt? storage_offset=None) -> Tensor(a)",
+      "inputs": [[22,145,0,1048576,4,"cuda:0"],[1024,1024],[1024,1],"<None>"], "input_shapes": [[1024,1024],[[],[]],[[],[]],[]], "input_types": ["Tensor(float)","GenericList[Int,Int]","GenericList[Int,Int]","None"],
+      "outputs": [[18,145,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::transpose", "id": 1139, "rf_id": 880, "parent": 1138, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::transpose.int(Tensor(a) self, int dim0, int dim1) -> Tensor(a)",
+      "inputs": [[22,145,0,1048576,4,"cuda:0"],0,1], "input_shapes": [[1024,1024],[],[]], "input_types": ["Tensor(float)","Int","Int"],
+      "outputs": [[18,145,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::t", "id": 1138, "rf_id": 879, "parent": 1137, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::t(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[22,145,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [[18,145,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "TBackward0", "id": 1137, "rf_id": 878, "parent": 1136, "fw_parent": 2, "seq_id": 660, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[22,145,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: TBackward0", "id": 1136, "rf_id": 877, "parent": 519, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::add_", "id": 1143, "rf_id": 884, "parent": 1142, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::add_.Tensor(Tensor(a!) self, Tensor other, *, Scalar alpha=1) -> Tensor(a!)",
+      "inputs": [[329,330,0,1048576,4,"cuda:0"],[18,145,0,1048576,4,"cuda:0"],1], "input_shapes": [[1024,1024],[1024,1024],[]], "input_types": ["Tensor(float)","Tensor(float)","Int"],
+      "outputs": [[329,330,0,1048576,4,"cuda:0"]], "output_shapes": [[1024,1024]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "torch::autograd::AccumulateGrad", "id": 1142, "rf_id": 883, "parent": 1141, "fw_parent": 2, "seq_id": -1, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[18,145,0,1048576,4,"cuda:0"]], "input_shapes": [[1024,1024]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: torch::autograd::AccumulateGrad", "id": 1141, "rf_id": 882, "parent": 519, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::result_type", "id": 1146, "rf_id": 887, "parent": 1145, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[5,6,0,1048576,4,"cuda:0"],-0.010000], "input_shapes": [[1024,1024],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1147, "rf_id": 888, "parent": 1145, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[7,8,0,1024,4,"cuda:0"],-0.010000], "input_shapes": [[1024],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1148, "rf_id": 889, "parent": 1145, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[24,25,0,1048576,4,"cuda:0"],-0.010000], "input_shapes": [[1024,1024],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1149, "rf_id": 890, "parent": 1145, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[26,27,0,1024,4,"cuda:0"],-0.010000], "input_shapes": [[1024],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1150, "rf_id": 891, "parent": 1145, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[39,40,0,1048576,4,"cuda:0"],-0.010000], "input_shapes": [[1024,1024],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1151, "rf_id": 892, "parent": 1145, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[41,42,0,1024,4,"cuda:0"],-0.010000], "input_shapes": [[1024],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1152, "rf_id": 893, "parent": 1145, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[54,55,0,1048576,4,"cuda:0"],-0.010000], "input_shapes": [[1024,1024],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1153, "rf_id": 894, "parent": 1145, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[56,57,0,1024,4,"cuda:0"],-0.010000], "input_shapes": [[1024],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1154, "rf_id": 895, "parent": 1145, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[70,71,0,1048576,4,"cuda:0"],-0.010000], "input_shapes": [[1024,1024],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1155, "rf_id": 896, "parent": 1145, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[72,73,0,1024,4,"cuda:0"],-0.010000], "input_shapes": [[1024],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1156, "rf_id": 897, "parent": 1145, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[85,86,0,1048576,4,"cuda:0"],-0.010000], "input_shapes": [[1024,1024],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1157, "rf_id": 898, "parent": 1145, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[87,88,0,1024,4,"cuda:0"],-0.010000], "input_shapes": [[1024],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1158, "rf_id": 899, "parent": 1145, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[100,101,0,1048576,4,"cuda:0"],-0.010000], "input_shapes": [[1024,1024],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1159, "rf_id": 900, "parent": 1145, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[102,103,0,1024,4,"cuda:0"],-0.010000], "input_shapes": [[1024],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1160, "rf_id": 901, "parent": 1145, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[116,117,0,1048576,4,"cuda:0"],-0.010000], "input_shapes": [[1024,1024],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1161, "rf_id": 902, "parent": 1145, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[118,119,0,1024,4,"cuda:0"],-0.010000], "input_shapes": [[1024],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1162, "rf_id": 903, "parent": 1145, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[131,132,0,1048576,4,"cuda:0"],-0.010000], "input_shapes": [[1024,1024],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1163, "rf_id": 904, "parent": 1145, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[133,134,0,1024,4,"cuda:0"],-0.010000], "input_shapes": [[1024],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1164, "rf_id": 905, "parent": 1145, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[146,147,0,1048576,4,"cuda:0"],-0.010000], "input_shapes": [[1024,1024],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1165, "rf_id": 906, "parent": 1145, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[148,149,0,1024,4,"cuda:0"],-0.010000], "input_shapes": [[1024],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1166, "rf_id": 907, "parent": 1145, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[161,162,0,1048576,4,"cuda:0"],-0.010000], "input_shapes": [[1024,1024],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1167, "rf_id": 908, "parent": 1145, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[163,164,0,1024,4,"cuda:0"],-0.010000], "input_shapes": [[1024],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1168, "rf_id": 909, "parent": 1145, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[176,177,0,1048576,4,"cuda:0"],-0.010000], "input_shapes": [[1024,1024],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1169, "rf_id": 910, "parent": 1145, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[178,179,0,1024,4,"cuda:0"],-0.010000], "input_shapes": [[1024],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1170, "rf_id": 911, "parent": 1145, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[191,192,0,1048576,4,"cuda:0"],-0.010000], "input_shapes": [[1024,1024],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1171, "rf_id": 912, "parent": 1145, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[193,194,0,1024,4,"cuda:0"],-0.010000], "input_shapes": [[1024],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1172, "rf_id": 913, "parent": 1145, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[206,207,0,1048576,4,"cuda:0"],-0.010000], "input_shapes": [[1024,1024],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1173, "rf_id": 914, "parent": 1145, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[208,209,0,1024,4,"cuda:0"],-0.010000], "input_shapes": [[1024],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1174, "rf_id": 915, "parent": 1145, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[221,222,0,1048576,4,"cuda:0"],-0.010000], "input_shapes": [[1024,1024],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1175, "rf_id": 916, "parent": 1145, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[223,224,0,1024,4,"cuda:0"],-0.010000], "input_shapes": [[1024],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1176, "rf_id": 917, "parent": 1145, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[236,237,0,1048576,4,"cuda:0"],-0.010000], "input_shapes": [[1024,1024],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1177, "rf_id": 918, "parent": 1145, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[238,239,0,1024,4,"cuda:0"],-0.010000], "input_shapes": [[1024],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1178, "rf_id": 919, "parent": 1145, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[251,252,0,1048576,4,"cuda:0"],-0.010000], "input_shapes": [[1024,1024],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1179, "rf_id": 920, "parent": 1145, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[253,254,0,1024,4,"cuda:0"],-0.010000], "input_shapes": [[1024],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1180, "rf_id": 921, "parent": 1145, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[266,267,0,1048576,4,"cuda:0"],-0.010000], "input_shapes": [[1024,1024],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1181, "rf_id": 922, "parent": 1145, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[268,269,0,1024,4,"cuda:0"],-0.010000], "input_shapes": [[1024],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1182, "rf_id": 923, "parent": 1145, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[281,282,0,1048576,4,"cuda:0"],-0.010000], "input_shapes": [[1024,1024],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1183, "rf_id": 924, "parent": 1145, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[283,284,0,1024,4,"cuda:0"],-0.010000], "input_shapes": [[1024],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1184, "rf_id": 925, "parent": 1145, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[296,297,0,1048576,4,"cuda:0"],-0.010000], "input_shapes": [[1024,1024],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1185, "rf_id": 926, "parent": 1145, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[298,299,0,1024,4,"cuda:0"],-0.010000], "input_shapes": [[1024],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1186, "rf_id": 927, "parent": 1145, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[311,312,0,1048576,4,"cuda:0"],-0.010000], "input_shapes": [[1024,1024],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1187, "rf_id": 928, "parent": 1145, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[313,314,0,1024,4,"cuda:0"],-0.010000], "input_shapes": [[1024],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::_foreach_add_", "id": 1145, "rf_id": 886, "parent": 1144, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::_foreach_add_.List(Tensor(a!)[] self, Tensor[] other, *, Scalar alpha=1) -> ()",
+      "inputs": [[[5,6,0,1048576,4,"cuda:0"],[7,8,0,1024,4,"cuda:0"],[24,25,0,1048576,4,"cuda:0"],[26,27,0,1024,4,"cuda:0"],[39,40,0,1048576,4,"cuda:0"],[41,42,0,1024,4,"cuda:0"],[54,55,0,1048576,4,"cuda:0"],[56,57,0,1024,4,"cuda:0"],[70,71,0,1048576,4,"cuda:0"],[72,73,0,1024,4,"cuda:0"],[85,86,0,1048576,4,"cuda:0"],[87,88,0,1024,4,"cuda:0"],[100,101,0,1048576,4,"cuda:0"],[102,103,0,1024,4,"cuda:0"],[116,117,0,1048576,4,"cuda:0"],[118,119,0,1024,4,"cuda:0"],[131,132,0,1048576,4,"cuda:0"],[133,134,0,1024,4,"cuda:0"],[146,147,0,1048576,4,"cuda:0"],[148,149,0,1024,4,"cuda:0"],[161,162,0,1048576,4,"cuda:0"],[163,164,0,1024,4,"cuda:0"],[176,177,0,1048576,4,"cuda:0"],[178,179,0,1024,4,"cuda:0"],[191,192,0,1048576,4,"cuda:0"],[193,194,0,1024,4,"cuda:0"],[206,207,0,1048576,4,"cuda:0"],[208,209,0,1024,4,"cuda:0"],[221,222,0,1048576,4,"cuda:0"],[223,224,0,1024,4,"cuda:0"],[236,237,0,1048576,4,"cuda:0"],[238,239,0,1024,4,"cuda:0"],[251,252,0,1048576,4,"cuda:0"],[253,254,0,1024,4,"cuda:0"],[266,267,0,1048576,4,"cuda:0"],[268,269,0,1024,4,"cuda:0"],[281,282,0,1048576,4,"cuda:0"],[283,284,0,1024,4,"cuda:0"],[296,297,0,1048576,4,"cuda:0"],[298,299,0,1024,4,"cuda:0"],[311,312,0,1048576,4,"cuda:0"],[313,314,0,1024,4,"cuda:0"]],[[329,330,0,1048576,4,"cuda:0"],[333,334,0,1024,4,"cuda:0"],[337,338,0,1048576,4,"cuda:0"],[341,342,0,1024,4,"cuda:0"],[345,346,0,1048576,4,"cuda:0"],[349,350,0,1024,4,"cuda:0"],[353,354,0,1048576,4,"cuda:0"],[357,358,0,1024,4,"cuda:0"],[361,362,0,1048576,4,"cuda:0"],[365,366,0,1024,4,"cuda:0"],[369,370,0,1048576,4,"cuda:0"],[373,374,0,1024,4,"cuda:0"],[377,378,0,1048576,4,"cuda:0"],[381,382,0,1024,4,"cuda:0"],[385,386,0,1048576,4,"cuda:0"],[389,390,0,1024,4,"cuda:0"],[393,394,0,1048576,4,"cuda:0"],[397,398,0,1024,4,"cuda:0"],[401,402,0,1048576,4,"cuda:0"],[405,406,0,1024,4,"cuda:0"],[409,410,0,1048576,4,"cuda:0"],[413,414,0,1024,4,"cuda:0"],[417,418,0,1048576,4,"cuda:0"],[421,422,0,1024,4,"cuda:0"],[425,426,0,1048576,4,"cuda:0"],[429,430,0,1024,4,"cuda:0"],[433,434,0,1048576,4,"cuda:0"],[437,438,0,1024,4,"cuda:0"],[441,442,0,1048576,4,"cuda:0"],[445,446,0,1024,4,"cuda:0"],[449,450,0,1048576,4,"cuda:0"],[453,454,0,1024,4,"cuda:0"],[457,458,0,1048576,4,"cuda:0"],[461,462,0,1024,4,"cuda:0"],[465,466,0,1048576,4,"cuda:0"],[469,470,0,1024,4,"cuda:0"],[473,474,0,1048576,4,"cuda:0"],[477,478,0,1024,4,"cuda:0"],[481,482,0,1048576,4,"cuda:0"],[485,486,0,1024,4,"cuda:0"],[489,490,0,1048576,4,"cuda:0"],[493,494,0,1024,4,"cuda:0"]],-0.010000], "input_shapes": [[[1024,1024],[1024],[1024,1024],[1024],[1024,1024],[1024],[1024,1024],[1024],[1024,1024],[1024],[1024,1024],[1024],[1024,1024],[1024],[1024,1024],[1024],[1024,1024],[1024],[1024,1024],[1024],[1024,1024],[1024],[1024,1024],[1024],[1024,1024],[1024],[1024,1024],[1024],[1024,1024],[1024],[1024,1024],[1024],[1024,1024],[1024],[1024,1024],[1024],[1024,1024],[1024],[1024,1024],[1024],[1024,1024],[1024]],[[1024,1024],[1024],[1024,1024],[1024],[1024,1024],[1024],[1024,1024],[1024],[1024,1024],[1024],[1024,1024],[1024],[1024,1024],[1024],[1024,1024],[1024],[1024,1024],[1024],[1024,1024],[1024],[1024,1024],[1024],[1024,1024],[1024],[1024,1024],[1024],[1024,1024],[1024],[1024,1024],[1024],[1024,1024],[1024],[1024,1024],[1024],[1024,1024],[1024],[1024,1024],[1024],[1024,1024],[1024],[1024,1024],[1024]],[]], "input_types": ["GenericList[Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float)]","GenericList[Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float)]","Double"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "Optimizer.step#SGD.step", "id": 1144, "rf_id": 885, "parent": 2, "fw_parent": 0, "seq_id": -1, "scope": 7, "tid": 1, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "[pytorch|profiler|execution_graph|process]", "id": 1, "rf_id": 0, "parent": 1, "fw_parent": 0, "seq_id": -1, "scope": 7, "tid": 0, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    }
+  ],
+  "finish_ts": 69840401
+}

--- a/train/compute/python/test/data/resnet_et.json
+++ b/train/compute/python/test/data/resnet_et.json
@@ -1,0 +1,6571 @@
+{
+  "schema": "1.0.1", "pid": 23442, "time": "2023-07-12 12:33:16", "start_ts": 68988431,
+  "nodes": [
+    {
+      "name": "[pytorch|profiler|execution_graph|thread]", "id": 2, "rf_id": 0, "parent": 1, "fw_parent": 0, "seq_id": -1, "scope": 7, "tid": 1, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::empty_strided", "id": 7, "rf_id": 3, "parent": 6, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty_strided(SymInt[] size, SymInt[] stride, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor",
+      "inputs": [[128,3,224,224],[150528,50176,224,1],6,0,"cuda:0",false], "input_shapes": [[[],[],[],[]],[[],[],[],[]],[],[],[],[]], "input_types": ["GenericList[Int,Int,Int,Int]","GenericList[Int,Int,Int,Int]","Int","Int","Device","Bool"],
+      "outputs": [[8,9,0,19267584,4,"cuda:0"]], "output_shapes": [[128,3,224,224]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::copy_", "id": 10, "rf_id": 4, "parent": 6, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::copy_(Tensor(a!) self, Tensor src, bool non_blocking=False) -> Tensor(a!)",
+      "inputs": [[8,9,0,19267584,4,"cuda:0"],[3,4,0,19267584,4,"cpu"],false], "input_shapes": [[128,3,224,224],[128,3,224,224],[]], "input_types": ["Tensor(float)","Tensor(float)","Bool"],
+      "outputs": [[8,9,0,19267584,4,"cuda:0"]], "output_shapes": [[128,3,224,224]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::_to_copy", "id": 6, "rf_id": 2, "parent": 5, "fw_parent": 0, "seq_id": 730, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::_to_copy(Tensor self, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, bool non_blocking=False, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[3,4,0,19267584,4,"cpu"],6,0,"cuda:0","<None>",false,"<None>"], "input_shapes": [[128,3,224,224],[],[],[],[],[],[]], "input_types": ["Tensor(float)","Int","Int","Device","None","Bool","None"],
+      "outputs": [[8,9,0,19267584,4,"cuda:0"]], "output_shapes": [[128,3,224,224]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::to", "id": 5, "rf_id": 1, "parent": 2, "fw_parent": 0, "seq_id": 730, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::to.dtype_layout(Tensor(a) self, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, bool non_blocking=False, bool copy=False, MemoryFormat? memory_format=None) -> Tensor(a)",
+      "inputs": [[3,4,0,19267584,4,"cpu"],6,0,"cuda:0","<None>",false,false,"<None>"], "input_shapes": [[128,3,224,224],[],[],[],[],[],[],[]], "input_types": ["Tensor(float)","Int","Int","Device","None","Bool","Bool","None"],
+      "outputs": [[8,9,0,19267584,4,"cuda:0"]], "output_shapes": [[128,3,224,224]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty_strided", "id": 15, "rf_id": 7, "parent": 14, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty_strided(SymInt[] size, SymInt[] stride, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor",
+      "inputs": [[128],[1],4,0,"cuda:0",false], "input_shapes": [[[]],[[]],[],[],[],[]], "input_types": ["GenericList[Int]","GenericList[Int]","Int","Int","Device","Bool"],
+      "outputs": [[16,17,0,128,8,"cuda:0"]], "output_shapes": [[128]], "output_types": ["Tensor(long int)"]
+    },
+    {
+      "name": "aten::copy_", "id": 18, "rf_id": 8, "parent": 14, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::copy_(Tensor(a!) self, Tensor src, bool non_blocking=False) -> Tensor(a!)",
+      "inputs": [[16,17,0,128,8,"cuda:0"],[11,12,0,128,8,"cpu"],false], "input_shapes": [[128],[128],[]], "input_types": ["Tensor(long int)","Tensor(long int)","Bool"],
+      "outputs": [[16,17,0,128,8,"cuda:0"]], "output_shapes": [[128]], "output_types": ["Tensor(long int)"]
+    },
+    {
+      "name": "aten::_to_copy", "id": 14, "rf_id": 6, "parent": 13, "fw_parent": 0, "seq_id": 730, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::_to_copy(Tensor self, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, bool non_blocking=False, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[11,12,0,128,8,"cpu"],4,0,"cuda:0","<None>",false,"<None>"], "input_shapes": [[128],[],[],[],[],[],[]], "input_types": ["Tensor(long int)","Int","Int","Device","None","Bool","None"],
+      "outputs": [[16,17,0,128,8,"cuda:0"]], "output_shapes": [[128]], "output_types": ["Tensor(long int)"]
+    },
+    {
+      "name": "aten::to", "id": 13, "rf_id": 5, "parent": 2, "fw_parent": 0, "seq_id": 730, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::to.dtype_layout(Tensor(a) self, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, bool non_blocking=False, bool copy=False, MemoryFormat? memory_format=None) -> Tensor(a)",
+      "inputs": [[11,12,0,128,8,"cpu"],4,0,"cuda:0","<None>",false,false,"<None>"], "input_shapes": [[128],[],[],[],[],[],[],[]], "input_types": ["Tensor(long int)","Int","Int","Device","None","Bool","Bool","None"],
+      "outputs": [[16,17,0,128,8,"cuda:0"]], "output_shapes": [[128]], "output_types": ["Tensor(long int)"]
+    },
+    {
+      "name": "Optimizer.zero_grad#SGD.zero_grad", "id": 19, "rf_id": 9, "parent": 2, "fw_parent": 0, "seq_id": -1, "scope": 7, "tid": 1, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::cudnn_convolution", "id": 26, "rf_id": 13, "parent": 25, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::cudnn_convolution(Tensor self, Tensor weight, int[] padding, int[] stride, int[] dilation, int groups, bool benchmark, bool deterministic, bool allow_tf32) -> Tensor",
+      "inputs": [[8,9,0,19267584,4,"cuda:0"],[20,21,0,9408,4,"cuda:0"],[3,3],[2,2],[1,1],1,false,false,true], "input_shapes": [[128,3,224,224],[64,3,7,7],[[],[]],[[],[]],[[],[]],[],[],[],[]], "input_types": ["Tensor(float)","Tensor(float)","GenericList[Int,Int]","GenericList[Int,Int]","GenericList[Int,Int]","Int","Bool","Bool","Bool"],
+      "outputs": [[27,28,0,102760448,4,"cuda:0"]], "output_shapes": [[128,64,112,112]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::_convolution", "id": 25, "rf_id": 12, "parent": 24, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::_convolution(Tensor input, Tensor weight, Tensor? bias, int[] stride, SymInt[] padding, int[] dilation, bool transposed, SymInt[] output_padding, int groups, bool benchmark, bool deterministic, bool cudnn_enabled, bool allow_tf32) -> Tensor",
+      "inputs": [[8,9,0,19267584,4,"cuda:0"],[20,21,0,9408,4,"cuda:0"],[23,0,0,0,0,""],[2,2],[3,3],[1,1],false,[0,0],1,false,false,true,true], "input_shapes": [[128,3,224,224],[64,3,7,7],[],[[],[]],[[],[]],[[],[]],[],[[],[]],[],[],[],[],[]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(nullptr (uninitialized))","GenericList[Int,Int]","GenericList[Int,Int]","GenericList[Int,Int]","Bool","GenericList[Int,Int]","Int","Bool","Bool","Bool","Bool"],
+      "outputs": [[27,28,0,102760448,4,"cuda:0"]], "output_shapes": [[128,64,112,112]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::convolution", "id": 24, "rf_id": 11, "parent": 22, "fw_parent": 0, "seq_id": 730, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::convolution(Tensor input, Tensor weight, Tensor? bias, int[] stride, SymInt[] padding, int[] dilation, bool transposed, SymInt[] output_padding, int groups) -> Tensor",
+      "inputs": [[8,9,0,19267584,4,"cuda:0"],[20,21,0,9408,4,"cuda:0"],[23,0,0,0,0,""],[2,2],[3,3],[1,1],false,[0,0],1], "input_shapes": [[128,3,224,224],[64,3,7,7],[],[[],[]],[[],[]],[[],[]],[],[[],[]],[]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(nullptr (uninitialized))","GenericList[Int,Int]","GenericList[Int,Int]","GenericList[Int,Int]","Bool","GenericList[Int,Int]","Int"],
+      "outputs": [[27,28,0,102760448,4,"cuda:0"]], "output_shapes": [[128,64,112,112]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::conv2d", "id": 22, "rf_id": 10, "parent": 2, "fw_parent": 0, "seq_id": 730, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::conv2d(Tensor input, Tensor weight, Tensor? bias=None, int[2] stride=1, int[2] padding=0, int[2] dilation=1, int groups=1) -> Tensor",
+      "inputs": [[8,9,0,19267584,4,"cuda:0"],[20,21,0,9408,4,"cuda:0"],"<None>",[2,2],[3,3],[1,1],1], "input_shapes": [[128,3,224,224],[64,3,7,7],[],[[],[]],[[],[]],[[],[]],[]], "input_types": ["Tensor(float)","Tensor(float)","None","GenericList[Int,Int]","GenericList[Int,Int]","GenericList[Int,Int]","Int"],
+      "outputs": [[27,28,0,102760448,4,"cuda:0"]], "output_shapes": [[128,64,112,112]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::add_", "id": 33, "rf_id": 14, "parent": 2, "fw_parent": 0, "seq_id": 731, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::add_.Tensor(Tensor(a!) self, Tensor other, *, Scalar alpha=1) -> Tensor(a!)",
+      "inputs": [[29,30,0,1,8,"cuda:0"],[31,32,0,1,8,"cpu"],1], "input_shapes": [[],[],[]], "input_types": ["Tensor(long int)","Tensor(long int)","Int"],
+      "outputs": [[29,30,0,1,8,"cuda:0"]], "output_shapes": [[]], "output_types": ["Tensor(long int)"]
+    },
+    {
+      "name": "aten::empty", "id": 46, "rf_id": 19, "parent": 45, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[128,64,112,112],6,0,"cuda:0","<None>",0], "input_shapes": [[[],[],[],[]],[],[],[],[],[]], "input_types": ["GenericList[Int,Int,Int,Int]","Int","Int","Device","None","Int"],
+      "outputs": [[31,47,0,102760448,4,"cuda:0"]], "output_shapes": [[128,64,112,112]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty_like", "id": 45, "rf_id": 18, "parent": 44, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty_like(Tensor self, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[27,28,0,102760448,4,"cuda:0"],6,0,"cuda:0","<None>",0], "input_shapes": [[128,64,112,112],[],[],[],[],[]], "input_types": ["Tensor(float)","Int","Int","Device","None","Int"],
+      "outputs": [[31,47,0,102760448,4,"cuda:0"]], "output_shapes": [[128,64,112,112]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::view", "id": 48, "rf_id": 20, "parent": 44, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::view(Tensor(a) self, SymInt[] size) -> Tensor(a)",
+      "inputs": [[34,35,0,64,4,"cuda:0"],[1,64,1,1]], "input_shapes": [[64],[[],[],[],[]]], "input_types": ["Tensor(float)","GenericList[Int,Int,Int,Int]"],
+      "outputs": [[49,35,0,64,4,"cuda:0"]], "output_shapes": [[1,64,1,1]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty", "id": 50, "rf_id": 21, "parent": 44, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[64],6,0,"cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","Int","Device","None","None"],
+      "outputs": [[49,51,0,64,4,"cuda:0"]], "output_shapes": [[64]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty", "id": 52, "rf_id": 22, "parent": 44, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[64],6,0,"cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","Int","Device","None","None"],
+      "outputs": [[53,54,0,64,4,"cuda:0"]], "output_shapes": [[64]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty", "id": 55, "rf_id": 23, "parent": 44, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[0],0,0,"cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","Int","Device","None","None"],
+      "outputs": [[56,57,0,0,1,"cuda:0"]], "output_shapes": [[0]], "output_types": ["Tensor(unsigned char)"]
+    },
+    {
+      "name": "aten::empty", "id": 58, "rf_id": 24, "parent": 44, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[0],0,0,"cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","Int","Device","None","None"],
+      "outputs": [[59,57,0,0,1,"cuda:0"]], "output_shapes": [[0]], "output_types": ["Tensor(unsigned char)"]
+    },
+    {
+      "name": "aten::cudnn_batch_norm", "id": 44, "rf_id": 17, "parent": 43, "fw_parent": 0, "seq_id": 731, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::cudnn_batch_norm(Tensor input, Tensor weight, Tensor? bias, Tensor? running_mean, Tensor? running_var, bool training, float exponential_average_factor, float epsilon) -> (Tensor, Tensor, Tensor, Tensor)",
+      "inputs": [[27,28,0,102760448,4,"cuda:0"],[34,35,0,64,4,"cuda:0"],[36,37,0,64,4,"cuda:0"],[38,39,0,64,4,"cuda:0"],[40,41,0,64,4,"cuda:0"],true,0.100000,0.000010], "input_shapes": [[128,64,112,112],[64],[64],[64],[64],[],[],[]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Bool","Double","Double"],
+      "outputs": [[31,47,0,102760448,4,"cuda:0"],[49,51,0,64,4,"cuda:0"],[53,54,0,64,4,"cuda:0"],[59,57,0,0,1,"cuda:0"]], "output_shapes": [[128,64,112,112],[64],[64],[0]], "output_types": ["Tensor(float)","Tensor(float)","Tensor(float)","Tensor(unsigned char)"]
+    },
+    {
+      "name": "aten::_batch_norm_impl_index", "id": 43, "rf_id": 16, "parent": 42, "fw_parent": 0, "seq_id": 731, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::_batch_norm_impl_index(Tensor input, Tensor? weight, Tensor? bias, Tensor? running_mean, Tensor? running_var, bool training, float momentum, float eps, bool cudnn_enabled) -> (Tensor, Tensor, Tensor, Tensor, int)",
+      "inputs": [[27,28,0,102760448,4,"cuda:0"],[34,35,0,64,4,"cuda:0"],[36,37,0,64,4,"cuda:0"],[38,39,0,64,4,"cuda:0"],[40,41,0,64,4,"cuda:0"],true,0.100000,0.000010,true], "input_shapes": [[128,64,112,112],[64],[64],[64],[64],[],[],[],[]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Bool","Double","Double","Bool"],
+      "outputs": [[31,47,0,102760448,4,"cuda:0"],[49,51,0,64,4,"cuda:0"],[53,54,0,64,4,"cuda:0"],[59,57,0,0,1,"cuda:0"],1], "output_shapes": [[128,64,112,112],[64],[64],[0],[]], "output_types": ["Tensor(float)","Tensor(float)","Tensor(float)","Tensor(unsigned char)","Int"]
+    },
+    {
+      "name": "aten::batch_norm", "id": 42, "rf_id": 15, "parent": 2, "fw_parent": 0, "seq_id": 731, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::batch_norm(Tensor input, Tensor? weight, Tensor? bias, Tensor? running_mean, Tensor? running_var, bool training, float momentum, float eps, bool cudnn_enabled) -> Tensor",
+      "inputs": [[27,28,0,102760448,4,"cuda:0"],[34,35,0,64,4,"cuda:0"],[36,37,0,64,4,"cuda:0"],[38,39,0,64,4,"cuda:0"],[40,41,0,64,4,"cuda:0"],true,0.100000,0.000010,true], "input_shapes": [[128,64,112,112],[64],[64],[64],[64],[],[],[],[]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Bool","Double","Double","Bool"],
+      "outputs": [[31,47,0,102760448,4,"cuda:0"]], "output_shapes": [[128,64,112,112]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::clamp_min_", "id": 61, "rf_id": 26, "parent": 60, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::clamp_min_(Tensor(a!) self, Scalar min) -> Tensor(a!)",
+      "inputs": [[31,47,0,102760448,4,"cuda:0"],0], "input_shapes": [[128,64,112,112],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [[31,47,0,102760448,4,"cuda:0"]], "output_shapes": [[128,64,112,112]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::relu_", "id": 60, "rf_id": 25, "parent": 2, "fw_parent": 0, "seq_id": 732, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::relu_(Tensor(a!) self) -> Tensor(a!)",
+      "inputs": [[31,47,0,102760448,4,"cuda:0"]], "input_shapes": [[128,64,112,112]], "input_types": ["Tensor(float)"],
+      "outputs": [[31,47,0,102760448,4,"cuda:0"]], "output_shapes": [[128,64,112,112]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::max_pool2d_with_indices", "id": 63, "rf_id": 28, "parent": 62, "fw_parent": 0, "seq_id": 733, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::max_pool2d_with_indices(Tensor self, int[2] kernel_size, int[2] stride=[], int[2] padding=0, int[2] dilation=1, bool ceil_mode=False) -> (Tensor, Tensor)",
+      "inputs": [[31,47,0,102760448,4,"cuda:0"],[3,3],[2,2],[1,1],[1,1],false], "input_shapes": [[128,64,112,112],[[],[]],[[],[]],[[],[]],[[],[]],[]], "input_types": ["Tensor(float)","GenericList[Int,Int]","GenericList[Int,Int]","GenericList[Int,Int]","GenericList[Int,Int]","Bool"],
+      "outputs": [[56,64,0,25690112,4,"cuda:0"],[65,66,0,25690112,8,"cuda:0"]], "output_shapes": [[128,64,56,56],[128,64,56,56]], "output_types": ["Tensor(float)","Tensor(long int)"]
+    },
+    {
+      "name": "aten::max_pool2d", "id": 62, "rf_id": 27, "parent": 2, "fw_parent": 0, "seq_id": 733, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::max_pool2d(Tensor self, int[2] kernel_size, int[2] stride=[], int[2] padding=0, int[2] dilation=1, bool ceil_mode=False) -> Tensor",
+      "inputs": [[31,47,0,102760448,4,"cuda:0"],[3,3],[2,2],[1,1],[1,1],false], "input_shapes": [[128,64,112,112],[[],[]],[[],[]],[[],[]],[[],[]],[]], "input_types": ["Tensor(float)","GenericList[Int,Int]","GenericList[Int,Int]","GenericList[Int,Int]","GenericList[Int,Int]","Bool"],
+      "outputs": [[56,64,0,25690112,4,"cuda:0"]], "output_shapes": [[128,64,56,56]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::cudnn_convolution", "id": 72, "rf_id": 32, "parent": 71, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::cudnn_convolution(Tensor self, Tensor weight, int[] padding, int[] stride, int[] dilation, int groups, bool benchmark, bool deterministic, bool allow_tf32) -> Tensor",
+      "inputs": [[56,64,0,25690112,4,"cuda:0"],[67,68,0,36864,4,"cuda:0"],[1,1],[1,1],[1,1],1,false,false,true], "input_shapes": [[128,64,56,56],[64,64,3,3],[[],[]],[[],[]],[[],[]],[],[],[],[]], "input_types": ["Tensor(float)","Tensor(float)","GenericList[Int,Int]","GenericList[Int,Int]","GenericList[Int,Int]","Int","Bool","Bool","Bool"],
+      "outputs": [[73,74,0,25690112,4,"cuda:0"]], "output_shapes": [[128,64,56,56]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::_convolution", "id": 71, "rf_id": 31, "parent": 70, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::_convolution(Tensor input, Tensor weight, Tensor? bias, int[] stride, SymInt[] padding, int[] dilation, bool transposed, SymInt[] output_padding, int groups, bool benchmark, bool deterministic, bool cudnn_enabled, bool allow_tf32) -> Tensor",
+      "inputs": [[56,64,0,25690112,4,"cuda:0"],[67,68,0,36864,4,"cuda:0"],[23,0,0,0,0,""],[1,1],[1,1],[1,1],false,[0,0],1,false,false,true,true], "input_shapes": [[128,64,56,56],[64,64,3,3],[],[[],[]],[[],[]],[[],[]],[],[[],[]],[],[],[],[],[]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(nullptr (uninitialized))","GenericList[Int,Int]","GenericList[Int,Int]","GenericList[Int,Int]","Bool","GenericList[Int,Int]","Int","Bool","Bool","Bool","Bool"],
+      "outputs": [[73,74,0,25690112,4,"cuda:0"]], "output_shapes": [[128,64,56,56]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::convolution", "id": 70, "rf_id": 30, "parent": 69, "fw_parent": 0, "seq_id": 734, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::convolution(Tensor input, Tensor weight, Tensor? bias, int[] stride, SymInt[] padding, int[] dilation, bool transposed, SymInt[] output_padding, int groups) -> Tensor",
+      "inputs": [[56,64,0,25690112,4,"cuda:0"],[67,68,0,36864,4,"cuda:0"],[23,0,0,0,0,""],[1,1],[1,1],[1,1],false,[0,0],1], "input_shapes": [[128,64,56,56],[64,64,3,3],[],[[],[]],[[],[]],[[],[]],[],[[],[]],[]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(nullptr (uninitialized))","GenericList[Int,Int]","GenericList[Int,Int]","GenericList[Int,Int]","Bool","GenericList[Int,Int]","Int"],
+      "outputs": [[73,74,0,25690112,4,"cuda:0"]], "output_shapes": [[128,64,56,56]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::conv2d", "id": 69, "rf_id": 29, "parent": 2, "fw_parent": 0, "seq_id": 734, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::conv2d(Tensor input, Tensor weight, Tensor? bias=None, int[2] stride=1, int[2] padding=0, int[2] dilation=1, int groups=1) -> Tensor",
+      "inputs": [[56,64,0,25690112,4,"cuda:0"],[67,68,0,36864,4,"cuda:0"],"<None>",[1,1],[1,1],[1,1],1], "input_shapes": [[128,64,56,56],[64,64,3,3],[],[[],[]],[[],[]],[[],[]],[]], "input_types": ["Tensor(float)","Tensor(float)","None","GenericList[Int,Int]","GenericList[Int,Int]","GenericList[Int,Int]","Int"],
+      "outputs": [[73,74,0,25690112,4,"cuda:0"]], "output_shapes": [[128,64,56,56]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::add_", "id": 79, "rf_id": 33, "parent": 2, "fw_parent": 0, "seq_id": 735, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::add_.Tensor(Tensor(a!) self, Tensor other, *, Scalar alpha=1) -> Tensor(a!)",
+      "inputs": [[75,76,0,1,8,"cuda:0"],[77,78,0,1,8,"cpu"],1], "input_shapes": [[],[],[]], "input_types": ["Tensor(long int)","Tensor(long int)","Int"],
+      "outputs": [[75,76,0,1,8,"cuda:0"]], "output_shapes": [[]], "output_types": ["Tensor(long int)"]
+    },
+    {
+      "name": "aten::empty", "id": 92, "rf_id": 38, "parent": 91, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[128,64,56,56],6,0,"cuda:0","<None>",0], "input_shapes": [[[],[],[],[]],[],[],[],[],[]], "input_types": ["GenericList[Int,Int,Int,Int]","Int","Int","Device","None","Int"],
+      "outputs": [[77,93,0,25690112,4,"cuda:0"]], "output_shapes": [[128,64,56,56]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty_like", "id": 91, "rf_id": 37, "parent": 90, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty_like(Tensor self, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[73,74,0,25690112,4,"cuda:0"],6,0,"cuda:0","<None>",0], "input_shapes": [[128,64,56,56],[],[],[],[],[]], "input_types": ["Tensor(float)","Int","Int","Device","None","Int"],
+      "outputs": [[77,93,0,25690112,4,"cuda:0"]], "output_shapes": [[128,64,56,56]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::view", "id": 94, "rf_id": 39, "parent": 90, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::view(Tensor(a) self, SymInt[] size) -> Tensor(a)",
+      "inputs": [[80,81,0,64,4,"cuda:0"],[1,64,1,1]], "input_shapes": [[64],[[],[],[],[]]], "input_types": ["Tensor(float)","GenericList[Int,Int,Int,Int]"],
+      "outputs": [[95,81,0,64,4,"cuda:0"]], "output_shapes": [[1,64,1,1]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty", "id": 96, "rf_id": 40, "parent": 90, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[64],6,0,"cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","Int","Device","None","None"],
+      "outputs": [[95,97,0,64,4,"cuda:0"]], "output_shapes": [[64]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty", "id": 98, "rf_id": 41, "parent": 90, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[64],6,0,"cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","Int","Device","None","None"],
+      "outputs": [[99,100,0,64,4,"cuda:0"]], "output_shapes": [[64]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty", "id": 101, "rf_id": 42, "parent": 90, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[0],0,0,"cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","Int","Device","None","None"],
+      "outputs": [[102,57,0,0,1,"cuda:0"]], "output_shapes": [[0]], "output_types": ["Tensor(unsigned char)"]
+    },
+    {
+      "name": "aten::empty", "id": 103, "rf_id": 43, "parent": 90, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[0],0,0,"cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","Int","Device","None","None"],
+      "outputs": [[104,57,0,0,1,"cuda:0"]], "output_shapes": [[0]], "output_types": ["Tensor(unsigned char)"]
+    },
+    {
+      "name": "aten::cudnn_batch_norm", "id": 90, "rf_id": 36, "parent": 89, "fw_parent": 0, "seq_id": 735, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::cudnn_batch_norm(Tensor input, Tensor weight, Tensor? bias, Tensor? running_mean, Tensor? running_var, bool training, float exponential_average_factor, float epsilon) -> (Tensor, Tensor, Tensor, Tensor)",
+      "inputs": [[73,74,0,25690112,4,"cuda:0"],[80,81,0,64,4,"cuda:0"],[82,83,0,64,4,"cuda:0"],[84,85,0,64,4,"cuda:0"],[86,87,0,64,4,"cuda:0"],true,0.100000,0.000010], "input_shapes": [[128,64,56,56],[64],[64],[64],[64],[],[],[]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Bool","Double","Double"],
+      "outputs": [[77,93,0,25690112,4,"cuda:0"],[95,97,0,64,4,"cuda:0"],[99,100,0,64,4,"cuda:0"],[104,57,0,0,1,"cuda:0"]], "output_shapes": [[128,64,56,56],[64],[64],[0]], "output_types": ["Tensor(float)","Tensor(float)","Tensor(float)","Tensor(unsigned char)"]
+    },
+    {
+      "name": "aten::_batch_norm_impl_index", "id": 89, "rf_id": 35, "parent": 88, "fw_parent": 0, "seq_id": 735, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::_batch_norm_impl_index(Tensor input, Tensor? weight, Tensor? bias, Tensor? running_mean, Tensor? running_var, bool training, float momentum, float eps, bool cudnn_enabled) -> (Tensor, Tensor, Tensor, Tensor, int)",
+      "inputs": [[73,74,0,25690112,4,"cuda:0"],[80,81,0,64,4,"cuda:0"],[82,83,0,64,4,"cuda:0"],[84,85,0,64,4,"cuda:0"],[86,87,0,64,4,"cuda:0"],true,0.100000,0.000010,true], "input_shapes": [[128,64,56,56],[64],[64],[64],[64],[],[],[],[]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Bool","Double","Double","Bool"],
+      "outputs": [[77,93,0,25690112,4,"cuda:0"],[95,97,0,64,4,"cuda:0"],[99,100,0,64,4,"cuda:0"],[104,57,0,0,1,"cuda:0"],1], "output_shapes": [[128,64,56,56],[64],[64],[0],[]], "output_types": ["Tensor(float)","Tensor(float)","Tensor(float)","Tensor(unsigned char)","Int"]
+    },
+    {
+      "name": "aten::batch_norm", "id": 88, "rf_id": 34, "parent": 2, "fw_parent": 0, "seq_id": 735, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::batch_norm(Tensor input, Tensor? weight, Tensor? bias, Tensor? running_mean, Tensor? running_var, bool training, float momentum, float eps, bool cudnn_enabled) -> Tensor",
+      "inputs": [[73,74,0,25690112,4,"cuda:0"],[80,81,0,64,4,"cuda:0"],[82,83,0,64,4,"cuda:0"],[84,85,0,64,4,"cuda:0"],[86,87,0,64,4,"cuda:0"],true,0.100000,0.000010,true], "input_shapes": [[128,64,56,56],[64],[64],[64],[64],[],[],[],[]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Bool","Double","Double","Bool"],
+      "outputs": [[77,93,0,25690112,4,"cuda:0"]], "output_shapes": [[128,64,56,56]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::clamp_min_", "id": 106, "rf_id": 45, "parent": 105, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::clamp_min_(Tensor(a!) self, Scalar min) -> Tensor(a!)",
+      "inputs": [[77,93,0,25690112,4,"cuda:0"],0], "input_shapes": [[128,64,56,56],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [[77,93,0,25690112,4,"cuda:0"]], "output_shapes": [[128,64,56,56]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::relu_", "id": 105, "rf_id": 44, "parent": 2, "fw_parent": 0, "seq_id": 736, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::relu_(Tensor(a!) self) -> Tensor(a!)",
+      "inputs": [[77,93,0,25690112,4,"cuda:0"]], "input_shapes": [[128,64,56,56]], "input_types": ["Tensor(float)"],
+      "outputs": [[77,93,0,25690112,4,"cuda:0"]], "output_shapes": [[128,64,56,56]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::cudnn_convolution", "id": 112, "rf_id": 49, "parent": 111, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::cudnn_convolution(Tensor self, Tensor weight, int[] padding, int[] stride, int[] dilation, int groups, bool benchmark, bool deterministic, bool allow_tf32) -> Tensor",
+      "inputs": [[77,93,0,25690112,4,"cuda:0"],[107,108,0,36864,4,"cuda:0"],[1,1],[1,1],[1,1],1,false,false,true], "input_shapes": [[128,64,56,56],[64,64,3,3],[[],[]],[[],[]],[[],[]],[],[],[],[]], "input_types": ["Tensor(float)","Tensor(float)","GenericList[Int,Int]","GenericList[Int,Int]","GenericList[Int,Int]","Int","Bool","Bool","Bool"],
+      "outputs": [[102,113,0,25690112,4,"cuda:0"]], "output_shapes": [[128,64,56,56]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::_convolution", "id": 111, "rf_id": 48, "parent": 110, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::_convolution(Tensor input, Tensor weight, Tensor? bias, int[] stride, SymInt[] padding, int[] dilation, bool transposed, SymInt[] output_padding, int groups, bool benchmark, bool deterministic, bool cudnn_enabled, bool allow_tf32) -> Tensor",
+      "inputs": [[77,93,0,25690112,4,"cuda:0"],[107,108,0,36864,4,"cuda:0"],[23,0,0,0,0,""],[1,1],[1,1],[1,1],false,[0,0],1,false,false,true,true], "input_shapes": [[128,64,56,56],[64,64,3,3],[],[[],[]],[[],[]],[[],[]],[],[[],[]],[],[],[],[],[]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(nullptr (uninitialized))","GenericList[Int,Int]","GenericList[Int,Int]","GenericList[Int,Int]","Bool","GenericList[Int,Int]","Int","Bool","Bool","Bool","Bool"],
+      "outputs": [[102,113,0,25690112,4,"cuda:0"]], "output_shapes": [[128,64,56,56]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::convolution", "id": 110, "rf_id": 47, "parent": 109, "fw_parent": 0, "seq_id": 737, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::convolution(Tensor input, Tensor weight, Tensor? bias, int[] stride, SymInt[] padding, int[] dilation, bool transposed, SymInt[] output_padding, int groups) -> Tensor",
+      "inputs": [[77,93,0,25690112,4,"cuda:0"],[107,108,0,36864,4,"cuda:0"],[23,0,0,0,0,""],[1,1],[1,1],[1,1],false,[0,0],1], "input_shapes": [[128,64,56,56],[64,64,3,3],[],[[],[]],[[],[]],[[],[]],[],[[],[]],[]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(nullptr (uninitialized))","GenericList[Int,Int]","GenericList[Int,Int]","GenericList[Int,Int]","Bool","GenericList[Int,Int]","Int"],
+      "outputs": [[102,113,0,25690112,4,"cuda:0"]], "output_shapes": [[128,64,56,56]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::conv2d", "id": 109, "rf_id": 46, "parent": 2, "fw_parent": 0, "seq_id": 737, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::conv2d(Tensor input, Tensor weight, Tensor? bias=None, int[2] stride=1, int[2] padding=0, int[2] dilation=1, int groups=1) -> Tensor",
+      "inputs": [[77,93,0,25690112,4,"cuda:0"],[107,108,0,36864,4,"cuda:0"],"<None>",[1,1],[1,1],[1,1],1], "input_shapes": [[128,64,56,56],[64,64,3,3],[],[[],[]],[[],[]],[[],[]],[]], "input_types": ["Tensor(float)","Tensor(float)","None","GenericList[Int,Int]","GenericList[Int,Int]","GenericList[Int,Int]","Int"],
+      "outputs": [[102,113,0,25690112,4,"cuda:0"]], "output_shapes": [[128,64,56,56]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::add_", "id": 118, "rf_id": 50, "parent": 2, "fw_parent": 0, "seq_id": 738, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::add_.Tensor(Tensor(a!) self, Tensor other, *, Scalar alpha=1) -> Tensor(a!)",
+      "inputs": [[114,115,0,1,8,"cuda:0"],[116,117,0,1,8,"cpu"],1], "input_shapes": [[],[],[]], "input_types": ["Tensor(long int)","Tensor(long int)","Int"],
+      "outputs": [[114,115,0,1,8,"cuda:0"]], "output_shapes": [[]], "output_types": ["Tensor(long int)"]
+    },
+    {
+      "name": "aten::empty", "id": 131, "rf_id": 55, "parent": 130, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[128,64,56,56],6,0,"cuda:0","<None>",0], "input_shapes": [[[],[],[],[]],[],[],[],[],[]], "input_types": ["GenericList[Int,Int,Int,Int]","Int","Int","Device","None","Int"],
+      "outputs": [[116,132,0,25690112,4,"cuda:0"]], "output_shapes": [[128,64,56,56]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty_like", "id": 130, "rf_id": 54, "parent": 129, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty_like(Tensor self, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[102,113,0,25690112,4,"cuda:0"],6,0,"cuda:0","<None>",0], "input_shapes": [[128,64,56,56],[],[],[],[],[]], "input_types": ["Tensor(float)","Int","Int","Device","None","Int"],
+      "outputs": [[116,132,0,25690112,4,"cuda:0"]], "output_shapes": [[128,64,56,56]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::view", "id": 133, "rf_id": 56, "parent": 129, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::view(Tensor(a) self, SymInt[] size) -> Tensor(a)",
+      "inputs": [[119,120,0,64,4,"cuda:0"],[1,64,1,1]], "input_shapes": [[64],[[],[],[],[]]], "input_types": ["Tensor(float)","GenericList[Int,Int,Int,Int]"],
+      "outputs": [[134,120,0,64,4,"cuda:0"]], "output_shapes": [[1,64,1,1]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty", "id": 135, "rf_id": 57, "parent": 129, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[64],6,0,"cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","Int","Device","None","None"],
+      "outputs": [[134,136,0,64,4,"cuda:0"]], "output_shapes": [[64]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty", "id": 137, "rf_id": 58, "parent": 129, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[64],6,0,"cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","Int","Device","None","None"],
+      "outputs": [[138,139,0,64,4,"cuda:0"]], "output_shapes": [[64]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty", "id": 140, "rf_id": 59, "parent": 129, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[0],0,0,"cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","Int","Device","None","None"],
+      "outputs": [[141,57,0,0,1,"cuda:0"]], "output_shapes": [[0]], "output_types": ["Tensor(unsigned char)"]
+    },
+    {
+      "name": "aten::empty", "id": 142, "rf_id": 60, "parent": 129, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[0],0,0,"cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","Int","Device","None","None"],
+      "outputs": [[143,57,0,0,1,"cuda:0"]], "output_shapes": [[0]], "output_types": ["Tensor(unsigned char)"]
+    },
+    {
+      "name": "aten::cudnn_batch_norm", "id": 129, "rf_id": 53, "parent": 128, "fw_parent": 0, "seq_id": 738, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::cudnn_batch_norm(Tensor input, Tensor weight, Tensor? bias, Tensor? running_mean, Tensor? running_var, bool training, float exponential_average_factor, float epsilon) -> (Tensor, Tensor, Tensor, Tensor)",
+      "inputs": [[102,113,0,25690112,4,"cuda:0"],[119,120,0,64,4,"cuda:0"],[121,122,0,64,4,"cuda:0"],[123,124,0,64,4,"cuda:0"],[125,126,0,64,4,"cuda:0"],true,0.100000,0.000010], "input_shapes": [[128,64,56,56],[64],[64],[64],[64],[],[],[]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Bool","Double","Double"],
+      "outputs": [[116,132,0,25690112,4,"cuda:0"],[134,136,0,64,4,"cuda:0"],[138,139,0,64,4,"cuda:0"],[143,57,0,0,1,"cuda:0"]], "output_shapes": [[128,64,56,56],[64],[64],[0]], "output_types": ["Tensor(float)","Tensor(float)","Tensor(float)","Tensor(unsigned char)"]
+    },
+    {
+      "name": "aten::_batch_norm_impl_index", "id": 128, "rf_id": 52, "parent": 127, "fw_parent": 0, "seq_id": 738, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::_batch_norm_impl_index(Tensor input, Tensor? weight, Tensor? bias, Tensor? running_mean, Tensor? running_var, bool training, float momentum, float eps, bool cudnn_enabled) -> (Tensor, Tensor, Tensor, Tensor, int)",
+      "inputs": [[102,113,0,25690112,4,"cuda:0"],[119,120,0,64,4,"cuda:0"],[121,122,0,64,4,"cuda:0"],[123,124,0,64,4,"cuda:0"],[125,126,0,64,4,"cuda:0"],true,0.100000,0.000010,true], "input_shapes": [[128,64,56,56],[64],[64],[64],[64],[],[],[],[]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Bool","Double","Double","Bool"],
+      "outputs": [[116,132,0,25690112,4,"cuda:0"],[134,136,0,64,4,"cuda:0"],[138,139,0,64,4,"cuda:0"],[143,57,0,0,1,"cuda:0"],1], "output_shapes": [[128,64,56,56],[64],[64],[0],[]], "output_types": ["Tensor(float)","Tensor(float)","Tensor(float)","Tensor(unsigned char)","Int"]
+    },
+    {
+      "name": "aten::batch_norm", "id": 127, "rf_id": 51, "parent": 2, "fw_parent": 0, "seq_id": 738, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::batch_norm(Tensor input, Tensor? weight, Tensor? bias, Tensor? running_mean, Tensor? running_var, bool training, float momentum, float eps, bool cudnn_enabled) -> Tensor",
+      "inputs": [[102,113,0,25690112,4,"cuda:0"],[119,120,0,64,4,"cuda:0"],[121,122,0,64,4,"cuda:0"],[123,124,0,64,4,"cuda:0"],[125,126,0,64,4,"cuda:0"],true,0.100000,0.000010,true], "input_shapes": [[128,64,56,56],[64],[64],[64],[64],[],[],[],[]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Bool","Double","Double","Bool"],
+      "outputs": [[116,132,0,25690112,4,"cuda:0"]], "output_shapes": [[128,64,56,56]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::add_", "id": 144, "rf_id": 61, "parent": 2, "fw_parent": 0, "seq_id": 739, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::add_.Tensor(Tensor(a!) self, Tensor other, *, Scalar alpha=1) -> Tensor(a!)",
+      "inputs": [[116,132,0,25690112,4,"cuda:0"],[56,64,0,25690112,4,"cuda:0"],1], "input_shapes": [[128,64,56,56],[128,64,56,56],[]], "input_types": ["Tensor(float)","Tensor(float)","Int"],
+      "outputs": [[116,132,0,25690112,4,"cuda:0"]], "output_shapes": [[128,64,56,56]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::clamp_min_", "id": 146, "rf_id": 63, "parent": 145, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::clamp_min_(Tensor(a!) self, Scalar min) -> Tensor(a!)",
+      "inputs": [[116,132,0,25690112,4,"cuda:0"],0], "input_shapes": [[128,64,56,56],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [[116,132,0,25690112,4,"cuda:0"]], "output_shapes": [[128,64,56,56]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::relu_", "id": 145, "rf_id": 62, "parent": 2, "fw_parent": 0, "seq_id": 740, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::relu_(Tensor(a!) self) -> Tensor(a!)",
+      "inputs": [[116,132,0,25690112,4,"cuda:0"]], "input_shapes": [[128,64,56,56]], "input_types": ["Tensor(float)"],
+      "outputs": [[116,132,0,25690112,4,"cuda:0"]], "output_shapes": [[128,64,56,56]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::cudnn_convolution", "id": 152, "rf_id": 67, "parent": 151, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::cudnn_convolution(Tensor self, Tensor weight, int[] padding, int[] stride, int[] dilation, int groups, bool benchmark, bool deterministic, bool allow_tf32) -> Tensor",
+      "inputs": [[116,132,0,25690112,4,"cuda:0"],[147,148,0,36864,4,"cuda:0"],[1,1],[1,1],[1,1],1,false,false,true], "input_shapes": [[128,64,56,56],[64,64,3,3],[[],[]],[[],[]],[[],[]],[],[],[],[]], "input_types": ["Tensor(float)","Tensor(float)","GenericList[Int,Int]","GenericList[Int,Int]","GenericList[Int,Int]","Int","Bool","Bool","Bool"],
+      "outputs": [[141,153,0,25690112,4,"cuda:0"]], "output_shapes": [[128,64,56,56]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::_convolution", "id": 151, "rf_id": 66, "parent": 150, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::_convolution(Tensor input, Tensor weight, Tensor? bias, int[] stride, SymInt[] padding, int[] dilation, bool transposed, SymInt[] output_padding, int groups, bool benchmark, bool deterministic, bool cudnn_enabled, bool allow_tf32) -> Tensor",
+      "inputs": [[116,132,0,25690112,4,"cuda:0"],[147,148,0,36864,4,"cuda:0"],[23,0,0,0,0,""],[1,1],[1,1],[1,1],false,[0,0],1,false,false,true,true], "input_shapes": [[128,64,56,56],[64,64,3,3],[],[[],[]],[[],[]],[[],[]],[],[[],[]],[],[],[],[],[]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(nullptr (uninitialized))","GenericList[Int,Int]","GenericList[Int,Int]","GenericList[Int,Int]","Bool","GenericList[Int,Int]","Int","Bool","Bool","Bool","Bool"],
+      "outputs": [[141,153,0,25690112,4,"cuda:0"]], "output_shapes": [[128,64,56,56]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::convolution", "id": 150, "rf_id": 65, "parent": 149, "fw_parent": 0, "seq_id": 741, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::convolution(Tensor input, Tensor weight, Tensor? bias, int[] stride, SymInt[] padding, int[] dilation, bool transposed, SymInt[] output_padding, int groups) -> Tensor",
+      "inputs": [[116,132,0,25690112,4,"cuda:0"],[147,148,0,36864,4,"cuda:0"],[23,0,0,0,0,""],[1,1],[1,1],[1,1],false,[0,0],1], "input_shapes": [[128,64,56,56],[64,64,3,3],[],[[],[]],[[],[]],[[],[]],[],[[],[]],[]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(nullptr (uninitialized))","GenericList[Int,Int]","GenericList[Int,Int]","GenericList[Int,Int]","Bool","GenericList[Int,Int]","Int"],
+      "outputs": [[141,153,0,25690112,4,"cuda:0"]], "output_shapes": [[128,64,56,56]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::conv2d", "id": 149, "rf_id": 64, "parent": 2, "fw_parent": 0, "seq_id": 741, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::conv2d(Tensor input, Tensor weight, Tensor? bias=None, int[2] stride=1, int[2] padding=0, int[2] dilation=1, int groups=1) -> Tensor",
+      "inputs": [[116,132,0,25690112,4,"cuda:0"],[147,148,0,36864,4,"cuda:0"],"<None>",[1,1],[1,1],[1,1],1], "input_shapes": [[128,64,56,56],[64,64,3,3],[],[[],[]],[[],[]],[[],[]],[]], "input_types": ["Tensor(float)","Tensor(float)","None","GenericList[Int,Int]","GenericList[Int,Int]","GenericList[Int,Int]","Int"],
+      "outputs": [[141,153,0,25690112,4,"cuda:0"]], "output_shapes": [[128,64,56,56]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::add_", "id": 158, "rf_id": 68, "parent": 2, "fw_parent": 0, "seq_id": 742, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::add_.Tensor(Tensor(a!) self, Tensor other, *, Scalar alpha=1) -> Tensor(a!)",
+      "inputs": [[154,155,0,1,8,"cuda:0"],[156,157,0,1,8,"cpu"],1], "input_shapes": [[],[],[]], "input_types": ["Tensor(long int)","Tensor(long int)","Int"],
+      "outputs": [[154,155,0,1,8,"cuda:0"]], "output_shapes": [[]], "output_types": ["Tensor(long int)"]
+    },
+    {
+      "name": "aten::empty", "id": 171, "rf_id": 73, "parent": 170, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[128,64,56,56],6,0,"cuda:0","<None>",0], "input_shapes": [[[],[],[],[]],[],[],[],[],[]], "input_types": ["GenericList[Int,Int,Int,Int]","Int","Int","Device","None","Int"],
+      "outputs": [[156,172,0,25690112,4,"cuda:0"]], "output_shapes": [[128,64,56,56]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty_like", "id": 170, "rf_id": 72, "parent": 169, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty_like(Tensor self, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[141,153,0,25690112,4,"cuda:0"],6,0,"cuda:0","<None>",0], "input_shapes": [[128,64,56,56],[],[],[],[],[]], "input_types": ["Tensor(float)","Int","Int","Device","None","Int"],
+      "outputs": [[156,172,0,25690112,4,"cuda:0"]], "output_shapes": [[128,64,56,56]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::view", "id": 173, "rf_id": 74, "parent": 169, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::view(Tensor(a) self, SymInt[] size) -> Tensor(a)",
+      "inputs": [[159,160,0,64,4,"cuda:0"],[1,64,1,1]], "input_shapes": [[64],[[],[],[],[]]], "input_types": ["Tensor(float)","GenericList[Int,Int,Int,Int]"],
+      "outputs": [[174,160,0,64,4,"cuda:0"]], "output_shapes": [[1,64,1,1]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty", "id": 175, "rf_id": 75, "parent": 169, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[64],6,0,"cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","Int","Device","None","None"],
+      "outputs": [[174,176,0,64,4,"cuda:0"]], "output_shapes": [[64]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty", "id": 177, "rf_id": 76, "parent": 169, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[64],6,0,"cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","Int","Device","None","None"],
+      "outputs": [[178,179,0,64,4,"cuda:0"]], "output_shapes": [[64]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty", "id": 180, "rf_id": 77, "parent": 169, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[0],0,0,"cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","Int","Device","None","None"],
+      "outputs": [[181,57,0,0,1,"cuda:0"]], "output_shapes": [[0]], "output_types": ["Tensor(unsigned char)"]
+    },
+    {
+      "name": "aten::empty", "id": 182, "rf_id": 78, "parent": 169, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[0],0,0,"cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","Int","Device","None","None"],
+      "outputs": [[183,57,0,0,1,"cuda:0"]], "output_shapes": [[0]], "output_types": ["Tensor(unsigned char)"]
+    },
+    {
+      "name": "aten::cudnn_batch_norm", "id": 169, "rf_id": 71, "parent": 168, "fw_parent": 0, "seq_id": 742, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::cudnn_batch_norm(Tensor input, Tensor weight, Tensor? bias, Tensor? running_mean, Tensor? running_var, bool training, float exponential_average_factor, float epsilon) -> (Tensor, Tensor, Tensor, Tensor)",
+      "inputs": [[141,153,0,25690112,4,"cuda:0"],[159,160,0,64,4,"cuda:0"],[161,162,0,64,4,"cuda:0"],[163,164,0,64,4,"cuda:0"],[165,166,0,64,4,"cuda:0"],true,0.100000,0.000010], "input_shapes": [[128,64,56,56],[64],[64],[64],[64],[],[],[]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Bool","Double","Double"],
+      "outputs": [[156,172,0,25690112,4,"cuda:0"],[174,176,0,64,4,"cuda:0"],[178,179,0,64,4,"cuda:0"],[183,57,0,0,1,"cuda:0"]], "output_shapes": [[128,64,56,56],[64],[64],[0]], "output_types": ["Tensor(float)","Tensor(float)","Tensor(float)","Tensor(unsigned char)"]
+    },
+    {
+      "name": "aten::_batch_norm_impl_index", "id": 168, "rf_id": 70, "parent": 167, "fw_parent": 0, "seq_id": 742, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::_batch_norm_impl_index(Tensor input, Tensor? weight, Tensor? bias, Tensor? running_mean, Tensor? running_var, bool training, float momentum, float eps, bool cudnn_enabled) -> (Tensor, Tensor, Tensor, Tensor, int)",
+      "inputs": [[141,153,0,25690112,4,"cuda:0"],[159,160,0,64,4,"cuda:0"],[161,162,0,64,4,"cuda:0"],[163,164,0,64,4,"cuda:0"],[165,166,0,64,4,"cuda:0"],true,0.100000,0.000010,true], "input_shapes": [[128,64,56,56],[64],[64],[64],[64],[],[],[],[]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Bool","Double","Double","Bool"],
+      "outputs": [[156,172,0,25690112,4,"cuda:0"],[174,176,0,64,4,"cuda:0"],[178,179,0,64,4,"cuda:0"],[183,57,0,0,1,"cuda:0"],1], "output_shapes": [[128,64,56,56],[64],[64],[0],[]], "output_types": ["Tensor(float)","Tensor(float)","Tensor(float)","Tensor(unsigned char)","Int"]
+    },
+    {
+      "name": "aten::batch_norm", "id": 167, "rf_id": 69, "parent": 2, "fw_parent": 0, "seq_id": 742, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::batch_norm(Tensor input, Tensor? weight, Tensor? bias, Tensor? running_mean, Tensor? running_var, bool training, float momentum, float eps, bool cudnn_enabled) -> Tensor",
+      "inputs": [[141,153,0,25690112,4,"cuda:0"],[159,160,0,64,4,"cuda:0"],[161,162,0,64,4,"cuda:0"],[163,164,0,64,4,"cuda:0"],[165,166,0,64,4,"cuda:0"],true,0.100000,0.000010,true], "input_shapes": [[128,64,56,56],[64],[64],[64],[64],[],[],[],[]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Bool","Double","Double","Bool"],
+      "outputs": [[156,172,0,25690112,4,"cuda:0"]], "output_shapes": [[128,64,56,56]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::clamp_min_", "id": 185, "rf_id": 80, "parent": 184, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::clamp_min_(Tensor(a!) self, Scalar min) -> Tensor(a!)",
+      "inputs": [[156,172,0,25690112,4,"cuda:0"],0], "input_shapes": [[128,64,56,56],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [[156,172,0,25690112,4,"cuda:0"]], "output_shapes": [[128,64,56,56]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::relu_", "id": 184, "rf_id": 79, "parent": 2, "fw_parent": 0, "seq_id": 743, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::relu_(Tensor(a!) self) -> Tensor(a!)",
+      "inputs": [[156,172,0,25690112,4,"cuda:0"]], "input_shapes": [[128,64,56,56]], "input_types": ["Tensor(float)"],
+      "outputs": [[156,172,0,25690112,4,"cuda:0"]], "output_shapes": [[128,64,56,56]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::cudnn_convolution", "id": 191, "rf_id": 84, "parent": 190, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::cudnn_convolution(Tensor self, Tensor weight, int[] padding, int[] stride, int[] dilation, int groups, bool benchmark, bool deterministic, bool allow_tf32) -> Tensor",
+      "inputs": [[156,172,0,25690112,4,"cuda:0"],[186,187,0,36864,4,"cuda:0"],[1,1],[1,1],[1,1],1,false,false,true], "input_shapes": [[128,64,56,56],[64,64,3,3],[[],[]],[[],[]],[[],[]],[],[],[],[]], "input_types": ["Tensor(float)","Tensor(float)","GenericList[Int,Int]","GenericList[Int,Int]","GenericList[Int,Int]","Int","Bool","Bool","Bool"],
+      "outputs": [[181,192,0,25690112,4,"cuda:0"]], "output_shapes": [[128,64,56,56]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::_convolution", "id": 190, "rf_id": 83, "parent": 189, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::_convolution(Tensor input, Tensor weight, Tensor? bias, int[] stride, SymInt[] padding, int[] dilation, bool transposed, SymInt[] output_padding, int groups, bool benchmark, bool deterministic, bool cudnn_enabled, bool allow_tf32) -> Tensor",
+      "inputs": [[156,172,0,25690112,4,"cuda:0"],[186,187,0,36864,4,"cuda:0"],[23,0,0,0,0,""],[1,1],[1,1],[1,1],false,[0,0],1,false,false,true,true], "input_shapes": [[128,64,56,56],[64,64,3,3],[],[[],[]],[[],[]],[[],[]],[],[[],[]],[],[],[],[],[]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(nullptr (uninitialized))","GenericList[Int,Int]","GenericList[Int,Int]","GenericList[Int,Int]","Bool","GenericList[Int,Int]","Int","Bool","Bool","Bool","Bool"],
+      "outputs": [[181,192,0,25690112,4,"cuda:0"]], "output_shapes": [[128,64,56,56]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::convolution", "id": 189, "rf_id": 82, "parent": 188, "fw_parent": 0, "seq_id": 744, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::convolution(Tensor input, Tensor weight, Tensor? bias, int[] stride, SymInt[] padding, int[] dilation, bool transposed, SymInt[] output_padding, int groups) -> Tensor",
+      "inputs": [[156,172,0,25690112,4,"cuda:0"],[186,187,0,36864,4,"cuda:0"],[23,0,0,0,0,""],[1,1],[1,1],[1,1],false,[0,0],1], "input_shapes": [[128,64,56,56],[64,64,3,3],[],[[],[]],[[],[]],[[],[]],[],[[],[]],[]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(nullptr (uninitialized))","GenericList[Int,Int]","GenericList[Int,Int]","GenericList[Int,Int]","Bool","GenericList[Int,Int]","Int"],
+      "outputs": [[181,192,0,25690112,4,"cuda:0"]], "output_shapes": [[128,64,56,56]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::conv2d", "id": 188, "rf_id": 81, "parent": 2, "fw_parent": 0, "seq_id": 744, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::conv2d(Tensor input, Tensor weight, Tensor? bias=None, int[2] stride=1, int[2] padding=0, int[2] dilation=1, int groups=1) -> Tensor",
+      "inputs": [[156,172,0,25690112,4,"cuda:0"],[186,187,0,36864,4,"cuda:0"],"<None>",[1,1],[1,1],[1,1],1], "input_shapes": [[128,64,56,56],[64,64,3,3],[],[[],[]],[[],[]],[[],[]],[]], "input_types": ["Tensor(float)","Tensor(float)","None","GenericList[Int,Int]","GenericList[Int,Int]","GenericList[Int,Int]","Int"],
+      "outputs": [[181,192,0,25690112,4,"cuda:0"]], "output_shapes": [[128,64,56,56]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::add_", "id": 197, "rf_id": 85, "parent": 2, "fw_parent": 0, "seq_id": 745, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::add_.Tensor(Tensor(a!) self, Tensor other, *, Scalar alpha=1) -> Tensor(a!)",
+      "inputs": [[193,194,0,1,8,"cuda:0"],[195,196,0,1,8,"cpu"],1], "input_shapes": [[],[],[]], "input_types": ["Tensor(long int)","Tensor(long int)","Int"],
+      "outputs": [[193,194,0,1,8,"cuda:0"]], "output_shapes": [[]], "output_types": ["Tensor(long int)"]
+    },
+    {
+      "name": "aten::empty", "id": 210, "rf_id": 90, "parent": 209, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[128,64,56,56],6,0,"cuda:0","<None>",0], "input_shapes": [[[],[],[],[]],[],[],[],[],[]], "input_types": ["GenericList[Int,Int,Int,Int]","Int","Int","Device","None","Int"],
+      "outputs": [[195,211,0,25690112,4,"cuda:0"]], "output_shapes": [[128,64,56,56]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty_like", "id": 209, "rf_id": 89, "parent": 208, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty_like(Tensor self, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[181,192,0,25690112,4,"cuda:0"],6,0,"cuda:0","<None>",0], "input_shapes": [[128,64,56,56],[],[],[],[],[]], "input_types": ["Tensor(float)","Int","Int","Device","None","Int"],
+      "outputs": [[195,211,0,25690112,4,"cuda:0"]], "output_shapes": [[128,64,56,56]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::view", "id": 212, "rf_id": 91, "parent": 208, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::view(Tensor(a) self, SymInt[] size) -> Tensor(a)",
+      "inputs": [[198,199,0,64,4,"cuda:0"],[1,64,1,1]], "input_shapes": [[64],[[],[],[],[]]], "input_types": ["Tensor(float)","GenericList[Int,Int,Int,Int]"],
+      "outputs": [[213,199,0,64,4,"cuda:0"]], "output_shapes": [[1,64,1,1]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty", "id": 214, "rf_id": 92, "parent": 208, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[64],6,0,"cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","Int","Device","None","None"],
+      "outputs": [[213,215,0,64,4,"cuda:0"]], "output_shapes": [[64]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty", "id": 216, "rf_id": 93, "parent": 208, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[64],6,0,"cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","Int","Device","None","None"],
+      "outputs": [[217,218,0,64,4,"cuda:0"]], "output_shapes": [[64]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty", "id": 219, "rf_id": 94, "parent": 208, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[0],0,0,"cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","Int","Device","None","None"],
+      "outputs": [[220,57,0,0,1,"cuda:0"]], "output_shapes": [[0]], "output_types": ["Tensor(unsigned char)"]
+    },
+    {
+      "name": "aten::empty", "id": 221, "rf_id": 95, "parent": 208, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[0],0,0,"cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","Int","Device","None","None"],
+      "outputs": [[222,57,0,0,1,"cuda:0"]], "output_shapes": [[0]], "output_types": ["Tensor(unsigned char)"]
+    },
+    {
+      "name": "aten::cudnn_batch_norm", "id": 208, "rf_id": 88, "parent": 207, "fw_parent": 0, "seq_id": 745, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::cudnn_batch_norm(Tensor input, Tensor weight, Tensor? bias, Tensor? running_mean, Tensor? running_var, bool training, float exponential_average_factor, float epsilon) -> (Tensor, Tensor, Tensor, Tensor)",
+      "inputs": [[181,192,0,25690112,4,"cuda:0"],[198,199,0,64,4,"cuda:0"],[200,201,0,64,4,"cuda:0"],[202,203,0,64,4,"cuda:0"],[204,205,0,64,4,"cuda:0"],true,0.100000,0.000010], "input_shapes": [[128,64,56,56],[64],[64],[64],[64],[],[],[]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Bool","Double","Double"],
+      "outputs": [[195,211,0,25690112,4,"cuda:0"],[213,215,0,64,4,"cuda:0"],[217,218,0,64,4,"cuda:0"],[222,57,0,0,1,"cuda:0"]], "output_shapes": [[128,64,56,56],[64],[64],[0]], "output_types": ["Tensor(float)","Tensor(float)","Tensor(float)","Tensor(unsigned char)"]
+    },
+    {
+      "name": "aten::_batch_norm_impl_index", "id": 207, "rf_id": 87, "parent": 206, "fw_parent": 0, "seq_id": 745, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::_batch_norm_impl_index(Tensor input, Tensor? weight, Tensor? bias, Tensor? running_mean, Tensor? running_var, bool training, float momentum, float eps, bool cudnn_enabled) -> (Tensor, Tensor, Tensor, Tensor, int)",
+      "inputs": [[181,192,0,25690112,4,"cuda:0"],[198,199,0,64,4,"cuda:0"],[200,201,0,64,4,"cuda:0"],[202,203,0,64,4,"cuda:0"],[204,205,0,64,4,"cuda:0"],true,0.100000,0.000010,true], "input_shapes": [[128,64,56,56],[64],[64],[64],[64],[],[],[],[]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Bool","Double","Double","Bool"],
+      "outputs": [[195,211,0,25690112,4,"cuda:0"],[213,215,0,64,4,"cuda:0"],[217,218,0,64,4,"cuda:0"],[222,57,0,0,1,"cuda:0"],1], "output_shapes": [[128,64,56,56],[64],[64],[0],[]], "output_types": ["Tensor(float)","Tensor(float)","Tensor(float)","Tensor(unsigned char)","Int"]
+    },
+    {
+      "name": "aten::batch_norm", "id": 206, "rf_id": 86, "parent": 2, "fw_parent": 0, "seq_id": 745, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::batch_norm(Tensor input, Tensor? weight, Tensor? bias, Tensor? running_mean, Tensor? running_var, bool training, float momentum, float eps, bool cudnn_enabled) -> Tensor",
+      "inputs": [[181,192,0,25690112,4,"cuda:0"],[198,199,0,64,4,"cuda:0"],[200,201,0,64,4,"cuda:0"],[202,203,0,64,4,"cuda:0"],[204,205,0,64,4,"cuda:0"],true,0.100000,0.000010,true], "input_shapes": [[128,64,56,56],[64],[64],[64],[64],[],[],[],[]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Bool","Double","Double","Bool"],
+      "outputs": [[195,211,0,25690112,4,"cuda:0"]], "output_shapes": [[128,64,56,56]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::add_", "id": 223, "rf_id": 96, "parent": 2, "fw_parent": 0, "seq_id": 746, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::add_.Tensor(Tensor(a!) self, Tensor other, *, Scalar alpha=1) -> Tensor(a!)",
+      "inputs": [[195,211,0,25690112,4,"cuda:0"],[116,132,0,25690112,4,"cuda:0"],1], "input_shapes": [[128,64,56,56],[128,64,56,56],[]], "input_types": ["Tensor(float)","Tensor(float)","Int"],
+      "outputs": [[195,211,0,25690112,4,"cuda:0"]], "output_shapes": [[128,64,56,56]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::clamp_min_", "id": 225, "rf_id": 98, "parent": 224, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::clamp_min_(Tensor(a!) self, Scalar min) -> Tensor(a!)",
+      "inputs": [[195,211,0,25690112,4,"cuda:0"],0], "input_shapes": [[128,64,56,56],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [[195,211,0,25690112,4,"cuda:0"]], "output_shapes": [[128,64,56,56]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::relu_", "id": 224, "rf_id": 97, "parent": 2, "fw_parent": 0, "seq_id": 747, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::relu_(Tensor(a!) self) -> Tensor(a!)",
+      "inputs": [[195,211,0,25690112,4,"cuda:0"]], "input_shapes": [[128,64,56,56]], "input_types": ["Tensor(float)"],
+      "outputs": [[195,211,0,25690112,4,"cuda:0"]], "output_shapes": [[128,64,56,56]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::cudnn_convolution", "id": 231, "rf_id": 102, "parent": 230, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::cudnn_convolution(Tensor self, Tensor weight, int[] padding, int[] stride, int[] dilation, int groups, bool benchmark, bool deterministic, bool allow_tf32) -> Tensor",
+      "inputs": [[195,211,0,25690112,4,"cuda:0"],[226,227,0,73728,4,"cuda:0"],[1,1],[2,2],[1,1],1,false,false,true], "input_shapes": [[128,64,56,56],[128,64,3,3],[[],[]],[[],[]],[[],[]],[],[],[],[]], "input_types": ["Tensor(float)","Tensor(float)","GenericList[Int,Int]","GenericList[Int,Int]","GenericList[Int,Int]","Int","Bool","Bool","Bool"],
+      "outputs": [[220,232,0,12845056,4,"cuda:0"]], "output_shapes": [[128,128,28,28]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::_convolution", "id": 230, "rf_id": 101, "parent": 229, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::_convolution(Tensor input, Tensor weight, Tensor? bias, int[] stride, SymInt[] padding, int[] dilation, bool transposed, SymInt[] output_padding, int groups, bool benchmark, bool deterministic, bool cudnn_enabled, bool allow_tf32) -> Tensor",
+      "inputs": [[195,211,0,25690112,4,"cuda:0"],[226,227,0,73728,4,"cuda:0"],[23,0,0,0,0,""],[2,2],[1,1],[1,1],false,[0,0],1,false,false,true,true], "input_shapes": [[128,64,56,56],[128,64,3,3],[],[[],[]],[[],[]],[[],[]],[],[[],[]],[],[],[],[],[]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(nullptr (uninitialized))","GenericList[Int,Int]","GenericList[Int,Int]","GenericList[Int,Int]","Bool","GenericList[Int,Int]","Int","Bool","Bool","Bool","Bool"],
+      "outputs": [[220,232,0,12845056,4,"cuda:0"]], "output_shapes": [[128,128,28,28]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::convolution", "id": 229, "rf_id": 100, "parent": 228, "fw_parent": 0, "seq_id": 748, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::convolution(Tensor input, Tensor weight, Tensor? bias, int[] stride, SymInt[] padding, int[] dilation, bool transposed, SymInt[] output_padding, int groups) -> Tensor",
+      "inputs": [[195,211,0,25690112,4,"cuda:0"],[226,227,0,73728,4,"cuda:0"],[23,0,0,0,0,""],[2,2],[1,1],[1,1],false,[0,0],1], "input_shapes": [[128,64,56,56],[128,64,3,3],[],[[],[]],[[],[]],[[],[]],[],[[],[]],[]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(nullptr (uninitialized))","GenericList[Int,Int]","GenericList[Int,Int]","GenericList[Int,Int]","Bool","GenericList[Int,Int]","Int"],
+      "outputs": [[220,232,0,12845056,4,"cuda:0"]], "output_shapes": [[128,128,28,28]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::conv2d", "id": 228, "rf_id": 99, "parent": 2, "fw_parent": 0, "seq_id": 748, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::conv2d(Tensor input, Tensor weight, Tensor? bias=None, int[2] stride=1, int[2] padding=0, int[2] dilation=1, int groups=1) -> Tensor",
+      "inputs": [[195,211,0,25690112,4,"cuda:0"],[226,227,0,73728,4,"cuda:0"],"<None>",[2,2],[1,1],[1,1],1], "input_shapes": [[128,64,56,56],[128,64,3,3],[],[[],[]],[[],[]],[[],[]],[]], "input_types": ["Tensor(float)","Tensor(float)","None","GenericList[Int,Int]","GenericList[Int,Int]","GenericList[Int,Int]","Int"],
+      "outputs": [[220,232,0,12845056,4,"cuda:0"]], "output_shapes": [[128,128,28,28]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::add_", "id": 237, "rf_id": 103, "parent": 2, "fw_parent": 0, "seq_id": 749, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::add_.Tensor(Tensor(a!) self, Tensor other, *, Scalar alpha=1) -> Tensor(a!)",
+      "inputs": [[233,234,0,1,8,"cuda:0"],[235,236,0,1,8,"cpu"],1], "input_shapes": [[],[],[]], "input_types": ["Tensor(long int)","Tensor(long int)","Int"],
+      "outputs": [[233,234,0,1,8,"cuda:0"]], "output_shapes": [[]], "output_types": ["Tensor(long int)"]
+    },
+    {
+      "name": "aten::empty", "id": 250, "rf_id": 108, "parent": 249, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[128,128,28,28],6,0,"cuda:0","<None>",0], "input_shapes": [[[],[],[],[]],[],[],[],[],[]], "input_types": ["GenericList[Int,Int,Int,Int]","Int","Int","Device","None","Int"],
+      "outputs": [[235,251,0,12845056,4,"cuda:0"]], "output_shapes": [[128,128,28,28]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty_like", "id": 249, "rf_id": 107, "parent": 248, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty_like(Tensor self, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[220,232,0,12845056,4,"cuda:0"],6,0,"cuda:0","<None>",0], "input_shapes": [[128,128,28,28],[],[],[],[],[]], "input_types": ["Tensor(float)","Int","Int","Device","None","Int"],
+      "outputs": [[235,251,0,12845056,4,"cuda:0"]], "output_shapes": [[128,128,28,28]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::view", "id": 252, "rf_id": 109, "parent": 248, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::view(Tensor(a) self, SymInt[] size) -> Tensor(a)",
+      "inputs": [[238,239,0,128,4,"cuda:0"],[1,128,1,1]], "input_shapes": [[128],[[],[],[],[]]], "input_types": ["Tensor(float)","GenericList[Int,Int,Int,Int]"],
+      "outputs": [[253,239,0,128,4,"cuda:0"]], "output_shapes": [[1,128,1,1]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty", "id": 254, "rf_id": 110, "parent": 248, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[128],6,0,"cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","Int","Device","None","None"],
+      "outputs": [[253,255,0,128,4,"cuda:0"]], "output_shapes": [[128]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty", "id": 256, "rf_id": 111, "parent": 248, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[128],6,0,"cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","Int","Device","None","None"],
+      "outputs": [[257,258,0,128,4,"cuda:0"]], "output_shapes": [[128]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty", "id": 259, "rf_id": 112, "parent": 248, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[0],0,0,"cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","Int","Device","None","None"],
+      "outputs": [[260,57,0,0,1,"cuda:0"]], "output_shapes": [[0]], "output_types": ["Tensor(unsigned char)"]
+    },
+    {
+      "name": "aten::empty", "id": 261, "rf_id": 113, "parent": 248, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[0],0,0,"cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","Int","Device","None","None"],
+      "outputs": [[262,57,0,0,1,"cuda:0"]], "output_shapes": [[0]], "output_types": ["Tensor(unsigned char)"]
+    },
+    {
+      "name": "aten::cudnn_batch_norm", "id": 248, "rf_id": 106, "parent": 247, "fw_parent": 0, "seq_id": 749, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::cudnn_batch_norm(Tensor input, Tensor weight, Tensor? bias, Tensor? running_mean, Tensor? running_var, bool training, float exponential_average_factor, float epsilon) -> (Tensor, Tensor, Tensor, Tensor)",
+      "inputs": [[220,232,0,12845056,4,"cuda:0"],[238,239,0,128,4,"cuda:0"],[240,241,0,128,4,"cuda:0"],[242,243,0,128,4,"cuda:0"],[244,245,0,128,4,"cuda:0"],true,0.100000,0.000010], "input_shapes": [[128,128,28,28],[128],[128],[128],[128],[],[],[]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Bool","Double","Double"],
+      "outputs": [[235,251,0,12845056,4,"cuda:0"],[253,255,0,128,4,"cuda:0"],[257,258,0,128,4,"cuda:0"],[262,57,0,0,1,"cuda:0"]], "output_shapes": [[128,128,28,28],[128],[128],[0]], "output_types": ["Tensor(float)","Tensor(float)","Tensor(float)","Tensor(unsigned char)"]
+    },
+    {
+      "name": "aten::_batch_norm_impl_index", "id": 247, "rf_id": 105, "parent": 246, "fw_parent": 0, "seq_id": 749, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::_batch_norm_impl_index(Tensor input, Tensor? weight, Tensor? bias, Tensor? running_mean, Tensor? running_var, bool training, float momentum, float eps, bool cudnn_enabled) -> (Tensor, Tensor, Tensor, Tensor, int)",
+      "inputs": [[220,232,0,12845056,4,"cuda:0"],[238,239,0,128,4,"cuda:0"],[240,241,0,128,4,"cuda:0"],[242,243,0,128,4,"cuda:0"],[244,245,0,128,4,"cuda:0"],true,0.100000,0.000010,true], "input_shapes": [[128,128,28,28],[128],[128],[128],[128],[],[],[],[]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Bool","Double","Double","Bool"],
+      "outputs": [[235,251,0,12845056,4,"cuda:0"],[253,255,0,128,4,"cuda:0"],[257,258,0,128,4,"cuda:0"],[262,57,0,0,1,"cuda:0"],1], "output_shapes": [[128,128,28,28],[128],[128],[0],[]], "output_types": ["Tensor(float)","Tensor(float)","Tensor(float)","Tensor(unsigned char)","Int"]
+    },
+    {
+      "name": "aten::batch_norm", "id": 246, "rf_id": 104, "parent": 2, "fw_parent": 0, "seq_id": 749, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::batch_norm(Tensor input, Tensor? weight, Tensor? bias, Tensor? running_mean, Tensor? running_var, bool training, float momentum, float eps, bool cudnn_enabled) -> Tensor",
+      "inputs": [[220,232,0,12845056,4,"cuda:0"],[238,239,0,128,4,"cuda:0"],[240,241,0,128,4,"cuda:0"],[242,243,0,128,4,"cuda:0"],[244,245,0,128,4,"cuda:0"],true,0.100000,0.000010,true], "input_shapes": [[128,128,28,28],[128],[128],[128],[128],[],[],[],[]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Bool","Double","Double","Bool"],
+      "outputs": [[235,251,0,12845056,4,"cuda:0"]], "output_shapes": [[128,128,28,28]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::clamp_min_", "id": 264, "rf_id": 115, "parent": 263, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::clamp_min_(Tensor(a!) self, Scalar min) -> Tensor(a!)",
+      "inputs": [[235,251,0,12845056,4,"cuda:0"],0], "input_shapes": [[128,128,28,28],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [[235,251,0,12845056,4,"cuda:0"]], "output_shapes": [[128,128,28,28]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::relu_", "id": 263, "rf_id": 114, "parent": 2, "fw_parent": 0, "seq_id": 750, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::relu_(Tensor(a!) self) -> Tensor(a!)",
+      "inputs": [[235,251,0,12845056,4,"cuda:0"]], "input_shapes": [[128,128,28,28]], "input_types": ["Tensor(float)"],
+      "outputs": [[235,251,0,12845056,4,"cuda:0"]], "output_shapes": [[128,128,28,28]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::cudnn_convolution", "id": 270, "rf_id": 119, "parent": 269, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::cudnn_convolution(Tensor self, Tensor weight, int[] padding, int[] stride, int[] dilation, int groups, bool benchmark, bool deterministic, bool allow_tf32) -> Tensor",
+      "inputs": [[235,251,0,12845056,4,"cuda:0"],[265,266,0,147456,4,"cuda:0"],[1,1],[1,1],[1,1],1,false,false,true], "input_shapes": [[128,128,28,28],[128,128,3,3],[[],[]],[[],[]],[[],[]],[],[],[],[]], "input_types": ["Tensor(float)","Tensor(float)","GenericList[Int,Int]","GenericList[Int,Int]","GenericList[Int,Int]","Int","Bool","Bool","Bool"],
+      "outputs": [[260,271,0,12845056,4,"cuda:0"]], "output_shapes": [[128,128,28,28]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::_convolution", "id": 269, "rf_id": 118, "parent": 268, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::_convolution(Tensor input, Tensor weight, Tensor? bias, int[] stride, SymInt[] padding, int[] dilation, bool transposed, SymInt[] output_padding, int groups, bool benchmark, bool deterministic, bool cudnn_enabled, bool allow_tf32) -> Tensor",
+      "inputs": [[235,251,0,12845056,4,"cuda:0"],[265,266,0,147456,4,"cuda:0"],[23,0,0,0,0,""],[1,1],[1,1],[1,1],false,[0,0],1,false,false,true,true], "input_shapes": [[128,128,28,28],[128,128,3,3],[],[[],[]],[[],[]],[[],[]],[],[[],[]],[],[],[],[],[]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(nullptr (uninitialized))","GenericList[Int,Int]","GenericList[Int,Int]","GenericList[Int,Int]","Bool","GenericList[Int,Int]","Int","Bool","Bool","Bool","Bool"],
+      "outputs": [[260,271,0,12845056,4,"cuda:0"]], "output_shapes": [[128,128,28,28]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::convolution", "id": 268, "rf_id": 117, "parent": 267, "fw_parent": 0, "seq_id": 751, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::convolution(Tensor input, Tensor weight, Tensor? bias, int[] stride, SymInt[] padding, int[] dilation, bool transposed, SymInt[] output_padding, int groups) -> Tensor",
+      "inputs": [[235,251,0,12845056,4,"cuda:0"],[265,266,0,147456,4,"cuda:0"],[23,0,0,0,0,""],[1,1],[1,1],[1,1],false,[0,0],1], "input_shapes": [[128,128,28,28],[128,128,3,3],[],[[],[]],[[],[]],[[],[]],[],[[],[]],[]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(nullptr (uninitialized))","GenericList[Int,Int]","GenericList[Int,Int]","GenericList[Int,Int]","Bool","GenericList[Int,Int]","Int"],
+      "outputs": [[260,271,0,12845056,4,"cuda:0"]], "output_shapes": [[128,128,28,28]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::conv2d", "id": 267, "rf_id": 116, "parent": 2, "fw_parent": 0, "seq_id": 751, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::conv2d(Tensor input, Tensor weight, Tensor? bias=None, int[2] stride=1, int[2] padding=0, int[2] dilation=1, int groups=1) -> Tensor",
+      "inputs": [[235,251,0,12845056,4,"cuda:0"],[265,266,0,147456,4,"cuda:0"],"<None>",[1,1],[1,1],[1,1],1], "input_shapes": [[128,128,28,28],[128,128,3,3],[],[[],[]],[[],[]],[[],[]],[]], "input_types": ["Tensor(float)","Tensor(float)","None","GenericList[Int,Int]","GenericList[Int,Int]","GenericList[Int,Int]","Int"],
+      "outputs": [[260,271,0,12845056,4,"cuda:0"]], "output_shapes": [[128,128,28,28]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::add_", "id": 276, "rf_id": 120, "parent": 2, "fw_parent": 0, "seq_id": 752, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::add_.Tensor(Tensor(a!) self, Tensor other, *, Scalar alpha=1) -> Tensor(a!)",
+      "inputs": [[272,273,0,1,8,"cuda:0"],[274,275,0,1,8,"cpu"],1], "input_shapes": [[],[],[]], "input_types": ["Tensor(long int)","Tensor(long int)","Int"],
+      "outputs": [[272,273,0,1,8,"cuda:0"]], "output_shapes": [[]], "output_types": ["Tensor(long int)"]
+    },
+    {
+      "name": "aten::empty", "id": 289, "rf_id": 125, "parent": 288, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[128,128,28,28],6,0,"cuda:0","<None>",0], "input_shapes": [[[],[],[],[]],[],[],[],[],[]], "input_types": ["GenericList[Int,Int,Int,Int]","Int","Int","Device","None","Int"],
+      "outputs": [[274,290,0,12845056,4,"cuda:0"]], "output_shapes": [[128,128,28,28]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty_like", "id": 288, "rf_id": 124, "parent": 287, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty_like(Tensor self, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[260,271,0,12845056,4,"cuda:0"],6,0,"cuda:0","<None>",0], "input_shapes": [[128,128,28,28],[],[],[],[],[]], "input_types": ["Tensor(float)","Int","Int","Device","None","Int"],
+      "outputs": [[274,290,0,12845056,4,"cuda:0"]], "output_shapes": [[128,128,28,28]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::view", "id": 291, "rf_id": 126, "parent": 287, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::view(Tensor(a) self, SymInt[] size) -> Tensor(a)",
+      "inputs": [[277,278,0,128,4,"cuda:0"],[1,128,1,1]], "input_shapes": [[128],[[],[],[],[]]], "input_types": ["Tensor(float)","GenericList[Int,Int,Int,Int]"],
+      "outputs": [[292,278,0,128,4,"cuda:0"]], "output_shapes": [[1,128,1,1]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty", "id": 293, "rf_id": 127, "parent": 287, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[128],6,0,"cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","Int","Device","None","None"],
+      "outputs": [[292,294,0,128,4,"cuda:0"]], "output_shapes": [[128]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty", "id": 295, "rf_id": 128, "parent": 287, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[128],6,0,"cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","Int","Device","None","None"],
+      "outputs": [[296,297,0,128,4,"cuda:0"]], "output_shapes": [[128]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty", "id": 298, "rf_id": 129, "parent": 287, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[0],0,0,"cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","Int","Device","None","None"],
+      "outputs": [[299,57,0,0,1,"cuda:0"]], "output_shapes": [[0]], "output_types": ["Tensor(unsigned char)"]
+    },
+    {
+      "name": "aten::empty", "id": 300, "rf_id": 130, "parent": 287, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[0],0,0,"cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","Int","Device","None","None"],
+      "outputs": [[301,57,0,0,1,"cuda:0"]], "output_shapes": [[0]], "output_types": ["Tensor(unsigned char)"]
+    },
+    {
+      "name": "aten::cudnn_batch_norm", "id": 287, "rf_id": 123, "parent": 286, "fw_parent": 0, "seq_id": 752, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::cudnn_batch_norm(Tensor input, Tensor weight, Tensor? bias, Tensor? running_mean, Tensor? running_var, bool training, float exponential_average_factor, float epsilon) -> (Tensor, Tensor, Tensor, Tensor)",
+      "inputs": [[260,271,0,12845056,4,"cuda:0"],[277,278,0,128,4,"cuda:0"],[279,280,0,128,4,"cuda:0"],[281,282,0,128,4,"cuda:0"],[283,284,0,128,4,"cuda:0"],true,0.100000,0.000010], "input_shapes": [[128,128,28,28],[128],[128],[128],[128],[],[],[]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Bool","Double","Double"],
+      "outputs": [[274,290,0,12845056,4,"cuda:0"],[292,294,0,128,4,"cuda:0"],[296,297,0,128,4,"cuda:0"],[301,57,0,0,1,"cuda:0"]], "output_shapes": [[128,128,28,28],[128],[128],[0]], "output_types": ["Tensor(float)","Tensor(float)","Tensor(float)","Tensor(unsigned char)"]
+    },
+    {
+      "name": "aten::_batch_norm_impl_index", "id": 286, "rf_id": 122, "parent": 285, "fw_parent": 0, "seq_id": 752, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::_batch_norm_impl_index(Tensor input, Tensor? weight, Tensor? bias, Tensor? running_mean, Tensor? running_var, bool training, float momentum, float eps, bool cudnn_enabled) -> (Tensor, Tensor, Tensor, Tensor, int)",
+      "inputs": [[260,271,0,12845056,4,"cuda:0"],[277,278,0,128,4,"cuda:0"],[279,280,0,128,4,"cuda:0"],[281,282,0,128,4,"cuda:0"],[283,284,0,128,4,"cuda:0"],true,0.100000,0.000010,true], "input_shapes": [[128,128,28,28],[128],[128],[128],[128],[],[],[],[]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Bool","Double","Double","Bool"],
+      "outputs": [[274,290,0,12845056,4,"cuda:0"],[292,294,0,128,4,"cuda:0"],[296,297,0,128,4,"cuda:0"],[301,57,0,0,1,"cuda:0"],1], "output_shapes": [[128,128,28,28],[128],[128],[0],[]], "output_types": ["Tensor(float)","Tensor(float)","Tensor(float)","Tensor(unsigned char)","Int"]
+    },
+    {
+      "name": "aten::batch_norm", "id": 285, "rf_id": 121, "parent": 2, "fw_parent": 0, "seq_id": 752, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::batch_norm(Tensor input, Tensor? weight, Tensor? bias, Tensor? running_mean, Tensor? running_var, bool training, float momentum, float eps, bool cudnn_enabled) -> Tensor",
+      "inputs": [[260,271,0,12845056,4,"cuda:0"],[277,278,0,128,4,"cuda:0"],[279,280,0,128,4,"cuda:0"],[281,282,0,128,4,"cuda:0"],[283,284,0,128,4,"cuda:0"],true,0.100000,0.000010,true], "input_shapes": [[128,128,28,28],[128],[128],[128],[128],[],[],[],[]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Bool","Double","Double","Bool"],
+      "outputs": [[274,290,0,12845056,4,"cuda:0"]], "output_shapes": [[128,128,28,28]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::cudnn_convolution", "id": 307, "rf_id": 134, "parent": 306, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::cudnn_convolution(Tensor self, Tensor weight, int[] padding, int[] stride, int[] dilation, int groups, bool benchmark, bool deterministic, bool allow_tf32) -> Tensor",
+      "inputs": [[195,211,0,25690112,4,"cuda:0"],[302,303,0,8192,4,"cuda:0"],[0,0],[2,2],[1,1],1,false,false,true], "input_shapes": [[128,64,56,56],[128,64,1,1],[[],[]],[[],[]],[[],[]],[],[],[],[]], "input_types": ["Tensor(float)","Tensor(float)","GenericList[Int,Int]","GenericList[Int,Int]","GenericList[Int,Int]","Int","Bool","Bool","Bool"],
+      "outputs": [[308,309,0,12845056,4,"cuda:0"]], "output_shapes": [[128,128,28,28]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::_convolution", "id": 306, "rf_id": 133, "parent": 305, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::_convolution(Tensor input, Tensor weight, Tensor? bias, int[] stride, SymInt[] padding, int[] dilation, bool transposed, SymInt[] output_padding, int groups, bool benchmark, bool deterministic, bool cudnn_enabled, bool allow_tf32) -> Tensor",
+      "inputs": [[195,211,0,25690112,4,"cuda:0"],[302,303,0,8192,4,"cuda:0"],[23,0,0,0,0,""],[2,2],[0,0],[1,1],false,[0,0],1,false,false,true,true], "input_shapes": [[128,64,56,56],[128,64,1,1],[],[[],[]],[[],[]],[[],[]],[],[[],[]],[],[],[],[],[]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(nullptr (uninitialized))","GenericList[Int,Int]","GenericList[Int,Int]","GenericList[Int,Int]","Bool","GenericList[Int,Int]","Int","Bool","Bool","Bool","Bool"],
+      "outputs": [[308,309,0,12845056,4,"cuda:0"]], "output_shapes": [[128,128,28,28]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::convolution", "id": 305, "rf_id": 132, "parent": 304, "fw_parent": 0, "seq_id": 753, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::convolution(Tensor input, Tensor weight, Tensor? bias, int[] stride, SymInt[] padding, int[] dilation, bool transposed, SymInt[] output_padding, int groups) -> Tensor",
+      "inputs": [[195,211,0,25690112,4,"cuda:0"],[302,303,0,8192,4,"cuda:0"],[23,0,0,0,0,""],[2,2],[0,0],[1,1],false,[0,0],1], "input_shapes": [[128,64,56,56],[128,64,1,1],[],[[],[]],[[],[]],[[],[]],[],[[],[]],[]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(nullptr (uninitialized))","GenericList[Int,Int]","GenericList[Int,Int]","GenericList[Int,Int]","Bool","GenericList[Int,Int]","Int"],
+      "outputs": [[308,309,0,12845056,4,"cuda:0"]], "output_shapes": [[128,128,28,28]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::conv2d", "id": 304, "rf_id": 131, "parent": 2, "fw_parent": 0, "seq_id": 753, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::conv2d(Tensor input, Tensor weight, Tensor? bias=None, int[2] stride=1, int[2] padding=0, int[2] dilation=1, int groups=1) -> Tensor",
+      "inputs": [[195,211,0,25690112,4,"cuda:0"],[302,303,0,8192,4,"cuda:0"],"<None>",[2,2],[0,0],[1,1],1], "input_shapes": [[128,64,56,56],[128,64,1,1],[],[[],[]],[[],[]],[[],[]],[]], "input_types": ["Tensor(float)","Tensor(float)","None","GenericList[Int,Int]","GenericList[Int,Int]","GenericList[Int,Int]","Int"],
+      "outputs": [[308,309,0,12845056,4,"cuda:0"]], "output_shapes": [[128,128,28,28]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::add_", "id": 313, "rf_id": 135, "parent": 2, "fw_parent": 0, "seq_id": 754, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::add_.Tensor(Tensor(a!) self, Tensor other, *, Scalar alpha=1) -> Tensor(a!)",
+      "inputs": [[310,311,0,1,8,"cuda:0"],[299,312,0,1,8,"cpu"],1], "input_shapes": [[],[],[]], "input_types": ["Tensor(long int)","Tensor(long int)","Int"],
+      "outputs": [[310,311,0,1,8,"cuda:0"]], "output_shapes": [[]], "output_types": ["Tensor(long int)"]
+    },
+    {
+      "name": "aten::empty", "id": 326, "rf_id": 140, "parent": 325, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[128,128,28,28],6,0,"cuda:0","<None>",0], "input_shapes": [[[],[],[],[]],[],[],[],[],[]], "input_types": ["GenericList[Int,Int,Int,Int]","Int","Int","Device","None","Int"],
+      "outputs": [[299,327,0,12845056,4,"cuda:0"]], "output_shapes": [[128,128,28,28]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty_like", "id": 325, "rf_id": 139, "parent": 324, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty_like(Tensor self, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[308,309,0,12845056,4,"cuda:0"],6,0,"cuda:0","<None>",0], "input_shapes": [[128,128,28,28],[],[],[],[],[]], "input_types": ["Tensor(float)","Int","Int","Device","None","Int"],
+      "outputs": [[299,327,0,12845056,4,"cuda:0"]], "output_shapes": [[128,128,28,28]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::view", "id": 328, "rf_id": 141, "parent": 324, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::view(Tensor(a) self, SymInt[] size) -> Tensor(a)",
+      "inputs": [[314,315,0,128,4,"cuda:0"],[1,128,1,1]], "input_shapes": [[128],[[],[],[],[]]], "input_types": ["Tensor(float)","GenericList[Int,Int,Int,Int]"],
+      "outputs": [[329,315,0,128,4,"cuda:0"]], "output_shapes": [[1,128,1,1]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty", "id": 330, "rf_id": 142, "parent": 324, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[128],6,0,"cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","Int","Device","None","None"],
+      "outputs": [[329,331,0,128,4,"cuda:0"]], "output_shapes": [[128]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty", "id": 332, "rf_id": 143, "parent": 324, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[128],6,0,"cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","Int","Device","None","None"],
+      "outputs": [[333,334,0,128,4,"cuda:0"]], "output_shapes": [[128]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty", "id": 335, "rf_id": 144, "parent": 324, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[0],0,0,"cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","Int","Device","None","None"],
+      "outputs": [[336,57,0,0,1,"cuda:0"]], "output_shapes": [[0]], "output_types": ["Tensor(unsigned char)"]
+    },
+    {
+      "name": "aten::empty", "id": 337, "rf_id": 145, "parent": 324, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[0],0,0,"cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","Int","Device","None","None"],
+      "outputs": [[338,57,0,0,1,"cuda:0"]], "output_shapes": [[0]], "output_types": ["Tensor(unsigned char)"]
+    },
+    {
+      "name": "aten::cudnn_batch_norm", "id": 324, "rf_id": 138, "parent": 323, "fw_parent": 0, "seq_id": 754, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::cudnn_batch_norm(Tensor input, Tensor weight, Tensor? bias, Tensor? running_mean, Tensor? running_var, bool training, float exponential_average_factor, float epsilon) -> (Tensor, Tensor, Tensor, Tensor)",
+      "inputs": [[308,309,0,12845056,4,"cuda:0"],[314,315,0,128,4,"cuda:0"],[316,317,0,128,4,"cuda:0"],[318,319,0,128,4,"cuda:0"],[320,321,0,128,4,"cuda:0"],true,0.100000,0.000010], "input_shapes": [[128,128,28,28],[128],[128],[128],[128],[],[],[]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Bool","Double","Double"],
+      "outputs": [[299,327,0,12845056,4,"cuda:0"],[329,331,0,128,4,"cuda:0"],[333,334,0,128,4,"cuda:0"],[338,57,0,0,1,"cuda:0"]], "output_shapes": [[128,128,28,28],[128],[128],[0]], "output_types": ["Tensor(float)","Tensor(float)","Tensor(float)","Tensor(unsigned char)"]
+    },
+    {
+      "name": "aten::_batch_norm_impl_index", "id": 323, "rf_id": 137, "parent": 322, "fw_parent": 0, "seq_id": 754, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::_batch_norm_impl_index(Tensor input, Tensor? weight, Tensor? bias, Tensor? running_mean, Tensor? running_var, bool training, float momentum, float eps, bool cudnn_enabled) -> (Tensor, Tensor, Tensor, Tensor, int)",
+      "inputs": [[308,309,0,12845056,4,"cuda:0"],[314,315,0,128,4,"cuda:0"],[316,317,0,128,4,"cuda:0"],[318,319,0,128,4,"cuda:0"],[320,321,0,128,4,"cuda:0"],true,0.100000,0.000010,true], "input_shapes": [[128,128,28,28],[128],[128],[128],[128],[],[],[],[]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Bool","Double","Double","Bool"],
+      "outputs": [[299,327,0,12845056,4,"cuda:0"],[329,331,0,128,4,"cuda:0"],[333,334,0,128,4,"cuda:0"],[338,57,0,0,1,"cuda:0"],1], "output_shapes": [[128,128,28,28],[128],[128],[0],[]], "output_types": ["Tensor(float)","Tensor(float)","Tensor(float)","Tensor(unsigned char)","Int"]
+    },
+    {
+      "name": "aten::batch_norm", "id": 322, "rf_id": 136, "parent": 2, "fw_parent": 0, "seq_id": 754, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::batch_norm(Tensor input, Tensor? weight, Tensor? bias, Tensor? running_mean, Tensor? running_var, bool training, float momentum, float eps, bool cudnn_enabled) -> Tensor",
+      "inputs": [[308,309,0,12845056,4,"cuda:0"],[314,315,0,128,4,"cuda:0"],[316,317,0,128,4,"cuda:0"],[318,319,0,128,4,"cuda:0"],[320,321,0,128,4,"cuda:0"],true,0.100000,0.000010,true], "input_shapes": [[128,128,28,28],[128],[128],[128],[128],[],[],[],[]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Bool","Double","Double","Bool"],
+      "outputs": [[299,327,0,12845056,4,"cuda:0"]], "output_shapes": [[128,128,28,28]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::add_", "id": 339, "rf_id": 146, "parent": 2, "fw_parent": 0, "seq_id": 755, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::add_.Tensor(Tensor(a!) self, Tensor other, *, Scalar alpha=1) -> Tensor(a!)",
+      "inputs": [[274,290,0,12845056,4,"cuda:0"],[299,327,0,12845056,4,"cuda:0"],1], "input_shapes": [[128,128,28,28],[128,128,28,28],[]], "input_types": ["Tensor(float)","Tensor(float)","Int"],
+      "outputs": [[274,290,0,12845056,4,"cuda:0"]], "output_shapes": [[128,128,28,28]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::clamp_min_", "id": 341, "rf_id": 148, "parent": 340, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::clamp_min_(Tensor(a!) self, Scalar min) -> Tensor(a!)",
+      "inputs": [[274,290,0,12845056,4,"cuda:0"],0], "input_shapes": [[128,128,28,28],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [[274,290,0,12845056,4,"cuda:0"]], "output_shapes": [[128,128,28,28]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::relu_", "id": 340, "rf_id": 147, "parent": 2, "fw_parent": 0, "seq_id": 756, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::relu_(Tensor(a!) self) -> Tensor(a!)",
+      "inputs": [[274,290,0,12845056,4,"cuda:0"]], "input_shapes": [[128,128,28,28]], "input_types": ["Tensor(float)"],
+      "outputs": [[274,290,0,12845056,4,"cuda:0"]], "output_shapes": [[128,128,28,28]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::cudnn_convolution", "id": 347, "rf_id": 152, "parent": 346, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::cudnn_convolution(Tensor self, Tensor weight, int[] padding, int[] stride, int[] dilation, int groups, bool benchmark, bool deterministic, bool allow_tf32) -> Tensor",
+      "inputs": [[274,290,0,12845056,4,"cuda:0"],[342,343,0,147456,4,"cuda:0"],[1,1],[1,1],[1,1],1,false,false,true], "input_shapes": [[128,128,28,28],[128,128,3,3],[[],[]],[[],[]],[[],[]],[],[],[],[]], "input_types": ["Tensor(float)","Tensor(float)","GenericList[Int,Int]","GenericList[Int,Int]","GenericList[Int,Int]","Int","Bool","Bool","Bool"],
+      "outputs": [[299,327,0,12845056,4,"cuda:0"]], "output_shapes": [[128,128,28,28]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::_convolution", "id": 346, "rf_id": 151, "parent": 345, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::_convolution(Tensor input, Tensor weight, Tensor? bias, int[] stride, SymInt[] padding, int[] dilation, bool transposed, SymInt[] output_padding, int groups, bool benchmark, bool deterministic, bool cudnn_enabled, bool allow_tf32) -> Tensor",
+      "inputs": [[274,290,0,12845056,4,"cuda:0"],[342,343,0,147456,4,"cuda:0"],[23,0,0,0,0,""],[1,1],[1,1],[1,1],false,[0,0],1,false,false,true,true], "input_shapes": [[128,128,28,28],[128,128,3,3],[],[[],[]],[[],[]],[[],[]],[],[[],[]],[],[],[],[],[]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(nullptr (uninitialized))","GenericList[Int,Int]","GenericList[Int,Int]","GenericList[Int,Int]","Bool","GenericList[Int,Int]","Int","Bool","Bool","Bool","Bool"],
+      "outputs": [[299,327,0,12845056,4,"cuda:0"]], "output_shapes": [[128,128,28,28]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::convolution", "id": 345, "rf_id": 150, "parent": 344, "fw_parent": 0, "seq_id": 757, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::convolution(Tensor input, Tensor weight, Tensor? bias, int[] stride, SymInt[] padding, int[] dilation, bool transposed, SymInt[] output_padding, int groups) -> Tensor",
+      "inputs": [[274,290,0,12845056,4,"cuda:0"],[342,343,0,147456,4,"cuda:0"],[23,0,0,0,0,""],[1,1],[1,1],[1,1],false,[0,0],1], "input_shapes": [[128,128,28,28],[128,128,3,3],[],[[],[]],[[],[]],[[],[]],[],[[],[]],[]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(nullptr (uninitialized))","GenericList[Int,Int]","GenericList[Int,Int]","GenericList[Int,Int]","Bool","GenericList[Int,Int]","Int"],
+      "outputs": [[299,327,0,12845056,4,"cuda:0"]], "output_shapes": [[128,128,28,28]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::conv2d", "id": 344, "rf_id": 149, "parent": 2, "fw_parent": 0, "seq_id": 757, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::conv2d(Tensor input, Tensor weight, Tensor? bias=None, int[2] stride=1, int[2] padding=0, int[2] dilation=1, int groups=1) -> Tensor",
+      "inputs": [[274,290,0,12845056,4,"cuda:0"],[342,343,0,147456,4,"cuda:0"],"<None>",[1,1],[1,1],[1,1],1], "input_shapes": [[128,128,28,28],[128,128,3,3],[],[[],[]],[[],[]],[[],[]],[]], "input_types": ["Tensor(float)","Tensor(float)","None","GenericList[Int,Int]","GenericList[Int,Int]","GenericList[Int,Int]","Int"],
+      "outputs": [[299,327,0,12845056,4,"cuda:0"]], "output_shapes": [[128,128,28,28]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::add_", "id": 352, "rf_id": 153, "parent": 2, "fw_parent": 0, "seq_id": 758, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::add_.Tensor(Tensor(a!) self, Tensor other, *, Scalar alpha=1) -> Tensor(a!)",
+      "inputs": [[348,349,0,1,8,"cuda:0"],[350,351,0,1,8,"cpu"],1], "input_shapes": [[],[],[]], "input_types": ["Tensor(long int)","Tensor(long int)","Int"],
+      "outputs": [[348,349,0,1,8,"cuda:0"]], "output_shapes": [[]], "output_types": ["Tensor(long int)"]
+    },
+    {
+      "name": "aten::empty", "id": 365, "rf_id": 158, "parent": 364, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[128,128,28,28],6,0,"cuda:0","<None>",0], "input_shapes": [[[],[],[],[]],[],[],[],[],[]], "input_types": ["GenericList[Int,Int,Int,Int]","Int","Int","Device","None","Int"],
+      "outputs": [[350,366,0,12845056,4,"cuda:0"]], "output_shapes": [[128,128,28,28]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty_like", "id": 364, "rf_id": 157, "parent": 363, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty_like(Tensor self, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[299,327,0,12845056,4,"cuda:0"],6,0,"cuda:0","<None>",0], "input_shapes": [[128,128,28,28],[],[],[],[],[]], "input_types": ["Tensor(float)","Int","Int","Device","None","Int"],
+      "outputs": [[350,366,0,12845056,4,"cuda:0"]], "output_shapes": [[128,128,28,28]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::view", "id": 367, "rf_id": 159, "parent": 363, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::view(Tensor(a) self, SymInt[] size) -> Tensor(a)",
+      "inputs": [[353,354,0,128,4,"cuda:0"],[1,128,1,1]], "input_shapes": [[128],[[],[],[],[]]], "input_types": ["Tensor(float)","GenericList[Int,Int,Int,Int]"],
+      "outputs": [[368,354,0,128,4,"cuda:0"]], "output_shapes": [[1,128,1,1]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty", "id": 369, "rf_id": 160, "parent": 363, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[128],6,0,"cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","Int","Device","None","None"],
+      "outputs": [[368,370,0,128,4,"cuda:0"]], "output_shapes": [[128]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty", "id": 371, "rf_id": 161, "parent": 363, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[128],6,0,"cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","Int","Device","None","None"],
+      "outputs": [[372,373,0,128,4,"cuda:0"]], "output_shapes": [[128]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty", "id": 374, "rf_id": 162, "parent": 363, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[0],0,0,"cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","Int","Device","None","None"],
+      "outputs": [[375,57,0,0,1,"cuda:0"]], "output_shapes": [[0]], "output_types": ["Tensor(unsigned char)"]
+    },
+    {
+      "name": "aten::empty", "id": 376, "rf_id": 163, "parent": 363, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[0],0,0,"cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","Int","Device","None","None"],
+      "outputs": [[377,57,0,0,1,"cuda:0"]], "output_shapes": [[0]], "output_types": ["Tensor(unsigned char)"]
+    },
+    {
+      "name": "aten::cudnn_batch_norm", "id": 363, "rf_id": 156, "parent": 362, "fw_parent": 0, "seq_id": 758, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::cudnn_batch_norm(Tensor input, Tensor weight, Tensor? bias, Tensor? running_mean, Tensor? running_var, bool training, float exponential_average_factor, float epsilon) -> (Tensor, Tensor, Tensor, Tensor)",
+      "inputs": [[299,327,0,12845056,4,"cuda:0"],[353,354,0,128,4,"cuda:0"],[355,356,0,128,4,"cuda:0"],[357,358,0,128,4,"cuda:0"],[359,360,0,128,4,"cuda:0"],true,0.100000,0.000010], "input_shapes": [[128,128,28,28],[128],[128],[128],[128],[],[],[]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Bool","Double","Double"],
+      "outputs": [[350,366,0,12845056,4,"cuda:0"],[368,370,0,128,4,"cuda:0"],[372,373,0,128,4,"cuda:0"],[377,57,0,0,1,"cuda:0"]], "output_shapes": [[128,128,28,28],[128],[128],[0]], "output_types": ["Tensor(float)","Tensor(float)","Tensor(float)","Tensor(unsigned char)"]
+    },
+    {
+      "name": "aten::_batch_norm_impl_index", "id": 362, "rf_id": 155, "parent": 361, "fw_parent": 0, "seq_id": 758, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::_batch_norm_impl_index(Tensor input, Tensor? weight, Tensor? bias, Tensor? running_mean, Tensor? running_var, bool training, float momentum, float eps, bool cudnn_enabled) -> (Tensor, Tensor, Tensor, Tensor, int)",
+      "inputs": [[299,327,0,12845056,4,"cuda:0"],[353,354,0,128,4,"cuda:0"],[355,356,0,128,4,"cuda:0"],[357,358,0,128,4,"cuda:0"],[359,360,0,128,4,"cuda:0"],true,0.100000,0.000010,true], "input_shapes": [[128,128,28,28],[128],[128],[128],[128],[],[],[],[]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Bool","Double","Double","Bool"],
+      "outputs": [[350,366,0,12845056,4,"cuda:0"],[368,370,0,128,4,"cuda:0"],[372,373,0,128,4,"cuda:0"],[377,57,0,0,1,"cuda:0"],1], "output_shapes": [[128,128,28,28],[128],[128],[0],[]], "output_types": ["Tensor(float)","Tensor(float)","Tensor(float)","Tensor(unsigned char)","Int"]
+    },
+    {
+      "name": "aten::batch_norm", "id": 361, "rf_id": 154, "parent": 2, "fw_parent": 0, "seq_id": 758, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::batch_norm(Tensor input, Tensor? weight, Tensor? bias, Tensor? running_mean, Tensor? running_var, bool training, float momentum, float eps, bool cudnn_enabled) -> Tensor",
+      "inputs": [[299,327,0,12845056,4,"cuda:0"],[353,354,0,128,4,"cuda:0"],[355,356,0,128,4,"cuda:0"],[357,358,0,128,4,"cuda:0"],[359,360,0,128,4,"cuda:0"],true,0.100000,0.000010,true], "input_shapes": [[128,128,28,28],[128],[128],[128],[128],[],[],[],[]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Bool","Double","Double","Bool"],
+      "outputs": [[350,366,0,12845056,4,"cuda:0"]], "output_shapes": [[128,128,28,28]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::clamp_min_", "id": 379, "rf_id": 165, "parent": 378, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::clamp_min_(Tensor(a!) self, Scalar min) -> Tensor(a!)",
+      "inputs": [[350,366,0,12845056,4,"cuda:0"],0], "input_shapes": [[128,128,28,28],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [[350,366,0,12845056,4,"cuda:0"]], "output_shapes": [[128,128,28,28]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::relu_", "id": 378, "rf_id": 164, "parent": 2, "fw_parent": 0, "seq_id": 759, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::relu_(Tensor(a!) self) -> Tensor(a!)",
+      "inputs": [[350,366,0,12845056,4,"cuda:0"]], "input_shapes": [[128,128,28,28]], "input_types": ["Tensor(float)"],
+      "outputs": [[350,366,0,12845056,4,"cuda:0"]], "output_shapes": [[128,128,28,28]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::cudnn_convolution", "id": 385, "rf_id": 169, "parent": 384, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::cudnn_convolution(Tensor self, Tensor weight, int[] padding, int[] stride, int[] dilation, int groups, bool benchmark, bool deterministic, bool allow_tf32) -> Tensor",
+      "inputs": [[350,366,0,12845056,4,"cuda:0"],[380,381,0,147456,4,"cuda:0"],[1,1],[1,1],[1,1],1,false,false,true], "input_shapes": [[128,128,28,28],[128,128,3,3],[[],[]],[[],[]],[[],[]],[],[],[],[]], "input_types": ["Tensor(float)","Tensor(float)","GenericList[Int,Int]","GenericList[Int,Int]","GenericList[Int,Int]","Int","Bool","Bool","Bool"],
+      "outputs": [[375,386,0,12845056,4,"cuda:0"]], "output_shapes": [[128,128,28,28]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::_convolution", "id": 384, "rf_id": 168, "parent": 383, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::_convolution(Tensor input, Tensor weight, Tensor? bias, int[] stride, SymInt[] padding, int[] dilation, bool transposed, SymInt[] output_padding, int groups, bool benchmark, bool deterministic, bool cudnn_enabled, bool allow_tf32) -> Tensor",
+      "inputs": [[350,366,0,12845056,4,"cuda:0"],[380,381,0,147456,4,"cuda:0"],[23,0,0,0,0,""],[1,1],[1,1],[1,1],false,[0,0],1,false,false,true,true], "input_shapes": [[128,128,28,28],[128,128,3,3],[],[[],[]],[[],[]],[[],[]],[],[[],[]],[],[],[],[],[]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(nullptr (uninitialized))","GenericList[Int,Int]","GenericList[Int,Int]","GenericList[Int,Int]","Bool","GenericList[Int,Int]","Int","Bool","Bool","Bool","Bool"],
+      "outputs": [[375,386,0,12845056,4,"cuda:0"]], "output_shapes": [[128,128,28,28]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::convolution", "id": 383, "rf_id": 167, "parent": 382, "fw_parent": 0, "seq_id": 760, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::convolution(Tensor input, Tensor weight, Tensor? bias, int[] stride, SymInt[] padding, int[] dilation, bool transposed, SymInt[] output_padding, int groups) -> Tensor",
+      "inputs": [[350,366,0,12845056,4,"cuda:0"],[380,381,0,147456,4,"cuda:0"],[23,0,0,0,0,""],[1,1],[1,1],[1,1],false,[0,0],1], "input_shapes": [[128,128,28,28],[128,128,3,3],[],[[],[]],[[],[]],[[],[]],[],[[],[]],[]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(nullptr (uninitialized))","GenericList[Int,Int]","GenericList[Int,Int]","GenericList[Int,Int]","Bool","GenericList[Int,Int]","Int"],
+      "outputs": [[375,386,0,12845056,4,"cuda:0"]], "output_shapes": [[128,128,28,28]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::conv2d", "id": 382, "rf_id": 166, "parent": 2, "fw_parent": 0, "seq_id": 760, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::conv2d(Tensor input, Tensor weight, Tensor? bias=None, int[2] stride=1, int[2] padding=0, int[2] dilation=1, int groups=1) -> Tensor",
+      "inputs": [[350,366,0,12845056,4,"cuda:0"],[380,381,0,147456,4,"cuda:0"],"<None>",[1,1],[1,1],[1,1],1], "input_shapes": [[128,128,28,28],[128,128,3,3],[],[[],[]],[[],[]],[[],[]],[]], "input_types": ["Tensor(float)","Tensor(float)","None","GenericList[Int,Int]","GenericList[Int,Int]","GenericList[Int,Int]","Int"],
+      "outputs": [[375,386,0,12845056,4,"cuda:0"]], "output_shapes": [[128,128,28,28]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::add_", "id": 391, "rf_id": 170, "parent": 2, "fw_parent": 0, "seq_id": 761, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::add_.Tensor(Tensor(a!) self, Tensor other, *, Scalar alpha=1) -> Tensor(a!)",
+      "inputs": [[387,388,0,1,8,"cuda:0"],[389,390,0,1,8,"cpu"],1], "input_shapes": [[],[],[]], "input_types": ["Tensor(long int)","Tensor(long int)","Int"],
+      "outputs": [[387,388,0,1,8,"cuda:0"]], "output_shapes": [[]], "output_types": ["Tensor(long int)"]
+    },
+    {
+      "name": "aten::empty", "id": 404, "rf_id": 175, "parent": 403, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[128,128,28,28],6,0,"cuda:0","<None>",0], "input_shapes": [[[],[],[],[]],[],[],[],[],[]], "input_types": ["GenericList[Int,Int,Int,Int]","Int","Int","Device","None","Int"],
+      "outputs": [[389,405,0,12845056,4,"cuda:0"]], "output_shapes": [[128,128,28,28]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty_like", "id": 403, "rf_id": 174, "parent": 402, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty_like(Tensor self, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[375,386,0,12845056,4,"cuda:0"],6,0,"cuda:0","<None>",0], "input_shapes": [[128,128,28,28],[],[],[],[],[]], "input_types": ["Tensor(float)","Int","Int","Device","None","Int"],
+      "outputs": [[389,405,0,12845056,4,"cuda:0"]], "output_shapes": [[128,128,28,28]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::view", "id": 406, "rf_id": 176, "parent": 402, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::view(Tensor(a) self, SymInt[] size) -> Tensor(a)",
+      "inputs": [[392,393,0,128,4,"cuda:0"],[1,128,1,1]], "input_shapes": [[128],[[],[],[],[]]], "input_types": ["Tensor(float)","GenericList[Int,Int,Int,Int]"],
+      "outputs": [[407,393,0,128,4,"cuda:0"]], "output_shapes": [[1,128,1,1]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty", "id": 408, "rf_id": 177, "parent": 402, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[128],6,0,"cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","Int","Device","None","None"],
+      "outputs": [[407,409,0,128,4,"cuda:0"]], "output_shapes": [[128]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty", "id": 410, "rf_id": 178, "parent": 402, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[128],6,0,"cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","Int","Device","None","None"],
+      "outputs": [[411,412,0,128,4,"cuda:0"]], "output_shapes": [[128]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty", "id": 413, "rf_id": 179, "parent": 402, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[0],0,0,"cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","Int","Device","None","None"],
+      "outputs": [[414,57,0,0,1,"cuda:0"]], "output_shapes": [[0]], "output_types": ["Tensor(unsigned char)"]
+    },
+    {
+      "name": "aten::empty", "id": 415, "rf_id": 180, "parent": 402, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[0],0,0,"cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","Int","Device","None","None"],
+      "outputs": [[416,57,0,0,1,"cuda:0"]], "output_shapes": [[0]], "output_types": ["Tensor(unsigned char)"]
+    },
+    {
+      "name": "aten::cudnn_batch_norm", "id": 402, "rf_id": 173, "parent": 401, "fw_parent": 0, "seq_id": 761, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::cudnn_batch_norm(Tensor input, Tensor weight, Tensor? bias, Tensor? running_mean, Tensor? running_var, bool training, float exponential_average_factor, float epsilon) -> (Tensor, Tensor, Tensor, Tensor)",
+      "inputs": [[375,386,0,12845056,4,"cuda:0"],[392,393,0,128,4,"cuda:0"],[394,395,0,128,4,"cuda:0"],[396,397,0,128,4,"cuda:0"],[398,399,0,128,4,"cuda:0"],true,0.100000,0.000010], "input_shapes": [[128,128,28,28],[128],[128],[128],[128],[],[],[]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Bool","Double","Double"],
+      "outputs": [[389,405,0,12845056,4,"cuda:0"],[407,409,0,128,4,"cuda:0"],[411,412,0,128,4,"cuda:0"],[416,57,0,0,1,"cuda:0"]], "output_shapes": [[128,128,28,28],[128],[128],[0]], "output_types": ["Tensor(float)","Tensor(float)","Tensor(float)","Tensor(unsigned char)"]
+    },
+    {
+      "name": "aten::_batch_norm_impl_index", "id": 401, "rf_id": 172, "parent": 400, "fw_parent": 0, "seq_id": 761, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::_batch_norm_impl_index(Tensor input, Tensor? weight, Tensor? bias, Tensor? running_mean, Tensor? running_var, bool training, float momentum, float eps, bool cudnn_enabled) -> (Tensor, Tensor, Tensor, Tensor, int)",
+      "inputs": [[375,386,0,12845056,4,"cuda:0"],[392,393,0,128,4,"cuda:0"],[394,395,0,128,4,"cuda:0"],[396,397,0,128,4,"cuda:0"],[398,399,0,128,4,"cuda:0"],true,0.100000,0.000010,true], "input_shapes": [[128,128,28,28],[128],[128],[128],[128],[],[],[],[]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Bool","Double","Double","Bool"],
+      "outputs": [[389,405,0,12845056,4,"cuda:0"],[407,409,0,128,4,"cuda:0"],[411,412,0,128,4,"cuda:0"],[416,57,0,0,1,"cuda:0"],1], "output_shapes": [[128,128,28,28],[128],[128],[0],[]], "output_types": ["Tensor(float)","Tensor(float)","Tensor(float)","Tensor(unsigned char)","Int"]
+    },
+    {
+      "name": "aten::batch_norm", "id": 400, "rf_id": 171, "parent": 2, "fw_parent": 0, "seq_id": 761, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::batch_norm(Tensor input, Tensor? weight, Tensor? bias, Tensor? running_mean, Tensor? running_var, bool training, float momentum, float eps, bool cudnn_enabled) -> Tensor",
+      "inputs": [[375,386,0,12845056,4,"cuda:0"],[392,393,0,128,4,"cuda:0"],[394,395,0,128,4,"cuda:0"],[396,397,0,128,4,"cuda:0"],[398,399,0,128,4,"cuda:0"],true,0.100000,0.000010,true], "input_shapes": [[128,128,28,28],[128],[128],[128],[128],[],[],[],[]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Bool","Double","Double","Bool"],
+      "outputs": [[389,405,0,12845056,4,"cuda:0"]], "output_shapes": [[128,128,28,28]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::add_", "id": 417, "rf_id": 181, "parent": 2, "fw_parent": 0, "seq_id": 762, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::add_.Tensor(Tensor(a!) self, Tensor other, *, Scalar alpha=1) -> Tensor(a!)",
+      "inputs": [[389,405,0,12845056,4,"cuda:0"],[274,290,0,12845056,4,"cuda:0"],1], "input_shapes": [[128,128,28,28],[128,128,28,28],[]], "input_types": ["Tensor(float)","Tensor(float)","Int"],
+      "outputs": [[389,405,0,12845056,4,"cuda:0"]], "output_shapes": [[128,128,28,28]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::clamp_min_", "id": 419, "rf_id": 183, "parent": 418, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::clamp_min_(Tensor(a!) self, Scalar min) -> Tensor(a!)",
+      "inputs": [[389,405,0,12845056,4,"cuda:0"],0], "input_shapes": [[128,128,28,28],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [[389,405,0,12845056,4,"cuda:0"]], "output_shapes": [[128,128,28,28]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::relu_", "id": 418, "rf_id": 182, "parent": 2, "fw_parent": 0, "seq_id": 763, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::relu_(Tensor(a!) self) -> Tensor(a!)",
+      "inputs": [[389,405,0,12845056,4,"cuda:0"]], "input_shapes": [[128,128,28,28]], "input_types": ["Tensor(float)"],
+      "outputs": [[389,405,0,12845056,4,"cuda:0"]], "output_shapes": [[128,128,28,28]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::cudnn_convolution", "id": 425, "rf_id": 187, "parent": 424, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::cudnn_convolution(Tensor self, Tensor weight, int[] padding, int[] stride, int[] dilation, int groups, bool benchmark, bool deterministic, bool allow_tf32) -> Tensor",
+      "inputs": [[389,405,0,12845056,4,"cuda:0"],[420,421,0,294912,4,"cuda:0"],[1,1],[2,2],[1,1],1,false,false,true], "input_shapes": [[128,128,28,28],[256,128,3,3],[[],[]],[[],[]],[[],[]],[],[],[],[]], "input_types": ["Tensor(float)","Tensor(float)","GenericList[Int,Int]","GenericList[Int,Int]","GenericList[Int,Int]","Int","Bool","Bool","Bool"],
+      "outputs": [[414,426,0,6422528,4,"cuda:0"]], "output_shapes": [[128,256,14,14]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::_convolution", "id": 424, "rf_id": 186, "parent": 423, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::_convolution(Tensor input, Tensor weight, Tensor? bias, int[] stride, SymInt[] padding, int[] dilation, bool transposed, SymInt[] output_padding, int groups, bool benchmark, bool deterministic, bool cudnn_enabled, bool allow_tf32) -> Tensor",
+      "inputs": [[389,405,0,12845056,4,"cuda:0"],[420,421,0,294912,4,"cuda:0"],[23,0,0,0,0,""],[2,2],[1,1],[1,1],false,[0,0],1,false,false,true,true], "input_shapes": [[128,128,28,28],[256,128,3,3],[],[[],[]],[[],[]],[[],[]],[],[[],[]],[],[],[],[],[]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(nullptr (uninitialized))","GenericList[Int,Int]","GenericList[Int,Int]","GenericList[Int,Int]","Bool","GenericList[Int,Int]","Int","Bool","Bool","Bool","Bool"],
+      "outputs": [[414,426,0,6422528,4,"cuda:0"]], "output_shapes": [[128,256,14,14]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::convolution", "id": 423, "rf_id": 185, "parent": 422, "fw_parent": 0, "seq_id": 764, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::convolution(Tensor input, Tensor weight, Tensor? bias, int[] stride, SymInt[] padding, int[] dilation, bool transposed, SymInt[] output_padding, int groups) -> Tensor",
+      "inputs": [[389,405,0,12845056,4,"cuda:0"],[420,421,0,294912,4,"cuda:0"],[23,0,0,0,0,""],[2,2],[1,1],[1,1],false,[0,0],1], "input_shapes": [[128,128,28,28],[256,128,3,3],[],[[],[]],[[],[]],[[],[]],[],[[],[]],[]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(nullptr (uninitialized))","GenericList[Int,Int]","GenericList[Int,Int]","GenericList[Int,Int]","Bool","GenericList[Int,Int]","Int"],
+      "outputs": [[414,426,0,6422528,4,"cuda:0"]], "output_shapes": [[128,256,14,14]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::conv2d", "id": 422, "rf_id": 184, "parent": 2, "fw_parent": 0, "seq_id": 764, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::conv2d(Tensor input, Tensor weight, Tensor? bias=None, int[2] stride=1, int[2] padding=0, int[2] dilation=1, int groups=1) -> Tensor",
+      "inputs": [[389,405,0,12845056,4,"cuda:0"],[420,421,0,294912,4,"cuda:0"],"<None>",[2,2],[1,1],[1,1],1], "input_shapes": [[128,128,28,28],[256,128,3,3],[],[[],[]],[[],[]],[[],[]],[]], "input_types": ["Tensor(float)","Tensor(float)","None","GenericList[Int,Int]","GenericList[Int,Int]","GenericList[Int,Int]","Int"],
+      "outputs": [[414,426,0,6422528,4,"cuda:0"]], "output_shapes": [[128,256,14,14]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::add_", "id": 431, "rf_id": 188, "parent": 2, "fw_parent": 0, "seq_id": 765, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::add_.Tensor(Tensor(a!) self, Tensor other, *, Scalar alpha=1) -> Tensor(a!)",
+      "inputs": [[427,428,0,1,8,"cuda:0"],[429,430,0,1,8,"cpu"],1], "input_shapes": [[],[],[]], "input_types": ["Tensor(long int)","Tensor(long int)","Int"],
+      "outputs": [[427,428,0,1,8,"cuda:0"]], "output_shapes": [[]], "output_types": ["Tensor(long int)"]
+    },
+    {
+      "name": "aten::empty", "id": 444, "rf_id": 193, "parent": 443, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[128,256,14,14],6,0,"cuda:0","<None>",0], "input_shapes": [[[],[],[],[]],[],[],[],[],[]], "input_types": ["GenericList[Int,Int,Int,Int]","Int","Int","Device","None","Int"],
+      "outputs": [[429,445,0,6422528,4,"cuda:0"]], "output_shapes": [[128,256,14,14]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty_like", "id": 443, "rf_id": 192, "parent": 442, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty_like(Tensor self, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[414,426,0,6422528,4,"cuda:0"],6,0,"cuda:0","<None>",0], "input_shapes": [[128,256,14,14],[],[],[],[],[]], "input_types": ["Tensor(float)","Int","Int","Device","None","Int"],
+      "outputs": [[429,445,0,6422528,4,"cuda:0"]], "output_shapes": [[128,256,14,14]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::view", "id": 446, "rf_id": 194, "parent": 442, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::view(Tensor(a) self, SymInt[] size) -> Tensor(a)",
+      "inputs": [[432,433,0,256,4,"cuda:0"],[1,256,1,1]], "input_shapes": [[256],[[],[],[],[]]], "input_types": ["Tensor(float)","GenericList[Int,Int,Int,Int]"],
+      "outputs": [[447,433,0,256,4,"cuda:0"]], "output_shapes": [[1,256,1,1]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty", "id": 448, "rf_id": 195, "parent": 442, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[256],6,0,"cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","Int","Device","None","None"],
+      "outputs": [[447,449,0,256,4,"cuda:0"]], "output_shapes": [[256]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty", "id": 450, "rf_id": 196, "parent": 442, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[256],6,0,"cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","Int","Device","None","None"],
+      "outputs": [[451,452,0,256,4,"cuda:0"]], "output_shapes": [[256]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty", "id": 453, "rf_id": 197, "parent": 442, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[0],0,0,"cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","Int","Device","None","None"],
+      "outputs": [[454,57,0,0,1,"cuda:0"]], "output_shapes": [[0]], "output_types": ["Tensor(unsigned char)"]
+    },
+    {
+      "name": "aten::empty", "id": 455, "rf_id": 198, "parent": 442, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[0],0,0,"cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","Int","Device","None","None"],
+      "outputs": [[456,57,0,0,1,"cuda:0"]], "output_shapes": [[0]], "output_types": ["Tensor(unsigned char)"]
+    },
+    {
+      "name": "aten::cudnn_batch_norm", "id": 442, "rf_id": 191, "parent": 441, "fw_parent": 0, "seq_id": 765, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::cudnn_batch_norm(Tensor input, Tensor weight, Tensor? bias, Tensor? running_mean, Tensor? running_var, bool training, float exponential_average_factor, float epsilon) -> (Tensor, Tensor, Tensor, Tensor)",
+      "inputs": [[414,426,0,6422528,4,"cuda:0"],[432,433,0,256,4,"cuda:0"],[434,435,0,256,4,"cuda:0"],[436,437,0,256,4,"cuda:0"],[438,439,0,256,4,"cuda:0"],true,0.100000,0.000010], "input_shapes": [[128,256,14,14],[256],[256],[256],[256],[],[],[]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Bool","Double","Double"],
+      "outputs": [[429,445,0,6422528,4,"cuda:0"],[447,449,0,256,4,"cuda:0"],[451,452,0,256,4,"cuda:0"],[456,57,0,0,1,"cuda:0"]], "output_shapes": [[128,256,14,14],[256],[256],[0]], "output_types": ["Tensor(float)","Tensor(float)","Tensor(float)","Tensor(unsigned char)"]
+    },
+    {
+      "name": "aten::_batch_norm_impl_index", "id": 441, "rf_id": 190, "parent": 440, "fw_parent": 0, "seq_id": 765, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::_batch_norm_impl_index(Tensor input, Tensor? weight, Tensor? bias, Tensor? running_mean, Tensor? running_var, bool training, float momentum, float eps, bool cudnn_enabled) -> (Tensor, Tensor, Tensor, Tensor, int)",
+      "inputs": [[414,426,0,6422528,4,"cuda:0"],[432,433,0,256,4,"cuda:0"],[434,435,0,256,4,"cuda:0"],[436,437,0,256,4,"cuda:0"],[438,439,0,256,4,"cuda:0"],true,0.100000,0.000010,true], "input_shapes": [[128,256,14,14],[256],[256],[256],[256],[],[],[],[]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Bool","Double","Double","Bool"],
+      "outputs": [[429,445,0,6422528,4,"cuda:0"],[447,449,0,256,4,"cuda:0"],[451,452,0,256,4,"cuda:0"],[456,57,0,0,1,"cuda:0"],1], "output_shapes": [[128,256,14,14],[256],[256],[0],[]], "output_types": ["Tensor(float)","Tensor(float)","Tensor(float)","Tensor(unsigned char)","Int"]
+    },
+    {
+      "name": "aten::batch_norm", "id": 440, "rf_id": 189, "parent": 2, "fw_parent": 0, "seq_id": 765, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::batch_norm(Tensor input, Tensor? weight, Tensor? bias, Tensor? running_mean, Tensor? running_var, bool training, float momentum, float eps, bool cudnn_enabled) -> Tensor",
+      "inputs": [[414,426,0,6422528,4,"cuda:0"],[432,433,0,256,4,"cuda:0"],[434,435,0,256,4,"cuda:0"],[436,437,0,256,4,"cuda:0"],[438,439,0,256,4,"cuda:0"],true,0.100000,0.000010,true], "input_shapes": [[128,256,14,14],[256],[256],[256],[256],[],[],[],[]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Bool","Double","Double","Bool"],
+      "outputs": [[429,445,0,6422528,4,"cuda:0"]], "output_shapes": [[128,256,14,14]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::clamp_min_", "id": 458, "rf_id": 200, "parent": 457, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::clamp_min_(Tensor(a!) self, Scalar min) -> Tensor(a!)",
+      "inputs": [[429,445,0,6422528,4,"cuda:0"],0], "input_shapes": [[128,256,14,14],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [[429,445,0,6422528,4,"cuda:0"]], "output_shapes": [[128,256,14,14]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::relu_", "id": 457, "rf_id": 199, "parent": 2, "fw_parent": 0, "seq_id": 766, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::relu_(Tensor(a!) self) -> Tensor(a!)",
+      "inputs": [[429,445,0,6422528,4,"cuda:0"]], "input_shapes": [[128,256,14,14]], "input_types": ["Tensor(float)"],
+      "outputs": [[429,445,0,6422528,4,"cuda:0"]], "output_shapes": [[128,256,14,14]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::cudnn_convolution", "id": 464, "rf_id": 204, "parent": 463, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::cudnn_convolution(Tensor self, Tensor weight, int[] padding, int[] stride, int[] dilation, int groups, bool benchmark, bool deterministic, bool allow_tf32) -> Tensor",
+      "inputs": [[429,445,0,6422528,4,"cuda:0"],[459,460,0,589824,4,"cuda:0"],[1,1],[1,1],[1,1],1,false,false,true], "input_shapes": [[128,256,14,14],[256,256,3,3],[[],[]],[[],[]],[[],[]],[],[],[],[]], "input_types": ["Tensor(float)","Tensor(float)","GenericList[Int,Int]","GenericList[Int,Int]","GenericList[Int,Int]","Int","Bool","Bool","Bool"],
+      "outputs": [[454,465,0,6422528,4,"cuda:0"]], "output_shapes": [[128,256,14,14]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::_convolution", "id": 463, "rf_id": 203, "parent": 462, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::_convolution(Tensor input, Tensor weight, Tensor? bias, int[] stride, SymInt[] padding, int[] dilation, bool transposed, SymInt[] output_padding, int groups, bool benchmark, bool deterministic, bool cudnn_enabled, bool allow_tf32) -> Tensor",
+      "inputs": [[429,445,0,6422528,4,"cuda:0"],[459,460,0,589824,4,"cuda:0"],[23,0,0,0,0,""],[1,1],[1,1],[1,1],false,[0,0],1,false,false,true,true], "input_shapes": [[128,256,14,14],[256,256,3,3],[],[[],[]],[[],[]],[[],[]],[],[[],[]],[],[],[],[],[]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(nullptr (uninitialized))","GenericList[Int,Int]","GenericList[Int,Int]","GenericList[Int,Int]","Bool","GenericList[Int,Int]","Int","Bool","Bool","Bool","Bool"],
+      "outputs": [[454,465,0,6422528,4,"cuda:0"]], "output_shapes": [[128,256,14,14]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::convolution", "id": 462, "rf_id": 202, "parent": 461, "fw_parent": 0, "seq_id": 767, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::convolution(Tensor input, Tensor weight, Tensor? bias, int[] stride, SymInt[] padding, int[] dilation, bool transposed, SymInt[] output_padding, int groups) -> Tensor",
+      "inputs": [[429,445,0,6422528,4,"cuda:0"],[459,460,0,589824,4,"cuda:0"],[23,0,0,0,0,""],[1,1],[1,1],[1,1],false,[0,0],1], "input_shapes": [[128,256,14,14],[256,256,3,3],[],[[],[]],[[],[]],[[],[]],[],[[],[]],[]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(nullptr (uninitialized))","GenericList[Int,Int]","GenericList[Int,Int]","GenericList[Int,Int]","Bool","GenericList[Int,Int]","Int"],
+      "outputs": [[454,465,0,6422528,4,"cuda:0"]], "output_shapes": [[128,256,14,14]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::conv2d", "id": 461, "rf_id": 201, "parent": 2, "fw_parent": 0, "seq_id": 767, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::conv2d(Tensor input, Tensor weight, Tensor? bias=None, int[2] stride=1, int[2] padding=0, int[2] dilation=1, int groups=1) -> Tensor",
+      "inputs": [[429,445,0,6422528,4,"cuda:0"],[459,460,0,589824,4,"cuda:0"],"<None>",[1,1],[1,1],[1,1],1], "input_shapes": [[128,256,14,14],[256,256,3,3],[],[[],[]],[[],[]],[[],[]],[]], "input_types": ["Tensor(float)","Tensor(float)","None","GenericList[Int,Int]","GenericList[Int,Int]","GenericList[Int,Int]","Int"],
+      "outputs": [[454,465,0,6422528,4,"cuda:0"]], "output_shapes": [[128,256,14,14]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::add_", "id": 470, "rf_id": 205, "parent": 2, "fw_parent": 0, "seq_id": 768, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::add_.Tensor(Tensor(a!) self, Tensor other, *, Scalar alpha=1) -> Tensor(a!)",
+      "inputs": [[466,467,0,1,8,"cuda:0"],[468,469,0,1,8,"cpu"],1], "input_shapes": [[],[],[]], "input_types": ["Tensor(long int)","Tensor(long int)","Int"],
+      "outputs": [[466,467,0,1,8,"cuda:0"]], "output_shapes": [[]], "output_types": ["Tensor(long int)"]
+    },
+    {
+      "name": "aten::empty", "id": 483, "rf_id": 210, "parent": 482, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[128,256,14,14],6,0,"cuda:0","<None>",0], "input_shapes": [[[],[],[],[]],[],[],[],[],[]], "input_types": ["GenericList[Int,Int,Int,Int]","Int","Int","Device","None","Int"],
+      "outputs": [[468,484,0,6422528,4,"cuda:0"]], "output_shapes": [[128,256,14,14]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty_like", "id": 482, "rf_id": 209, "parent": 481, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty_like(Tensor self, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[454,465,0,6422528,4,"cuda:0"],6,0,"cuda:0","<None>",0], "input_shapes": [[128,256,14,14],[],[],[],[],[]], "input_types": ["Tensor(float)","Int","Int","Device","None","Int"],
+      "outputs": [[468,484,0,6422528,4,"cuda:0"]], "output_shapes": [[128,256,14,14]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::view", "id": 485, "rf_id": 211, "parent": 481, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::view(Tensor(a) self, SymInt[] size) -> Tensor(a)",
+      "inputs": [[471,472,0,256,4,"cuda:0"],[1,256,1,1]], "input_shapes": [[256],[[],[],[],[]]], "input_types": ["Tensor(float)","GenericList[Int,Int,Int,Int]"],
+      "outputs": [[486,472,0,256,4,"cuda:0"]], "output_shapes": [[1,256,1,1]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty", "id": 487, "rf_id": 212, "parent": 481, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[256],6,0,"cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","Int","Device","None","None"],
+      "outputs": [[486,488,0,256,4,"cuda:0"]], "output_shapes": [[256]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty", "id": 489, "rf_id": 213, "parent": 481, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[256],6,0,"cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","Int","Device","None","None"],
+      "outputs": [[490,491,0,256,4,"cuda:0"]], "output_shapes": [[256]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty", "id": 492, "rf_id": 214, "parent": 481, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[0],0,0,"cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","Int","Device","None","None"],
+      "outputs": [[493,57,0,0,1,"cuda:0"]], "output_shapes": [[0]], "output_types": ["Tensor(unsigned char)"]
+    },
+    {
+      "name": "aten::empty", "id": 494, "rf_id": 215, "parent": 481, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[0],0,0,"cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","Int","Device","None","None"],
+      "outputs": [[495,57,0,0,1,"cuda:0"]], "output_shapes": [[0]], "output_types": ["Tensor(unsigned char)"]
+    },
+    {
+      "name": "aten::cudnn_batch_norm", "id": 481, "rf_id": 208, "parent": 480, "fw_parent": 0, "seq_id": 768, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::cudnn_batch_norm(Tensor input, Tensor weight, Tensor? bias, Tensor? running_mean, Tensor? running_var, bool training, float exponential_average_factor, float epsilon) -> (Tensor, Tensor, Tensor, Tensor)",
+      "inputs": [[454,465,0,6422528,4,"cuda:0"],[471,472,0,256,4,"cuda:0"],[473,474,0,256,4,"cuda:0"],[475,476,0,256,4,"cuda:0"],[477,478,0,256,4,"cuda:0"],true,0.100000,0.000010], "input_shapes": [[128,256,14,14],[256],[256],[256],[256],[],[],[]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Bool","Double","Double"],
+      "outputs": [[468,484,0,6422528,4,"cuda:0"],[486,488,0,256,4,"cuda:0"],[490,491,0,256,4,"cuda:0"],[495,57,0,0,1,"cuda:0"]], "output_shapes": [[128,256,14,14],[256],[256],[0]], "output_types": ["Tensor(float)","Tensor(float)","Tensor(float)","Tensor(unsigned char)"]
+    },
+    {
+      "name": "aten::_batch_norm_impl_index", "id": 480, "rf_id": 207, "parent": 479, "fw_parent": 0, "seq_id": 768, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::_batch_norm_impl_index(Tensor input, Tensor? weight, Tensor? bias, Tensor? running_mean, Tensor? running_var, bool training, float momentum, float eps, bool cudnn_enabled) -> (Tensor, Tensor, Tensor, Tensor, int)",
+      "inputs": [[454,465,0,6422528,4,"cuda:0"],[471,472,0,256,4,"cuda:0"],[473,474,0,256,4,"cuda:0"],[475,476,0,256,4,"cuda:0"],[477,478,0,256,4,"cuda:0"],true,0.100000,0.000010,true], "input_shapes": [[128,256,14,14],[256],[256],[256],[256],[],[],[],[]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Bool","Double","Double","Bool"],
+      "outputs": [[468,484,0,6422528,4,"cuda:0"],[486,488,0,256,4,"cuda:0"],[490,491,0,256,4,"cuda:0"],[495,57,0,0,1,"cuda:0"],1], "output_shapes": [[128,256,14,14],[256],[256],[0],[]], "output_types": ["Tensor(float)","Tensor(float)","Tensor(float)","Tensor(unsigned char)","Int"]
+    },
+    {
+      "name": "aten::batch_norm", "id": 479, "rf_id": 206, "parent": 2, "fw_parent": 0, "seq_id": 768, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::batch_norm(Tensor input, Tensor? weight, Tensor? bias, Tensor? running_mean, Tensor? running_var, bool training, float momentum, float eps, bool cudnn_enabled) -> Tensor",
+      "inputs": [[454,465,0,6422528,4,"cuda:0"],[471,472,0,256,4,"cuda:0"],[473,474,0,256,4,"cuda:0"],[475,476,0,256,4,"cuda:0"],[477,478,0,256,4,"cuda:0"],true,0.100000,0.000010,true], "input_shapes": [[128,256,14,14],[256],[256],[256],[256],[],[],[],[]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Bool","Double","Double","Bool"],
+      "outputs": [[468,484,0,6422528,4,"cuda:0"]], "output_shapes": [[128,256,14,14]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::cudnn_convolution", "id": 501, "rf_id": 219, "parent": 500, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::cudnn_convolution(Tensor self, Tensor weight, int[] padding, int[] stride, int[] dilation, int groups, bool benchmark, bool deterministic, bool allow_tf32) -> Tensor",
+      "inputs": [[389,405,0,12845056,4,"cuda:0"],[496,497,0,32768,4,"cuda:0"],[0,0],[2,2],[1,1],1,false,false,true], "input_shapes": [[128,128,28,28],[256,128,1,1],[[],[]],[[],[]],[[],[]],[],[],[],[]], "input_types": ["Tensor(float)","Tensor(float)","GenericList[Int,Int]","GenericList[Int,Int]","GenericList[Int,Int]","Int","Bool","Bool","Bool"],
+      "outputs": [[502,503,0,6422528,4,"cuda:0"]], "output_shapes": [[128,256,14,14]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::_convolution", "id": 500, "rf_id": 218, "parent": 499, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::_convolution(Tensor input, Tensor weight, Tensor? bias, int[] stride, SymInt[] padding, int[] dilation, bool transposed, SymInt[] output_padding, int groups, bool benchmark, bool deterministic, bool cudnn_enabled, bool allow_tf32) -> Tensor",
+      "inputs": [[389,405,0,12845056,4,"cuda:0"],[496,497,0,32768,4,"cuda:0"],[23,0,0,0,0,""],[2,2],[0,0],[1,1],false,[0,0],1,false,false,true,true], "input_shapes": [[128,128,28,28],[256,128,1,1],[],[[],[]],[[],[]],[[],[]],[],[[],[]],[],[],[],[],[]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(nullptr (uninitialized))","GenericList[Int,Int]","GenericList[Int,Int]","GenericList[Int,Int]","Bool","GenericList[Int,Int]","Int","Bool","Bool","Bool","Bool"],
+      "outputs": [[502,503,0,6422528,4,"cuda:0"]], "output_shapes": [[128,256,14,14]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::convolution", "id": 499, "rf_id": 217, "parent": 498, "fw_parent": 0, "seq_id": 769, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::convolution(Tensor input, Tensor weight, Tensor? bias, int[] stride, SymInt[] padding, int[] dilation, bool transposed, SymInt[] output_padding, int groups) -> Tensor",
+      "inputs": [[389,405,0,12845056,4,"cuda:0"],[496,497,0,32768,4,"cuda:0"],[23,0,0,0,0,""],[2,2],[0,0],[1,1],false,[0,0],1], "input_shapes": [[128,128,28,28],[256,128,1,1],[],[[],[]],[[],[]],[[],[]],[],[[],[]],[]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(nullptr (uninitialized))","GenericList[Int,Int]","GenericList[Int,Int]","GenericList[Int,Int]","Bool","GenericList[Int,Int]","Int"],
+      "outputs": [[502,503,0,6422528,4,"cuda:0"]], "output_shapes": [[128,256,14,14]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::conv2d", "id": 498, "rf_id": 216, "parent": 2, "fw_parent": 0, "seq_id": 769, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::conv2d(Tensor input, Tensor weight, Tensor? bias=None, int[2] stride=1, int[2] padding=0, int[2] dilation=1, int groups=1) -> Tensor",
+      "inputs": [[389,405,0,12845056,4,"cuda:0"],[496,497,0,32768,4,"cuda:0"],"<None>",[2,2],[0,0],[1,1],1], "input_shapes": [[128,128,28,28],[256,128,1,1],[],[[],[]],[[],[]],[[],[]],[]], "input_types": ["Tensor(float)","Tensor(float)","None","GenericList[Int,Int]","GenericList[Int,Int]","GenericList[Int,Int]","Int"],
+      "outputs": [[502,503,0,6422528,4,"cuda:0"]], "output_shapes": [[128,256,14,14]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::add_", "id": 507, "rf_id": 220, "parent": 2, "fw_parent": 0, "seq_id": 770, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::add_.Tensor(Tensor(a!) self, Tensor other, *, Scalar alpha=1) -> Tensor(a!)",
+      "inputs": [[504,505,0,1,8,"cuda:0"],[493,506,0,1,8,"cpu"],1], "input_shapes": [[],[],[]], "input_types": ["Tensor(long int)","Tensor(long int)","Int"],
+      "outputs": [[504,505,0,1,8,"cuda:0"]], "output_shapes": [[]], "output_types": ["Tensor(long int)"]
+    },
+    {
+      "name": "aten::empty", "id": 520, "rf_id": 225, "parent": 519, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[128,256,14,14],6,0,"cuda:0","<None>",0], "input_shapes": [[[],[],[],[]],[],[],[],[],[]], "input_types": ["GenericList[Int,Int,Int,Int]","Int","Int","Device","None","Int"],
+      "outputs": [[493,521,0,6422528,4,"cuda:0"]], "output_shapes": [[128,256,14,14]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty_like", "id": 519, "rf_id": 224, "parent": 518, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty_like(Tensor self, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[502,503,0,6422528,4,"cuda:0"],6,0,"cuda:0","<None>",0], "input_shapes": [[128,256,14,14],[],[],[],[],[]], "input_types": ["Tensor(float)","Int","Int","Device","None","Int"],
+      "outputs": [[493,521,0,6422528,4,"cuda:0"]], "output_shapes": [[128,256,14,14]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::view", "id": 522, "rf_id": 226, "parent": 518, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::view(Tensor(a) self, SymInt[] size) -> Tensor(a)",
+      "inputs": [[508,509,0,256,4,"cuda:0"],[1,256,1,1]], "input_shapes": [[256],[[],[],[],[]]], "input_types": ["Tensor(float)","GenericList[Int,Int,Int,Int]"],
+      "outputs": [[523,509,0,256,4,"cuda:0"]], "output_shapes": [[1,256,1,1]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty", "id": 524, "rf_id": 227, "parent": 518, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[256],6,0,"cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","Int","Device","None","None"],
+      "outputs": [[523,525,0,256,4,"cuda:0"]], "output_shapes": [[256]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty", "id": 526, "rf_id": 228, "parent": 518, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[256],6,0,"cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","Int","Device","None","None"],
+      "outputs": [[527,528,0,256,4,"cuda:0"]], "output_shapes": [[256]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty", "id": 529, "rf_id": 229, "parent": 518, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[0],0,0,"cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","Int","Device","None","None"],
+      "outputs": [[530,57,0,0,1,"cuda:0"]], "output_shapes": [[0]], "output_types": ["Tensor(unsigned char)"]
+    },
+    {
+      "name": "aten::empty", "id": 531, "rf_id": 230, "parent": 518, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[0],0,0,"cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","Int","Device","None","None"],
+      "outputs": [[532,57,0,0,1,"cuda:0"]], "output_shapes": [[0]], "output_types": ["Tensor(unsigned char)"]
+    },
+    {
+      "name": "aten::cudnn_batch_norm", "id": 518, "rf_id": 223, "parent": 517, "fw_parent": 0, "seq_id": 770, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::cudnn_batch_norm(Tensor input, Tensor weight, Tensor? bias, Tensor? running_mean, Tensor? running_var, bool training, float exponential_average_factor, float epsilon) -> (Tensor, Tensor, Tensor, Tensor)",
+      "inputs": [[502,503,0,6422528,4,"cuda:0"],[508,509,0,256,4,"cuda:0"],[510,511,0,256,4,"cuda:0"],[512,513,0,256,4,"cuda:0"],[514,515,0,256,4,"cuda:0"],true,0.100000,0.000010], "input_shapes": [[128,256,14,14],[256],[256],[256],[256],[],[],[]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Bool","Double","Double"],
+      "outputs": [[493,521,0,6422528,4,"cuda:0"],[523,525,0,256,4,"cuda:0"],[527,528,0,256,4,"cuda:0"],[532,57,0,0,1,"cuda:0"]], "output_shapes": [[128,256,14,14],[256],[256],[0]], "output_types": ["Tensor(float)","Tensor(float)","Tensor(float)","Tensor(unsigned char)"]
+    },
+    {
+      "name": "aten::_batch_norm_impl_index", "id": 517, "rf_id": 222, "parent": 516, "fw_parent": 0, "seq_id": 770, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::_batch_norm_impl_index(Tensor input, Tensor? weight, Tensor? bias, Tensor? running_mean, Tensor? running_var, bool training, float momentum, float eps, bool cudnn_enabled) -> (Tensor, Tensor, Tensor, Tensor, int)",
+      "inputs": [[502,503,0,6422528,4,"cuda:0"],[508,509,0,256,4,"cuda:0"],[510,511,0,256,4,"cuda:0"],[512,513,0,256,4,"cuda:0"],[514,515,0,256,4,"cuda:0"],true,0.100000,0.000010,true], "input_shapes": [[128,256,14,14],[256],[256],[256],[256],[],[],[],[]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Bool","Double","Double","Bool"],
+      "outputs": [[493,521,0,6422528,4,"cuda:0"],[523,525,0,256,4,"cuda:0"],[527,528,0,256,4,"cuda:0"],[532,57,0,0,1,"cuda:0"],1], "output_shapes": [[128,256,14,14],[256],[256],[0],[]], "output_types": ["Tensor(float)","Tensor(float)","Tensor(float)","Tensor(unsigned char)","Int"]
+    },
+    {
+      "name": "aten::batch_norm", "id": 516, "rf_id": 221, "parent": 2, "fw_parent": 0, "seq_id": 770, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::batch_norm(Tensor input, Tensor? weight, Tensor? bias, Tensor? running_mean, Tensor? running_var, bool training, float momentum, float eps, bool cudnn_enabled) -> Tensor",
+      "inputs": [[502,503,0,6422528,4,"cuda:0"],[508,509,0,256,4,"cuda:0"],[510,511,0,256,4,"cuda:0"],[512,513,0,256,4,"cuda:0"],[514,515,0,256,4,"cuda:0"],true,0.100000,0.000010,true], "input_shapes": [[128,256,14,14],[256],[256],[256],[256],[],[],[],[]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Bool","Double","Double","Bool"],
+      "outputs": [[493,521,0,6422528,4,"cuda:0"]], "output_shapes": [[128,256,14,14]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::add_", "id": 533, "rf_id": 231, "parent": 2, "fw_parent": 0, "seq_id": 771, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::add_.Tensor(Tensor(a!) self, Tensor other, *, Scalar alpha=1) -> Tensor(a!)",
+      "inputs": [[468,484,0,6422528,4,"cuda:0"],[493,521,0,6422528,4,"cuda:0"],1], "input_shapes": [[128,256,14,14],[128,256,14,14],[]], "input_types": ["Tensor(float)","Tensor(float)","Int"],
+      "outputs": [[468,484,0,6422528,4,"cuda:0"]], "output_shapes": [[128,256,14,14]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::clamp_min_", "id": 535, "rf_id": 233, "parent": 534, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::clamp_min_(Tensor(a!) self, Scalar min) -> Tensor(a!)",
+      "inputs": [[468,484,0,6422528,4,"cuda:0"],0], "input_shapes": [[128,256,14,14],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [[468,484,0,6422528,4,"cuda:0"]], "output_shapes": [[128,256,14,14]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::relu_", "id": 534, "rf_id": 232, "parent": 2, "fw_parent": 0, "seq_id": 772, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::relu_(Tensor(a!) self) -> Tensor(a!)",
+      "inputs": [[468,484,0,6422528,4,"cuda:0"]], "input_shapes": [[128,256,14,14]], "input_types": ["Tensor(float)"],
+      "outputs": [[468,484,0,6422528,4,"cuda:0"]], "output_shapes": [[128,256,14,14]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::cudnn_convolution", "id": 541, "rf_id": 237, "parent": 540, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::cudnn_convolution(Tensor self, Tensor weight, int[] padding, int[] stride, int[] dilation, int groups, bool benchmark, bool deterministic, bool allow_tf32) -> Tensor",
+      "inputs": [[468,484,0,6422528,4,"cuda:0"],[536,537,0,589824,4,"cuda:0"],[1,1],[1,1],[1,1],1,false,false,true], "input_shapes": [[128,256,14,14],[256,256,3,3],[[],[]],[[],[]],[[],[]],[],[],[],[]], "input_types": ["Tensor(float)","Tensor(float)","GenericList[Int,Int]","GenericList[Int,Int]","GenericList[Int,Int]","Int","Bool","Bool","Bool"],
+      "outputs": [[493,521,0,6422528,4,"cuda:0"]], "output_shapes": [[128,256,14,14]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::_convolution", "id": 540, "rf_id": 236, "parent": 539, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::_convolution(Tensor input, Tensor weight, Tensor? bias, int[] stride, SymInt[] padding, int[] dilation, bool transposed, SymInt[] output_padding, int groups, bool benchmark, bool deterministic, bool cudnn_enabled, bool allow_tf32) -> Tensor",
+      "inputs": [[468,484,0,6422528,4,"cuda:0"],[536,537,0,589824,4,"cuda:0"],[23,0,0,0,0,""],[1,1],[1,1],[1,1],false,[0,0],1,false,false,true,true], "input_shapes": [[128,256,14,14],[256,256,3,3],[],[[],[]],[[],[]],[[],[]],[],[[],[]],[],[],[],[],[]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(nullptr (uninitialized))","GenericList[Int,Int]","GenericList[Int,Int]","GenericList[Int,Int]","Bool","GenericList[Int,Int]","Int","Bool","Bool","Bool","Bool"],
+      "outputs": [[493,521,0,6422528,4,"cuda:0"]], "output_shapes": [[128,256,14,14]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::convolution", "id": 539, "rf_id": 235, "parent": 538, "fw_parent": 0, "seq_id": 773, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::convolution(Tensor input, Tensor weight, Tensor? bias, int[] stride, SymInt[] padding, int[] dilation, bool transposed, SymInt[] output_padding, int groups) -> Tensor",
+      "inputs": [[468,484,0,6422528,4,"cuda:0"],[536,537,0,589824,4,"cuda:0"],[23,0,0,0,0,""],[1,1],[1,1],[1,1],false,[0,0],1], "input_shapes": [[128,256,14,14],[256,256,3,3],[],[[],[]],[[],[]],[[],[]],[],[[],[]],[]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(nullptr (uninitialized))","GenericList[Int,Int]","GenericList[Int,Int]","GenericList[Int,Int]","Bool","GenericList[Int,Int]","Int"],
+      "outputs": [[493,521,0,6422528,4,"cuda:0"]], "output_shapes": [[128,256,14,14]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::conv2d", "id": 538, "rf_id": 234, "parent": 2, "fw_parent": 0, "seq_id": 773, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::conv2d(Tensor input, Tensor weight, Tensor? bias=None, int[2] stride=1, int[2] padding=0, int[2] dilation=1, int groups=1) -> Tensor",
+      "inputs": [[468,484,0,6422528,4,"cuda:0"],[536,537,0,589824,4,"cuda:0"],"<None>",[1,1],[1,1],[1,1],1], "input_shapes": [[128,256,14,14],[256,256,3,3],[],[[],[]],[[],[]],[[],[]],[]], "input_types": ["Tensor(float)","Tensor(float)","None","GenericList[Int,Int]","GenericList[Int,Int]","GenericList[Int,Int]","Int"],
+      "outputs": [[493,521,0,6422528,4,"cuda:0"]], "output_shapes": [[128,256,14,14]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::add_", "id": 545, "rf_id": 238, "parent": 2, "fw_parent": 0, "seq_id": 774, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::add_.Tensor(Tensor(a!) self, Tensor other, *, Scalar alpha=1) -> Tensor(a!)",
+      "inputs": [[542,543,0,1,8,"cuda:0"],[530,544,0,1,8,"cpu"],1], "input_shapes": [[],[],[]], "input_types": ["Tensor(long int)","Tensor(long int)","Int"],
+      "outputs": [[542,543,0,1,8,"cuda:0"]], "output_shapes": [[]], "output_types": ["Tensor(long int)"]
+    },
+    {
+      "name": "aten::empty", "id": 558, "rf_id": 243, "parent": 557, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[128,256,14,14],6,0,"cuda:0","<None>",0], "input_shapes": [[[],[],[],[]],[],[],[],[],[]], "input_types": ["GenericList[Int,Int,Int,Int]","Int","Int","Device","None","Int"],
+      "outputs": [[530,559,0,6422528,4,"cuda:0"]], "output_shapes": [[128,256,14,14]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty_like", "id": 557, "rf_id": 242, "parent": 556, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty_like(Tensor self, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[493,521,0,6422528,4,"cuda:0"],6,0,"cuda:0","<None>",0], "input_shapes": [[128,256,14,14],[],[],[],[],[]], "input_types": ["Tensor(float)","Int","Int","Device","None","Int"],
+      "outputs": [[530,559,0,6422528,4,"cuda:0"]], "output_shapes": [[128,256,14,14]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::view", "id": 560, "rf_id": 244, "parent": 556, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::view(Tensor(a) self, SymInt[] size) -> Tensor(a)",
+      "inputs": [[546,547,0,256,4,"cuda:0"],[1,256,1,1]], "input_shapes": [[256],[[],[],[],[]]], "input_types": ["Tensor(float)","GenericList[Int,Int,Int,Int]"],
+      "outputs": [[561,547,0,256,4,"cuda:0"]], "output_shapes": [[1,256,1,1]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty", "id": 562, "rf_id": 245, "parent": 556, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[256],6,0,"cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","Int","Device","None","None"],
+      "outputs": [[561,563,0,256,4,"cuda:0"]], "output_shapes": [[256]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty", "id": 564, "rf_id": 246, "parent": 556, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[256],6,0,"cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","Int","Device","None","None"],
+      "outputs": [[565,566,0,256,4,"cuda:0"]], "output_shapes": [[256]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty", "id": 567, "rf_id": 247, "parent": 556, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[0],0,0,"cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","Int","Device","None","None"],
+      "outputs": [[568,57,0,0,1,"cuda:0"]], "output_shapes": [[0]], "output_types": ["Tensor(unsigned char)"]
+    },
+    {
+      "name": "aten::empty", "id": 569, "rf_id": 248, "parent": 556, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[0],0,0,"cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","Int","Device","None","None"],
+      "outputs": [[570,57,0,0,1,"cuda:0"]], "output_shapes": [[0]], "output_types": ["Tensor(unsigned char)"]
+    },
+    {
+      "name": "aten::cudnn_batch_norm", "id": 556, "rf_id": 241, "parent": 555, "fw_parent": 0, "seq_id": 774, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::cudnn_batch_norm(Tensor input, Tensor weight, Tensor? bias, Tensor? running_mean, Tensor? running_var, bool training, float exponential_average_factor, float epsilon) -> (Tensor, Tensor, Tensor, Tensor)",
+      "inputs": [[493,521,0,6422528,4,"cuda:0"],[546,547,0,256,4,"cuda:0"],[548,549,0,256,4,"cuda:0"],[550,551,0,256,4,"cuda:0"],[552,553,0,256,4,"cuda:0"],true,0.100000,0.000010], "input_shapes": [[128,256,14,14],[256],[256],[256],[256],[],[],[]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Bool","Double","Double"],
+      "outputs": [[530,559,0,6422528,4,"cuda:0"],[561,563,0,256,4,"cuda:0"],[565,566,0,256,4,"cuda:0"],[570,57,0,0,1,"cuda:0"]], "output_shapes": [[128,256,14,14],[256],[256],[0]], "output_types": ["Tensor(float)","Tensor(float)","Tensor(float)","Tensor(unsigned char)"]
+    },
+    {
+      "name": "aten::_batch_norm_impl_index", "id": 555, "rf_id": 240, "parent": 554, "fw_parent": 0, "seq_id": 774, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::_batch_norm_impl_index(Tensor input, Tensor? weight, Tensor? bias, Tensor? running_mean, Tensor? running_var, bool training, float momentum, float eps, bool cudnn_enabled) -> (Tensor, Tensor, Tensor, Tensor, int)",
+      "inputs": [[493,521,0,6422528,4,"cuda:0"],[546,547,0,256,4,"cuda:0"],[548,549,0,256,4,"cuda:0"],[550,551,0,256,4,"cuda:0"],[552,553,0,256,4,"cuda:0"],true,0.100000,0.000010,true], "input_shapes": [[128,256,14,14],[256],[256],[256],[256],[],[],[],[]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Bool","Double","Double","Bool"],
+      "outputs": [[530,559,0,6422528,4,"cuda:0"],[561,563,0,256,4,"cuda:0"],[565,566,0,256,4,"cuda:0"],[570,57,0,0,1,"cuda:0"],1], "output_shapes": [[128,256,14,14],[256],[256],[0],[]], "output_types": ["Tensor(float)","Tensor(float)","Tensor(float)","Tensor(unsigned char)","Int"]
+    },
+    {
+      "name": "aten::batch_norm", "id": 554, "rf_id": 239, "parent": 2, "fw_parent": 0, "seq_id": 774, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::batch_norm(Tensor input, Tensor? weight, Tensor? bias, Tensor? running_mean, Tensor? running_var, bool training, float momentum, float eps, bool cudnn_enabled) -> Tensor",
+      "inputs": [[493,521,0,6422528,4,"cuda:0"],[546,547,0,256,4,"cuda:0"],[548,549,0,256,4,"cuda:0"],[550,551,0,256,4,"cuda:0"],[552,553,0,256,4,"cuda:0"],true,0.100000,0.000010,true], "input_shapes": [[128,256,14,14],[256],[256],[256],[256],[],[],[],[]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Bool","Double","Double","Bool"],
+      "outputs": [[530,559,0,6422528,4,"cuda:0"]], "output_shapes": [[128,256,14,14]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::clamp_min_", "id": 572, "rf_id": 250, "parent": 571, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::clamp_min_(Tensor(a!) self, Scalar min) -> Tensor(a!)",
+      "inputs": [[530,559,0,6422528,4,"cuda:0"],0], "input_shapes": [[128,256,14,14],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [[530,559,0,6422528,4,"cuda:0"]], "output_shapes": [[128,256,14,14]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::relu_", "id": 571, "rf_id": 249, "parent": 2, "fw_parent": 0, "seq_id": 775, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::relu_(Tensor(a!) self) -> Tensor(a!)",
+      "inputs": [[530,559,0,6422528,4,"cuda:0"]], "input_shapes": [[128,256,14,14]], "input_types": ["Tensor(float)"],
+      "outputs": [[530,559,0,6422528,4,"cuda:0"]], "output_shapes": [[128,256,14,14]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::cudnn_convolution", "id": 578, "rf_id": 254, "parent": 577, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::cudnn_convolution(Tensor self, Tensor weight, int[] padding, int[] stride, int[] dilation, int groups, bool benchmark, bool deterministic, bool allow_tf32) -> Tensor",
+      "inputs": [[530,559,0,6422528,4,"cuda:0"],[573,574,0,589824,4,"cuda:0"],[1,1],[1,1],[1,1],1,false,false,true], "input_shapes": [[128,256,14,14],[256,256,3,3],[[],[]],[[],[]],[[],[]],[],[],[],[]], "input_types": ["Tensor(float)","Tensor(float)","GenericList[Int,Int]","GenericList[Int,Int]","GenericList[Int,Int]","Int","Bool","Bool","Bool"],
+      "outputs": [[568,579,0,6422528,4,"cuda:0"]], "output_shapes": [[128,256,14,14]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::_convolution", "id": 577, "rf_id": 253, "parent": 576, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::_convolution(Tensor input, Tensor weight, Tensor? bias, int[] stride, SymInt[] padding, int[] dilation, bool transposed, SymInt[] output_padding, int groups, bool benchmark, bool deterministic, bool cudnn_enabled, bool allow_tf32) -> Tensor",
+      "inputs": [[530,559,0,6422528,4,"cuda:0"],[573,574,0,589824,4,"cuda:0"],[23,0,0,0,0,""],[1,1],[1,1],[1,1],false,[0,0],1,false,false,true,true], "input_shapes": [[128,256,14,14],[256,256,3,3],[],[[],[]],[[],[]],[[],[]],[],[[],[]],[],[],[],[],[]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(nullptr (uninitialized))","GenericList[Int,Int]","GenericList[Int,Int]","GenericList[Int,Int]","Bool","GenericList[Int,Int]","Int","Bool","Bool","Bool","Bool"],
+      "outputs": [[568,579,0,6422528,4,"cuda:0"]], "output_shapes": [[128,256,14,14]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::convolution", "id": 576, "rf_id": 252, "parent": 575, "fw_parent": 0, "seq_id": 776, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::convolution(Tensor input, Tensor weight, Tensor? bias, int[] stride, SymInt[] padding, int[] dilation, bool transposed, SymInt[] output_padding, int groups) -> Tensor",
+      "inputs": [[530,559,0,6422528,4,"cuda:0"],[573,574,0,589824,4,"cuda:0"],[23,0,0,0,0,""],[1,1],[1,1],[1,1],false,[0,0],1], "input_shapes": [[128,256,14,14],[256,256,3,3],[],[[],[]],[[],[]],[[],[]],[],[[],[]],[]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(nullptr (uninitialized))","GenericList[Int,Int]","GenericList[Int,Int]","GenericList[Int,Int]","Bool","GenericList[Int,Int]","Int"],
+      "outputs": [[568,579,0,6422528,4,"cuda:0"]], "output_shapes": [[128,256,14,14]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::conv2d", "id": 575, "rf_id": 251, "parent": 2, "fw_parent": 0, "seq_id": 776, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::conv2d(Tensor input, Tensor weight, Tensor? bias=None, int[2] stride=1, int[2] padding=0, int[2] dilation=1, int groups=1) -> Tensor",
+      "inputs": [[530,559,0,6422528,4,"cuda:0"],[573,574,0,589824,4,"cuda:0"],"<None>",[1,1],[1,1],[1,1],1], "input_shapes": [[128,256,14,14],[256,256,3,3],[],[[],[]],[[],[]],[[],[]],[]], "input_types": ["Tensor(float)","Tensor(float)","None","GenericList[Int,Int]","GenericList[Int,Int]","GenericList[Int,Int]","Int"],
+      "outputs": [[568,579,0,6422528,4,"cuda:0"]], "output_shapes": [[128,256,14,14]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::add_", "id": 584, "rf_id": 255, "parent": 2, "fw_parent": 0, "seq_id": 777, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::add_.Tensor(Tensor(a!) self, Tensor other, *, Scalar alpha=1) -> Tensor(a!)",
+      "inputs": [[580,581,0,1,8,"cuda:0"],[582,583,0,1,8,"cpu"],1], "input_shapes": [[],[],[]], "input_types": ["Tensor(long int)","Tensor(long int)","Int"],
+      "outputs": [[580,581,0,1,8,"cuda:0"]], "output_shapes": [[]], "output_types": ["Tensor(long int)"]
+    },
+    {
+      "name": "aten::empty", "id": 597, "rf_id": 260, "parent": 596, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[128,256,14,14],6,0,"cuda:0","<None>",0], "input_shapes": [[[],[],[],[]],[],[],[],[],[]], "input_types": ["GenericList[Int,Int,Int,Int]","Int","Int","Device","None","Int"],
+      "outputs": [[582,598,0,6422528,4,"cuda:0"]], "output_shapes": [[128,256,14,14]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty_like", "id": 596, "rf_id": 259, "parent": 595, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty_like(Tensor self, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[568,579,0,6422528,4,"cuda:0"],6,0,"cuda:0","<None>",0], "input_shapes": [[128,256,14,14],[],[],[],[],[]], "input_types": ["Tensor(float)","Int","Int","Device","None","Int"],
+      "outputs": [[582,598,0,6422528,4,"cuda:0"]], "output_shapes": [[128,256,14,14]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::view", "id": 599, "rf_id": 261, "parent": 595, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::view(Tensor(a) self, SymInt[] size) -> Tensor(a)",
+      "inputs": [[585,586,0,256,4,"cuda:0"],[1,256,1,1]], "input_shapes": [[256],[[],[],[],[]]], "input_types": ["Tensor(float)","GenericList[Int,Int,Int,Int]"],
+      "outputs": [[600,586,0,256,4,"cuda:0"]], "output_shapes": [[1,256,1,1]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty", "id": 601, "rf_id": 262, "parent": 595, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[256],6,0,"cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","Int","Device","None","None"],
+      "outputs": [[600,602,0,256,4,"cuda:0"]], "output_shapes": [[256]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty", "id": 603, "rf_id": 263, "parent": 595, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[256],6,0,"cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","Int","Device","None","None"],
+      "outputs": [[604,605,0,256,4,"cuda:0"]], "output_shapes": [[256]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty", "id": 606, "rf_id": 264, "parent": 595, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[0],0,0,"cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","Int","Device","None","None"],
+      "outputs": [[607,57,0,0,1,"cuda:0"]], "output_shapes": [[0]], "output_types": ["Tensor(unsigned char)"]
+    },
+    {
+      "name": "aten::empty", "id": 608, "rf_id": 265, "parent": 595, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[0],0,0,"cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","Int","Device","None","None"],
+      "outputs": [[609,57,0,0,1,"cuda:0"]], "output_shapes": [[0]], "output_types": ["Tensor(unsigned char)"]
+    },
+    {
+      "name": "aten::cudnn_batch_norm", "id": 595, "rf_id": 258, "parent": 594, "fw_parent": 0, "seq_id": 777, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::cudnn_batch_norm(Tensor input, Tensor weight, Tensor? bias, Tensor? running_mean, Tensor? running_var, bool training, float exponential_average_factor, float epsilon) -> (Tensor, Tensor, Tensor, Tensor)",
+      "inputs": [[568,579,0,6422528,4,"cuda:0"],[585,586,0,256,4,"cuda:0"],[587,588,0,256,4,"cuda:0"],[589,590,0,256,4,"cuda:0"],[591,592,0,256,4,"cuda:0"],true,0.100000,0.000010], "input_shapes": [[128,256,14,14],[256],[256],[256],[256],[],[],[]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Bool","Double","Double"],
+      "outputs": [[582,598,0,6422528,4,"cuda:0"],[600,602,0,256,4,"cuda:0"],[604,605,0,256,4,"cuda:0"],[609,57,0,0,1,"cuda:0"]], "output_shapes": [[128,256,14,14],[256],[256],[0]], "output_types": ["Tensor(float)","Tensor(float)","Tensor(float)","Tensor(unsigned char)"]
+    },
+    {
+      "name": "aten::_batch_norm_impl_index", "id": 594, "rf_id": 257, "parent": 593, "fw_parent": 0, "seq_id": 777, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::_batch_norm_impl_index(Tensor input, Tensor? weight, Tensor? bias, Tensor? running_mean, Tensor? running_var, bool training, float momentum, float eps, bool cudnn_enabled) -> (Tensor, Tensor, Tensor, Tensor, int)",
+      "inputs": [[568,579,0,6422528,4,"cuda:0"],[585,586,0,256,4,"cuda:0"],[587,588,0,256,4,"cuda:0"],[589,590,0,256,4,"cuda:0"],[591,592,0,256,4,"cuda:0"],true,0.100000,0.000010,true], "input_shapes": [[128,256,14,14],[256],[256],[256],[256],[],[],[],[]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Bool","Double","Double","Bool"],
+      "outputs": [[582,598,0,6422528,4,"cuda:0"],[600,602,0,256,4,"cuda:0"],[604,605,0,256,4,"cuda:0"],[609,57,0,0,1,"cuda:0"],1], "output_shapes": [[128,256,14,14],[256],[256],[0],[]], "output_types": ["Tensor(float)","Tensor(float)","Tensor(float)","Tensor(unsigned char)","Int"]
+    },
+    {
+      "name": "aten::batch_norm", "id": 593, "rf_id": 256, "parent": 2, "fw_parent": 0, "seq_id": 777, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::batch_norm(Tensor input, Tensor? weight, Tensor? bias, Tensor? running_mean, Tensor? running_var, bool training, float momentum, float eps, bool cudnn_enabled) -> Tensor",
+      "inputs": [[568,579,0,6422528,4,"cuda:0"],[585,586,0,256,4,"cuda:0"],[587,588,0,256,4,"cuda:0"],[589,590,0,256,4,"cuda:0"],[591,592,0,256,4,"cuda:0"],true,0.100000,0.000010,true], "input_shapes": [[128,256,14,14],[256],[256],[256],[256],[],[],[],[]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Bool","Double","Double","Bool"],
+      "outputs": [[582,598,0,6422528,4,"cuda:0"]], "output_shapes": [[128,256,14,14]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::add_", "id": 610, "rf_id": 266, "parent": 2, "fw_parent": 0, "seq_id": 778, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::add_.Tensor(Tensor(a!) self, Tensor other, *, Scalar alpha=1) -> Tensor(a!)",
+      "inputs": [[582,598,0,6422528,4,"cuda:0"],[468,484,0,6422528,4,"cuda:0"],1], "input_shapes": [[128,256,14,14],[128,256,14,14],[]], "input_types": ["Tensor(float)","Tensor(float)","Int"],
+      "outputs": [[582,598,0,6422528,4,"cuda:0"]], "output_shapes": [[128,256,14,14]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::clamp_min_", "id": 612, "rf_id": 268, "parent": 611, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::clamp_min_(Tensor(a!) self, Scalar min) -> Tensor(a!)",
+      "inputs": [[582,598,0,6422528,4,"cuda:0"],0], "input_shapes": [[128,256,14,14],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [[582,598,0,6422528,4,"cuda:0"]], "output_shapes": [[128,256,14,14]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::relu_", "id": 611, "rf_id": 267, "parent": 2, "fw_parent": 0, "seq_id": 779, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::relu_(Tensor(a!) self) -> Tensor(a!)",
+      "inputs": [[582,598,0,6422528,4,"cuda:0"]], "input_shapes": [[128,256,14,14]], "input_types": ["Tensor(float)"],
+      "outputs": [[582,598,0,6422528,4,"cuda:0"]], "output_shapes": [[128,256,14,14]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::cudnn_convolution", "id": 618, "rf_id": 272, "parent": 617, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::cudnn_convolution(Tensor self, Tensor weight, int[] padding, int[] stride, int[] dilation, int groups, bool benchmark, bool deterministic, bool allow_tf32) -> Tensor",
+      "inputs": [[582,598,0,6422528,4,"cuda:0"],[613,614,0,1179648,4,"cuda:0"],[1,1],[2,2],[1,1],1,false,false,true], "input_shapes": [[128,256,14,14],[512,256,3,3],[[],[]],[[],[]],[[],[]],[],[],[],[]], "input_types": ["Tensor(float)","Tensor(float)","GenericList[Int,Int]","GenericList[Int,Int]","GenericList[Int,Int]","Int","Bool","Bool","Bool"],
+      "outputs": [[607,619,0,3211264,4,"cuda:0"]], "output_shapes": [[128,512,7,7]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::_convolution", "id": 617, "rf_id": 271, "parent": 616, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::_convolution(Tensor input, Tensor weight, Tensor? bias, int[] stride, SymInt[] padding, int[] dilation, bool transposed, SymInt[] output_padding, int groups, bool benchmark, bool deterministic, bool cudnn_enabled, bool allow_tf32) -> Tensor",
+      "inputs": [[582,598,0,6422528,4,"cuda:0"],[613,614,0,1179648,4,"cuda:0"],[23,0,0,0,0,""],[2,2],[1,1],[1,1],false,[0,0],1,false,false,true,true], "input_shapes": [[128,256,14,14],[512,256,3,3],[],[[],[]],[[],[]],[[],[]],[],[[],[]],[],[],[],[],[]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(nullptr (uninitialized))","GenericList[Int,Int]","GenericList[Int,Int]","GenericList[Int,Int]","Bool","GenericList[Int,Int]","Int","Bool","Bool","Bool","Bool"],
+      "outputs": [[607,619,0,3211264,4,"cuda:0"]], "output_shapes": [[128,512,7,7]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::convolution", "id": 616, "rf_id": 270, "parent": 615, "fw_parent": 0, "seq_id": 780, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::convolution(Tensor input, Tensor weight, Tensor? bias, int[] stride, SymInt[] padding, int[] dilation, bool transposed, SymInt[] output_padding, int groups) -> Tensor",
+      "inputs": [[582,598,0,6422528,4,"cuda:0"],[613,614,0,1179648,4,"cuda:0"],[23,0,0,0,0,""],[2,2],[1,1],[1,1],false,[0,0],1], "input_shapes": [[128,256,14,14],[512,256,3,3],[],[[],[]],[[],[]],[[],[]],[],[[],[]],[]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(nullptr (uninitialized))","GenericList[Int,Int]","GenericList[Int,Int]","GenericList[Int,Int]","Bool","GenericList[Int,Int]","Int"],
+      "outputs": [[607,619,0,3211264,4,"cuda:0"]], "output_shapes": [[128,512,7,7]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::conv2d", "id": 615, "rf_id": 269, "parent": 2, "fw_parent": 0, "seq_id": 780, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::conv2d(Tensor input, Tensor weight, Tensor? bias=None, int[2] stride=1, int[2] padding=0, int[2] dilation=1, int groups=1) -> Tensor",
+      "inputs": [[582,598,0,6422528,4,"cuda:0"],[613,614,0,1179648,4,"cuda:0"],"<None>",[2,2],[1,1],[1,1],1], "input_shapes": [[128,256,14,14],[512,256,3,3],[],[[],[]],[[],[]],[[],[]],[]], "input_types": ["Tensor(float)","Tensor(float)","None","GenericList[Int,Int]","GenericList[Int,Int]","GenericList[Int,Int]","Int"],
+      "outputs": [[607,619,0,3211264,4,"cuda:0"]], "output_shapes": [[128,512,7,7]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::add_", "id": 624, "rf_id": 273, "parent": 2, "fw_parent": 0, "seq_id": 781, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::add_.Tensor(Tensor(a!) self, Tensor other, *, Scalar alpha=1) -> Tensor(a!)",
+      "inputs": [[620,621,0,1,8,"cuda:0"],[622,623,0,1,8,"cpu"],1], "input_shapes": [[],[],[]], "input_types": ["Tensor(long int)","Tensor(long int)","Int"],
+      "outputs": [[620,621,0,1,8,"cuda:0"]], "output_shapes": [[]], "output_types": ["Tensor(long int)"]
+    },
+    {
+      "name": "aten::empty", "id": 637, "rf_id": 278, "parent": 636, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[128,512,7,7],6,0,"cuda:0","<None>",0], "input_shapes": [[[],[],[],[]],[],[],[],[],[]], "input_types": ["GenericList[Int,Int,Int,Int]","Int","Int","Device","None","Int"],
+      "outputs": [[622,638,0,3211264,4,"cuda:0"]], "output_shapes": [[128,512,7,7]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty_like", "id": 636, "rf_id": 277, "parent": 635, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty_like(Tensor self, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[607,619,0,3211264,4,"cuda:0"],6,0,"cuda:0","<None>",0], "input_shapes": [[128,512,7,7],[],[],[],[],[]], "input_types": ["Tensor(float)","Int","Int","Device","None","Int"],
+      "outputs": [[622,638,0,3211264,4,"cuda:0"]], "output_shapes": [[128,512,7,7]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::view", "id": 639, "rf_id": 279, "parent": 635, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::view(Tensor(a) self, SymInt[] size) -> Tensor(a)",
+      "inputs": [[625,626,0,512,4,"cuda:0"],[1,512,1,1]], "input_shapes": [[512],[[],[],[],[]]], "input_types": ["Tensor(float)","GenericList[Int,Int,Int,Int]"],
+      "outputs": [[640,626,0,512,4,"cuda:0"]], "output_shapes": [[1,512,1,1]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty", "id": 641, "rf_id": 280, "parent": 635, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[512],6,0,"cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","Int","Device","None","None"],
+      "outputs": [[640,642,0,512,4,"cuda:0"]], "output_shapes": [[512]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty", "id": 643, "rf_id": 281, "parent": 635, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[512],6,0,"cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","Int","Device","None","None"],
+      "outputs": [[644,645,0,512,4,"cuda:0"]], "output_shapes": [[512]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty", "id": 646, "rf_id": 282, "parent": 635, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[0],0,0,"cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","Int","Device","None","None"],
+      "outputs": [[647,57,0,0,1,"cuda:0"]], "output_shapes": [[0]], "output_types": ["Tensor(unsigned char)"]
+    },
+    {
+      "name": "aten::empty", "id": 648, "rf_id": 283, "parent": 635, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[0],0,0,"cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","Int","Device","None","None"],
+      "outputs": [[649,57,0,0,1,"cuda:0"]], "output_shapes": [[0]], "output_types": ["Tensor(unsigned char)"]
+    },
+    {
+      "name": "aten::cudnn_batch_norm", "id": 635, "rf_id": 276, "parent": 634, "fw_parent": 0, "seq_id": 781, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::cudnn_batch_norm(Tensor input, Tensor weight, Tensor? bias, Tensor? running_mean, Tensor? running_var, bool training, float exponential_average_factor, float epsilon) -> (Tensor, Tensor, Tensor, Tensor)",
+      "inputs": [[607,619,0,3211264,4,"cuda:0"],[625,626,0,512,4,"cuda:0"],[627,628,0,512,4,"cuda:0"],[629,630,0,512,4,"cuda:0"],[631,632,0,512,4,"cuda:0"],true,0.100000,0.000010], "input_shapes": [[128,512,7,7],[512],[512],[512],[512],[],[],[]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Bool","Double","Double"],
+      "outputs": [[622,638,0,3211264,4,"cuda:0"],[640,642,0,512,4,"cuda:0"],[644,645,0,512,4,"cuda:0"],[649,57,0,0,1,"cuda:0"]], "output_shapes": [[128,512,7,7],[512],[512],[0]], "output_types": ["Tensor(float)","Tensor(float)","Tensor(float)","Tensor(unsigned char)"]
+    },
+    {
+      "name": "aten::_batch_norm_impl_index", "id": 634, "rf_id": 275, "parent": 633, "fw_parent": 0, "seq_id": 781, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::_batch_norm_impl_index(Tensor input, Tensor? weight, Tensor? bias, Tensor? running_mean, Tensor? running_var, bool training, float momentum, float eps, bool cudnn_enabled) -> (Tensor, Tensor, Tensor, Tensor, int)",
+      "inputs": [[607,619,0,3211264,4,"cuda:0"],[625,626,0,512,4,"cuda:0"],[627,628,0,512,4,"cuda:0"],[629,630,0,512,4,"cuda:0"],[631,632,0,512,4,"cuda:0"],true,0.100000,0.000010,true], "input_shapes": [[128,512,7,7],[512],[512],[512],[512],[],[],[],[]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Bool","Double","Double","Bool"],
+      "outputs": [[622,638,0,3211264,4,"cuda:0"],[640,642,0,512,4,"cuda:0"],[644,645,0,512,4,"cuda:0"],[649,57,0,0,1,"cuda:0"],1], "output_shapes": [[128,512,7,7],[512],[512],[0],[]], "output_types": ["Tensor(float)","Tensor(float)","Tensor(float)","Tensor(unsigned char)","Int"]
+    },
+    {
+      "name": "aten::batch_norm", "id": 633, "rf_id": 274, "parent": 2, "fw_parent": 0, "seq_id": 781, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::batch_norm(Tensor input, Tensor? weight, Tensor? bias, Tensor? running_mean, Tensor? running_var, bool training, float momentum, float eps, bool cudnn_enabled) -> Tensor",
+      "inputs": [[607,619,0,3211264,4,"cuda:0"],[625,626,0,512,4,"cuda:0"],[627,628,0,512,4,"cuda:0"],[629,630,0,512,4,"cuda:0"],[631,632,0,512,4,"cuda:0"],true,0.100000,0.000010,true], "input_shapes": [[128,512,7,7],[512],[512],[512],[512],[],[],[],[]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Bool","Double","Double","Bool"],
+      "outputs": [[622,638,0,3211264,4,"cuda:0"]], "output_shapes": [[128,512,7,7]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::clamp_min_", "id": 651, "rf_id": 285, "parent": 650, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::clamp_min_(Tensor(a!) self, Scalar min) -> Tensor(a!)",
+      "inputs": [[622,638,0,3211264,4,"cuda:0"],0], "input_shapes": [[128,512,7,7],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [[622,638,0,3211264,4,"cuda:0"]], "output_shapes": [[128,512,7,7]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::relu_", "id": 650, "rf_id": 284, "parent": 2, "fw_parent": 0, "seq_id": 782, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::relu_(Tensor(a!) self) -> Tensor(a!)",
+      "inputs": [[622,638,0,3211264,4,"cuda:0"]], "input_shapes": [[128,512,7,7]], "input_types": ["Tensor(float)"],
+      "outputs": [[622,638,0,3211264,4,"cuda:0"]], "output_shapes": [[128,512,7,7]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::cudnn_convolution", "id": 657, "rf_id": 289, "parent": 656, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::cudnn_convolution(Tensor self, Tensor weight, int[] padding, int[] stride, int[] dilation, int groups, bool benchmark, bool deterministic, bool allow_tf32) -> Tensor",
+      "inputs": [[622,638,0,3211264,4,"cuda:0"],[652,653,0,2359296,4,"cuda:0"],[1,1],[1,1],[1,1],1,false,false,true], "input_shapes": [[128,512,7,7],[512,512,3,3],[[],[]],[[],[]],[[],[]],[],[],[],[]], "input_types": ["Tensor(float)","Tensor(float)","GenericList[Int,Int]","GenericList[Int,Int]","GenericList[Int,Int]","Int","Bool","Bool","Bool"],
+      "outputs": [[647,658,0,3211264,4,"cuda:0"]], "output_shapes": [[128,512,7,7]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::_convolution", "id": 656, "rf_id": 288, "parent": 655, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::_convolution(Tensor input, Tensor weight, Tensor? bias, int[] stride, SymInt[] padding, int[] dilation, bool transposed, SymInt[] output_padding, int groups, bool benchmark, bool deterministic, bool cudnn_enabled, bool allow_tf32) -> Tensor",
+      "inputs": [[622,638,0,3211264,4,"cuda:0"],[652,653,0,2359296,4,"cuda:0"],[23,0,0,0,0,""],[1,1],[1,1],[1,1],false,[0,0],1,false,false,true,true], "input_shapes": [[128,512,7,7],[512,512,3,3],[],[[],[]],[[],[]],[[],[]],[],[[],[]],[],[],[],[],[]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(nullptr (uninitialized))","GenericList[Int,Int]","GenericList[Int,Int]","GenericList[Int,Int]","Bool","GenericList[Int,Int]","Int","Bool","Bool","Bool","Bool"],
+      "outputs": [[647,658,0,3211264,4,"cuda:0"]], "output_shapes": [[128,512,7,7]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::convolution", "id": 655, "rf_id": 287, "parent": 654, "fw_parent": 0, "seq_id": 783, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::convolution(Tensor input, Tensor weight, Tensor? bias, int[] stride, SymInt[] padding, int[] dilation, bool transposed, SymInt[] output_padding, int groups) -> Tensor",
+      "inputs": [[622,638,0,3211264,4,"cuda:0"],[652,653,0,2359296,4,"cuda:0"],[23,0,0,0,0,""],[1,1],[1,1],[1,1],false,[0,0],1], "input_shapes": [[128,512,7,7],[512,512,3,3],[],[[],[]],[[],[]],[[],[]],[],[[],[]],[]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(nullptr (uninitialized))","GenericList[Int,Int]","GenericList[Int,Int]","GenericList[Int,Int]","Bool","GenericList[Int,Int]","Int"],
+      "outputs": [[647,658,0,3211264,4,"cuda:0"]], "output_shapes": [[128,512,7,7]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::conv2d", "id": 654, "rf_id": 286, "parent": 2, "fw_parent": 0, "seq_id": 783, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::conv2d(Tensor input, Tensor weight, Tensor? bias=None, int[2] stride=1, int[2] padding=0, int[2] dilation=1, int groups=1) -> Tensor",
+      "inputs": [[622,638,0,3211264,4,"cuda:0"],[652,653,0,2359296,4,"cuda:0"],"<None>",[1,1],[1,1],[1,1],1], "input_shapes": [[128,512,7,7],[512,512,3,3],[],[[],[]],[[],[]],[[],[]],[]], "input_types": ["Tensor(float)","Tensor(float)","None","GenericList[Int,Int]","GenericList[Int,Int]","GenericList[Int,Int]","Int"],
+      "outputs": [[647,658,0,3211264,4,"cuda:0"]], "output_shapes": [[128,512,7,7]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::add_", "id": 663, "rf_id": 290, "parent": 2, "fw_parent": 0, "seq_id": 784, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::add_.Tensor(Tensor(a!) self, Tensor other, *, Scalar alpha=1) -> Tensor(a!)",
+      "inputs": [[659,660,0,1,8,"cuda:0"],[661,662,0,1,8,"cpu"],1], "input_shapes": [[],[],[]], "input_types": ["Tensor(long int)","Tensor(long int)","Int"],
+      "outputs": [[659,660,0,1,8,"cuda:0"]], "output_shapes": [[]], "output_types": ["Tensor(long int)"]
+    },
+    {
+      "name": "aten::empty", "id": 676, "rf_id": 295, "parent": 675, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[128,512,7,7],6,0,"cuda:0","<None>",0], "input_shapes": [[[],[],[],[]],[],[],[],[],[]], "input_types": ["GenericList[Int,Int,Int,Int]","Int","Int","Device","None","Int"],
+      "outputs": [[661,677,0,3211264,4,"cuda:0"]], "output_shapes": [[128,512,7,7]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty_like", "id": 675, "rf_id": 294, "parent": 674, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty_like(Tensor self, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[647,658,0,3211264,4,"cuda:0"],6,0,"cuda:0","<None>",0], "input_shapes": [[128,512,7,7],[],[],[],[],[]], "input_types": ["Tensor(float)","Int","Int","Device","None","Int"],
+      "outputs": [[661,677,0,3211264,4,"cuda:0"]], "output_shapes": [[128,512,7,7]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::view", "id": 678, "rf_id": 296, "parent": 674, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::view(Tensor(a) self, SymInt[] size) -> Tensor(a)",
+      "inputs": [[664,665,0,512,4,"cuda:0"],[1,512,1,1]], "input_shapes": [[512],[[],[],[],[]]], "input_types": ["Tensor(float)","GenericList[Int,Int,Int,Int]"],
+      "outputs": [[679,665,0,512,4,"cuda:0"]], "output_shapes": [[1,512,1,1]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty", "id": 680, "rf_id": 297, "parent": 674, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[512],6,0,"cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","Int","Device","None","None"],
+      "outputs": [[679,681,0,512,4,"cuda:0"]], "output_shapes": [[512]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty", "id": 682, "rf_id": 298, "parent": 674, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[512],6,0,"cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","Int","Device","None","None"],
+      "outputs": [[683,684,0,512,4,"cuda:0"]], "output_shapes": [[512]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty", "id": 685, "rf_id": 299, "parent": 674, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[0],0,0,"cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","Int","Device","None","None"],
+      "outputs": [[686,57,0,0,1,"cuda:0"]], "output_shapes": [[0]], "output_types": ["Tensor(unsigned char)"]
+    },
+    {
+      "name": "aten::empty", "id": 687, "rf_id": 300, "parent": 674, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[0],0,0,"cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","Int","Device","None","None"],
+      "outputs": [[688,57,0,0,1,"cuda:0"]], "output_shapes": [[0]], "output_types": ["Tensor(unsigned char)"]
+    },
+    {
+      "name": "aten::cudnn_batch_norm", "id": 674, "rf_id": 293, "parent": 673, "fw_parent": 0, "seq_id": 784, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::cudnn_batch_norm(Tensor input, Tensor weight, Tensor? bias, Tensor? running_mean, Tensor? running_var, bool training, float exponential_average_factor, float epsilon) -> (Tensor, Tensor, Tensor, Tensor)",
+      "inputs": [[647,658,0,3211264,4,"cuda:0"],[664,665,0,512,4,"cuda:0"],[666,667,0,512,4,"cuda:0"],[668,669,0,512,4,"cuda:0"],[670,671,0,512,4,"cuda:0"],true,0.100000,0.000010], "input_shapes": [[128,512,7,7],[512],[512],[512],[512],[],[],[]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Bool","Double","Double"],
+      "outputs": [[661,677,0,3211264,4,"cuda:0"],[679,681,0,512,4,"cuda:0"],[683,684,0,512,4,"cuda:0"],[688,57,0,0,1,"cuda:0"]], "output_shapes": [[128,512,7,7],[512],[512],[0]], "output_types": ["Tensor(float)","Tensor(float)","Tensor(float)","Tensor(unsigned char)"]
+    },
+    {
+      "name": "aten::_batch_norm_impl_index", "id": 673, "rf_id": 292, "parent": 672, "fw_parent": 0, "seq_id": 784, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::_batch_norm_impl_index(Tensor input, Tensor? weight, Tensor? bias, Tensor? running_mean, Tensor? running_var, bool training, float momentum, float eps, bool cudnn_enabled) -> (Tensor, Tensor, Tensor, Tensor, int)",
+      "inputs": [[647,658,0,3211264,4,"cuda:0"],[664,665,0,512,4,"cuda:0"],[666,667,0,512,4,"cuda:0"],[668,669,0,512,4,"cuda:0"],[670,671,0,512,4,"cuda:0"],true,0.100000,0.000010,true], "input_shapes": [[128,512,7,7],[512],[512],[512],[512],[],[],[],[]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Bool","Double","Double","Bool"],
+      "outputs": [[661,677,0,3211264,4,"cuda:0"],[679,681,0,512,4,"cuda:0"],[683,684,0,512,4,"cuda:0"],[688,57,0,0,1,"cuda:0"],1], "output_shapes": [[128,512,7,7],[512],[512],[0],[]], "output_types": ["Tensor(float)","Tensor(float)","Tensor(float)","Tensor(unsigned char)","Int"]
+    },
+    {
+      "name": "aten::batch_norm", "id": 672, "rf_id": 291, "parent": 2, "fw_parent": 0, "seq_id": 784, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::batch_norm(Tensor input, Tensor? weight, Tensor? bias, Tensor? running_mean, Tensor? running_var, bool training, float momentum, float eps, bool cudnn_enabled) -> Tensor",
+      "inputs": [[647,658,0,3211264,4,"cuda:0"],[664,665,0,512,4,"cuda:0"],[666,667,0,512,4,"cuda:0"],[668,669,0,512,4,"cuda:0"],[670,671,0,512,4,"cuda:0"],true,0.100000,0.000010,true], "input_shapes": [[128,512,7,7],[512],[512],[512],[512],[],[],[],[]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Bool","Double","Double","Bool"],
+      "outputs": [[661,677,0,3211264,4,"cuda:0"]], "output_shapes": [[128,512,7,7]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::cudnn_convolution", "id": 694, "rf_id": 304, "parent": 693, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::cudnn_convolution(Tensor self, Tensor weight, int[] padding, int[] stride, int[] dilation, int groups, bool benchmark, bool deterministic, bool allow_tf32) -> Tensor",
+      "inputs": [[582,598,0,6422528,4,"cuda:0"],[689,690,0,131072,4,"cuda:0"],[0,0],[2,2],[1,1],1,false,false,true], "input_shapes": [[128,256,14,14],[512,256,1,1],[[],[]],[[],[]],[[],[]],[],[],[],[]], "input_types": ["Tensor(float)","Tensor(float)","GenericList[Int,Int]","GenericList[Int,Int]","GenericList[Int,Int]","Int","Bool","Bool","Bool"],
+      "outputs": [[695,696,0,3211264,4,"cuda:0"]], "output_shapes": [[128,512,7,7]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::_convolution", "id": 693, "rf_id": 303, "parent": 692, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::_convolution(Tensor input, Tensor weight, Tensor? bias, int[] stride, SymInt[] padding, int[] dilation, bool transposed, SymInt[] output_padding, int groups, bool benchmark, bool deterministic, bool cudnn_enabled, bool allow_tf32) -> Tensor",
+      "inputs": [[582,598,0,6422528,4,"cuda:0"],[689,690,0,131072,4,"cuda:0"],[23,0,0,0,0,""],[2,2],[0,0],[1,1],false,[0,0],1,false,false,true,true], "input_shapes": [[128,256,14,14],[512,256,1,1],[],[[],[]],[[],[]],[[],[]],[],[[],[]],[],[],[],[],[]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(nullptr (uninitialized))","GenericList[Int,Int]","GenericList[Int,Int]","GenericList[Int,Int]","Bool","GenericList[Int,Int]","Int","Bool","Bool","Bool","Bool"],
+      "outputs": [[695,696,0,3211264,4,"cuda:0"]], "output_shapes": [[128,512,7,7]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::convolution", "id": 692, "rf_id": 302, "parent": 691, "fw_parent": 0, "seq_id": 785, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::convolution(Tensor input, Tensor weight, Tensor? bias, int[] stride, SymInt[] padding, int[] dilation, bool transposed, SymInt[] output_padding, int groups) -> Tensor",
+      "inputs": [[582,598,0,6422528,4,"cuda:0"],[689,690,0,131072,4,"cuda:0"],[23,0,0,0,0,""],[2,2],[0,0],[1,1],false,[0,0],1], "input_shapes": [[128,256,14,14],[512,256,1,1],[],[[],[]],[[],[]],[[],[]],[],[[],[]],[]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(nullptr (uninitialized))","GenericList[Int,Int]","GenericList[Int,Int]","GenericList[Int,Int]","Bool","GenericList[Int,Int]","Int"],
+      "outputs": [[695,696,0,3211264,4,"cuda:0"]], "output_shapes": [[128,512,7,7]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::conv2d", "id": 691, "rf_id": 301, "parent": 2, "fw_parent": 0, "seq_id": 785, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::conv2d(Tensor input, Tensor weight, Tensor? bias=None, int[2] stride=1, int[2] padding=0, int[2] dilation=1, int groups=1) -> Tensor",
+      "inputs": [[582,598,0,6422528,4,"cuda:0"],[689,690,0,131072,4,"cuda:0"],"<None>",[2,2],[0,0],[1,1],1], "input_shapes": [[128,256,14,14],[512,256,1,1],[],[[],[]],[[],[]],[[],[]],[]], "input_types": ["Tensor(float)","Tensor(float)","None","GenericList[Int,Int]","GenericList[Int,Int]","GenericList[Int,Int]","Int"],
+      "outputs": [[695,696,0,3211264,4,"cuda:0"]], "output_shapes": [[128,512,7,7]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::add_", "id": 700, "rf_id": 305, "parent": 2, "fw_parent": 0, "seq_id": 786, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::add_.Tensor(Tensor(a!) self, Tensor other, *, Scalar alpha=1) -> Tensor(a!)",
+      "inputs": [[697,698,0,1,8,"cuda:0"],[686,699,0,1,8,"cpu"],1], "input_shapes": [[],[],[]], "input_types": ["Tensor(long int)","Tensor(long int)","Int"],
+      "outputs": [[697,698,0,1,8,"cuda:0"]], "output_shapes": [[]], "output_types": ["Tensor(long int)"]
+    },
+    {
+      "name": "aten::empty", "id": 713, "rf_id": 310, "parent": 712, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[128,512,7,7],6,0,"cuda:0","<None>",0], "input_shapes": [[[],[],[],[]],[],[],[],[],[]], "input_types": ["GenericList[Int,Int,Int,Int]","Int","Int","Device","None","Int"],
+      "outputs": [[686,714,0,3211264,4,"cuda:0"]], "output_shapes": [[128,512,7,7]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty_like", "id": 712, "rf_id": 309, "parent": 711, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty_like(Tensor self, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[695,696,0,3211264,4,"cuda:0"],6,0,"cuda:0","<None>",0], "input_shapes": [[128,512,7,7],[],[],[],[],[]], "input_types": ["Tensor(float)","Int","Int","Device","None","Int"],
+      "outputs": [[686,714,0,3211264,4,"cuda:0"]], "output_shapes": [[128,512,7,7]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::view", "id": 715, "rf_id": 311, "parent": 711, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::view(Tensor(a) self, SymInt[] size) -> Tensor(a)",
+      "inputs": [[701,702,0,512,4,"cuda:0"],[1,512,1,1]], "input_shapes": [[512],[[],[],[],[]]], "input_types": ["Tensor(float)","GenericList[Int,Int,Int,Int]"],
+      "outputs": [[716,702,0,512,4,"cuda:0"]], "output_shapes": [[1,512,1,1]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty", "id": 717, "rf_id": 312, "parent": 711, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[512],6,0,"cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","Int","Device","None","None"],
+      "outputs": [[716,718,0,512,4,"cuda:0"]], "output_shapes": [[512]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty", "id": 719, "rf_id": 313, "parent": 711, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[512],6,0,"cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","Int","Device","None","None"],
+      "outputs": [[720,721,0,512,4,"cuda:0"]], "output_shapes": [[512]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty", "id": 722, "rf_id": 314, "parent": 711, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[0],0,0,"cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","Int","Device","None","None"],
+      "outputs": [[723,57,0,0,1,"cuda:0"]], "output_shapes": [[0]], "output_types": ["Tensor(unsigned char)"]
+    },
+    {
+      "name": "aten::empty", "id": 724, "rf_id": 315, "parent": 711, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[0],0,0,"cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","Int","Device","None","None"],
+      "outputs": [[725,57,0,0,1,"cuda:0"]], "output_shapes": [[0]], "output_types": ["Tensor(unsigned char)"]
+    },
+    {
+      "name": "aten::cudnn_batch_norm", "id": 711, "rf_id": 308, "parent": 710, "fw_parent": 0, "seq_id": 786, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::cudnn_batch_norm(Tensor input, Tensor weight, Tensor? bias, Tensor? running_mean, Tensor? running_var, bool training, float exponential_average_factor, float epsilon) -> (Tensor, Tensor, Tensor, Tensor)",
+      "inputs": [[695,696,0,3211264,4,"cuda:0"],[701,702,0,512,4,"cuda:0"],[703,704,0,512,4,"cuda:0"],[705,706,0,512,4,"cuda:0"],[707,708,0,512,4,"cuda:0"],true,0.100000,0.000010], "input_shapes": [[128,512,7,7],[512],[512],[512],[512],[],[],[]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Bool","Double","Double"],
+      "outputs": [[686,714,0,3211264,4,"cuda:0"],[716,718,0,512,4,"cuda:0"],[720,721,0,512,4,"cuda:0"],[725,57,0,0,1,"cuda:0"]], "output_shapes": [[128,512,7,7],[512],[512],[0]], "output_types": ["Tensor(float)","Tensor(float)","Tensor(float)","Tensor(unsigned char)"]
+    },
+    {
+      "name": "aten::_batch_norm_impl_index", "id": 710, "rf_id": 307, "parent": 709, "fw_parent": 0, "seq_id": 786, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::_batch_norm_impl_index(Tensor input, Tensor? weight, Tensor? bias, Tensor? running_mean, Tensor? running_var, bool training, float momentum, float eps, bool cudnn_enabled) -> (Tensor, Tensor, Tensor, Tensor, int)",
+      "inputs": [[695,696,0,3211264,4,"cuda:0"],[701,702,0,512,4,"cuda:0"],[703,704,0,512,4,"cuda:0"],[705,706,0,512,4,"cuda:0"],[707,708,0,512,4,"cuda:0"],true,0.100000,0.000010,true], "input_shapes": [[128,512,7,7],[512],[512],[512],[512],[],[],[],[]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Bool","Double","Double","Bool"],
+      "outputs": [[686,714,0,3211264,4,"cuda:0"],[716,718,0,512,4,"cuda:0"],[720,721,0,512,4,"cuda:0"],[725,57,0,0,1,"cuda:0"],1], "output_shapes": [[128,512,7,7],[512],[512],[0],[]], "output_types": ["Tensor(float)","Tensor(float)","Tensor(float)","Tensor(unsigned char)","Int"]
+    },
+    {
+      "name": "aten::batch_norm", "id": 709, "rf_id": 306, "parent": 2, "fw_parent": 0, "seq_id": 786, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::batch_norm(Tensor input, Tensor? weight, Tensor? bias, Tensor? running_mean, Tensor? running_var, bool training, float momentum, float eps, bool cudnn_enabled) -> Tensor",
+      "inputs": [[695,696,0,3211264,4,"cuda:0"],[701,702,0,512,4,"cuda:0"],[703,704,0,512,4,"cuda:0"],[705,706,0,512,4,"cuda:0"],[707,708,0,512,4,"cuda:0"],true,0.100000,0.000010,true], "input_shapes": [[128,512,7,7],[512],[512],[512],[512],[],[],[],[]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Bool","Double","Double","Bool"],
+      "outputs": [[686,714,0,3211264,4,"cuda:0"]], "output_shapes": [[128,512,7,7]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::add_", "id": 726, "rf_id": 316, "parent": 2, "fw_parent": 0, "seq_id": 787, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::add_.Tensor(Tensor(a!) self, Tensor other, *, Scalar alpha=1) -> Tensor(a!)",
+      "inputs": [[661,677,0,3211264,4,"cuda:0"],[686,714,0,3211264,4,"cuda:0"],1], "input_shapes": [[128,512,7,7],[128,512,7,7],[]], "input_types": ["Tensor(float)","Tensor(float)","Int"],
+      "outputs": [[661,677,0,3211264,4,"cuda:0"]], "output_shapes": [[128,512,7,7]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::clamp_min_", "id": 728, "rf_id": 318, "parent": 727, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::clamp_min_(Tensor(a!) self, Scalar min) -> Tensor(a!)",
+      "inputs": [[661,677,0,3211264,4,"cuda:0"],0], "input_shapes": [[128,512,7,7],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [[661,677,0,3211264,4,"cuda:0"]], "output_shapes": [[128,512,7,7]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::relu_", "id": 727, "rf_id": 317, "parent": 2, "fw_parent": 0, "seq_id": 788, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::relu_(Tensor(a!) self) -> Tensor(a!)",
+      "inputs": [[661,677,0,3211264,4,"cuda:0"]], "input_shapes": [[128,512,7,7]], "input_types": ["Tensor(float)"],
+      "outputs": [[661,677,0,3211264,4,"cuda:0"]], "output_shapes": [[128,512,7,7]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::cudnn_convolution", "id": 734, "rf_id": 322, "parent": 733, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::cudnn_convolution(Tensor self, Tensor weight, int[] padding, int[] stride, int[] dilation, int groups, bool benchmark, bool deterministic, bool allow_tf32) -> Tensor",
+      "inputs": [[661,677,0,3211264,4,"cuda:0"],[729,730,0,2359296,4,"cuda:0"],[1,1],[1,1],[1,1],1,false,false,true], "input_shapes": [[128,512,7,7],[512,512,3,3],[[],[]],[[],[]],[[],[]],[],[],[],[]], "input_types": ["Tensor(float)","Tensor(float)","GenericList[Int,Int]","GenericList[Int,Int]","GenericList[Int,Int]","Int","Bool","Bool","Bool"],
+      "outputs": [[686,714,0,3211264,4,"cuda:0"]], "output_shapes": [[128,512,7,7]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::_convolution", "id": 733, "rf_id": 321, "parent": 732, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::_convolution(Tensor input, Tensor weight, Tensor? bias, int[] stride, SymInt[] padding, int[] dilation, bool transposed, SymInt[] output_padding, int groups, bool benchmark, bool deterministic, bool cudnn_enabled, bool allow_tf32) -> Tensor",
+      "inputs": [[661,677,0,3211264,4,"cuda:0"],[729,730,0,2359296,4,"cuda:0"],[23,0,0,0,0,""],[1,1],[1,1],[1,1],false,[0,0],1,false,false,true,true], "input_shapes": [[128,512,7,7],[512,512,3,3],[],[[],[]],[[],[]],[[],[]],[],[[],[]],[],[],[],[],[]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(nullptr (uninitialized))","GenericList[Int,Int]","GenericList[Int,Int]","GenericList[Int,Int]","Bool","GenericList[Int,Int]","Int","Bool","Bool","Bool","Bool"],
+      "outputs": [[686,714,0,3211264,4,"cuda:0"]], "output_shapes": [[128,512,7,7]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::convolution", "id": 732, "rf_id": 320, "parent": 731, "fw_parent": 0, "seq_id": 789, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::convolution(Tensor input, Tensor weight, Tensor? bias, int[] stride, SymInt[] padding, int[] dilation, bool transposed, SymInt[] output_padding, int groups) -> Tensor",
+      "inputs": [[661,677,0,3211264,4,"cuda:0"],[729,730,0,2359296,4,"cuda:0"],[23,0,0,0,0,""],[1,1],[1,1],[1,1],false,[0,0],1], "input_shapes": [[128,512,7,7],[512,512,3,3],[],[[],[]],[[],[]],[[],[]],[],[[],[]],[]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(nullptr (uninitialized))","GenericList[Int,Int]","GenericList[Int,Int]","GenericList[Int,Int]","Bool","GenericList[Int,Int]","Int"],
+      "outputs": [[686,714,0,3211264,4,"cuda:0"]], "output_shapes": [[128,512,7,7]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::conv2d", "id": 731, "rf_id": 319, "parent": 2, "fw_parent": 0, "seq_id": 789, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::conv2d(Tensor input, Tensor weight, Tensor? bias=None, int[2] stride=1, int[2] padding=0, int[2] dilation=1, int groups=1) -> Tensor",
+      "inputs": [[661,677,0,3211264,4,"cuda:0"],[729,730,0,2359296,4,"cuda:0"],"<None>",[1,1],[1,1],[1,1],1], "input_shapes": [[128,512,7,7],[512,512,3,3],[],[[],[]],[[],[]],[[],[]],[]], "input_types": ["Tensor(float)","Tensor(float)","None","GenericList[Int,Int]","GenericList[Int,Int]","GenericList[Int,Int]","Int"],
+      "outputs": [[686,714,0,3211264,4,"cuda:0"]], "output_shapes": [[128,512,7,7]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::add_", "id": 738, "rf_id": 323, "parent": 2, "fw_parent": 0, "seq_id": 790, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::add_.Tensor(Tensor(a!) self, Tensor other, *, Scalar alpha=1) -> Tensor(a!)",
+      "inputs": [[735,736,0,1,8,"cuda:0"],[723,737,0,1,8,"cpu"],1], "input_shapes": [[],[],[]], "input_types": ["Tensor(long int)","Tensor(long int)","Int"],
+      "outputs": [[735,736,0,1,8,"cuda:0"]], "output_shapes": [[]], "output_types": ["Tensor(long int)"]
+    },
+    {
+      "name": "aten::empty", "id": 751, "rf_id": 328, "parent": 750, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[128,512,7,7],6,0,"cuda:0","<None>",0], "input_shapes": [[[],[],[],[]],[],[],[],[],[]], "input_types": ["GenericList[Int,Int,Int,Int]","Int","Int","Device","None","Int"],
+      "outputs": [[723,752,0,3211264,4,"cuda:0"]], "output_shapes": [[128,512,7,7]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty_like", "id": 750, "rf_id": 327, "parent": 749, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty_like(Tensor self, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[686,714,0,3211264,4,"cuda:0"],6,0,"cuda:0","<None>",0], "input_shapes": [[128,512,7,7],[],[],[],[],[]], "input_types": ["Tensor(float)","Int","Int","Device","None","Int"],
+      "outputs": [[723,752,0,3211264,4,"cuda:0"]], "output_shapes": [[128,512,7,7]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::view", "id": 753, "rf_id": 329, "parent": 749, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::view(Tensor(a) self, SymInt[] size) -> Tensor(a)",
+      "inputs": [[739,740,0,512,4,"cuda:0"],[1,512,1,1]], "input_shapes": [[512],[[],[],[],[]]], "input_types": ["Tensor(float)","GenericList[Int,Int,Int,Int]"],
+      "outputs": [[754,740,0,512,4,"cuda:0"]], "output_shapes": [[1,512,1,1]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty", "id": 755, "rf_id": 330, "parent": 749, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[512],6,0,"cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","Int","Device","None","None"],
+      "outputs": [[754,756,0,512,4,"cuda:0"]], "output_shapes": [[512]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty", "id": 757, "rf_id": 331, "parent": 749, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[512],6,0,"cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","Int","Device","None","None"],
+      "outputs": [[758,759,0,512,4,"cuda:0"]], "output_shapes": [[512]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty", "id": 760, "rf_id": 332, "parent": 749, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[0],0,0,"cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","Int","Device","None","None"],
+      "outputs": [[761,57,0,0,1,"cuda:0"]], "output_shapes": [[0]], "output_types": ["Tensor(unsigned char)"]
+    },
+    {
+      "name": "aten::empty", "id": 762, "rf_id": 333, "parent": 749, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[0],0,0,"cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","Int","Device","None","None"],
+      "outputs": [[763,57,0,0,1,"cuda:0"]], "output_shapes": [[0]], "output_types": ["Tensor(unsigned char)"]
+    },
+    {
+      "name": "aten::cudnn_batch_norm", "id": 749, "rf_id": 326, "parent": 748, "fw_parent": 0, "seq_id": 790, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::cudnn_batch_norm(Tensor input, Tensor weight, Tensor? bias, Tensor? running_mean, Tensor? running_var, bool training, float exponential_average_factor, float epsilon) -> (Tensor, Tensor, Tensor, Tensor)",
+      "inputs": [[686,714,0,3211264,4,"cuda:0"],[739,740,0,512,4,"cuda:0"],[741,742,0,512,4,"cuda:0"],[743,744,0,512,4,"cuda:0"],[745,746,0,512,4,"cuda:0"],true,0.100000,0.000010], "input_shapes": [[128,512,7,7],[512],[512],[512],[512],[],[],[]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Bool","Double","Double"],
+      "outputs": [[723,752,0,3211264,4,"cuda:0"],[754,756,0,512,4,"cuda:0"],[758,759,0,512,4,"cuda:0"],[763,57,0,0,1,"cuda:0"]], "output_shapes": [[128,512,7,7],[512],[512],[0]], "output_types": ["Tensor(float)","Tensor(float)","Tensor(float)","Tensor(unsigned char)"]
+    },
+    {
+      "name": "aten::_batch_norm_impl_index", "id": 748, "rf_id": 325, "parent": 747, "fw_parent": 0, "seq_id": 790, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::_batch_norm_impl_index(Tensor input, Tensor? weight, Tensor? bias, Tensor? running_mean, Tensor? running_var, bool training, float momentum, float eps, bool cudnn_enabled) -> (Tensor, Tensor, Tensor, Tensor, int)",
+      "inputs": [[686,714,0,3211264,4,"cuda:0"],[739,740,0,512,4,"cuda:0"],[741,742,0,512,4,"cuda:0"],[743,744,0,512,4,"cuda:0"],[745,746,0,512,4,"cuda:0"],true,0.100000,0.000010,true], "input_shapes": [[128,512,7,7],[512],[512],[512],[512],[],[],[],[]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Bool","Double","Double","Bool"],
+      "outputs": [[723,752,0,3211264,4,"cuda:0"],[754,756,0,512,4,"cuda:0"],[758,759,0,512,4,"cuda:0"],[763,57,0,0,1,"cuda:0"],1], "output_shapes": [[128,512,7,7],[512],[512],[0],[]], "output_types": ["Tensor(float)","Tensor(float)","Tensor(float)","Tensor(unsigned char)","Int"]
+    },
+    {
+      "name": "aten::batch_norm", "id": 747, "rf_id": 324, "parent": 2, "fw_parent": 0, "seq_id": 790, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::batch_norm(Tensor input, Tensor? weight, Tensor? bias, Tensor? running_mean, Tensor? running_var, bool training, float momentum, float eps, bool cudnn_enabled) -> Tensor",
+      "inputs": [[686,714,0,3211264,4,"cuda:0"],[739,740,0,512,4,"cuda:0"],[741,742,0,512,4,"cuda:0"],[743,744,0,512,4,"cuda:0"],[745,746,0,512,4,"cuda:0"],true,0.100000,0.000010,true], "input_shapes": [[128,512,7,7],[512],[512],[512],[512],[],[],[],[]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Bool","Double","Double","Bool"],
+      "outputs": [[723,752,0,3211264,4,"cuda:0"]], "output_shapes": [[128,512,7,7]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::clamp_min_", "id": 765, "rf_id": 335, "parent": 764, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::clamp_min_(Tensor(a!) self, Scalar min) -> Tensor(a!)",
+      "inputs": [[723,752,0,3211264,4,"cuda:0"],0], "input_shapes": [[128,512,7,7],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [[723,752,0,3211264,4,"cuda:0"]], "output_shapes": [[128,512,7,7]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::relu_", "id": 764, "rf_id": 334, "parent": 2, "fw_parent": 0, "seq_id": 791, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::relu_(Tensor(a!) self) -> Tensor(a!)",
+      "inputs": [[723,752,0,3211264,4,"cuda:0"]], "input_shapes": [[128,512,7,7]], "input_types": ["Tensor(float)"],
+      "outputs": [[723,752,0,3211264,4,"cuda:0"]], "output_shapes": [[128,512,7,7]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::cudnn_convolution", "id": 771, "rf_id": 339, "parent": 770, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::cudnn_convolution(Tensor self, Tensor weight, int[] padding, int[] stride, int[] dilation, int groups, bool benchmark, bool deterministic, bool allow_tf32) -> Tensor",
+      "inputs": [[723,752,0,3211264,4,"cuda:0"],[766,767,0,2359296,4,"cuda:0"],[1,1],[1,1],[1,1],1,false,false,true], "input_shapes": [[128,512,7,7],[512,512,3,3],[[],[]],[[],[]],[[],[]],[],[],[],[]], "input_types": ["Tensor(float)","Tensor(float)","GenericList[Int,Int]","GenericList[Int,Int]","GenericList[Int,Int]","Int","Bool","Bool","Bool"],
+      "outputs": [[761,772,0,3211264,4,"cuda:0"]], "output_shapes": [[128,512,7,7]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::_convolution", "id": 770, "rf_id": 338, "parent": 769, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::_convolution(Tensor input, Tensor weight, Tensor? bias, int[] stride, SymInt[] padding, int[] dilation, bool transposed, SymInt[] output_padding, int groups, bool benchmark, bool deterministic, bool cudnn_enabled, bool allow_tf32) -> Tensor",
+      "inputs": [[723,752,0,3211264,4,"cuda:0"],[766,767,0,2359296,4,"cuda:0"],[23,0,0,0,0,""],[1,1],[1,1],[1,1],false,[0,0],1,false,false,true,true], "input_shapes": [[128,512,7,7],[512,512,3,3],[],[[],[]],[[],[]],[[],[]],[],[[],[]],[],[],[],[],[]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(nullptr (uninitialized))","GenericList[Int,Int]","GenericList[Int,Int]","GenericList[Int,Int]","Bool","GenericList[Int,Int]","Int","Bool","Bool","Bool","Bool"],
+      "outputs": [[761,772,0,3211264,4,"cuda:0"]], "output_shapes": [[128,512,7,7]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::convolution", "id": 769, "rf_id": 337, "parent": 768, "fw_parent": 0, "seq_id": 792, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::convolution(Tensor input, Tensor weight, Tensor? bias, int[] stride, SymInt[] padding, int[] dilation, bool transposed, SymInt[] output_padding, int groups) -> Tensor",
+      "inputs": [[723,752,0,3211264,4,"cuda:0"],[766,767,0,2359296,4,"cuda:0"],[23,0,0,0,0,""],[1,1],[1,1],[1,1],false,[0,0],1], "input_shapes": [[128,512,7,7],[512,512,3,3],[],[[],[]],[[],[]],[[],[]],[],[[],[]],[]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(nullptr (uninitialized))","GenericList[Int,Int]","GenericList[Int,Int]","GenericList[Int,Int]","Bool","GenericList[Int,Int]","Int"],
+      "outputs": [[761,772,0,3211264,4,"cuda:0"]], "output_shapes": [[128,512,7,7]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::conv2d", "id": 768, "rf_id": 336, "parent": 2, "fw_parent": 0, "seq_id": 792, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::conv2d(Tensor input, Tensor weight, Tensor? bias=None, int[2] stride=1, int[2] padding=0, int[2] dilation=1, int groups=1) -> Tensor",
+      "inputs": [[723,752,0,3211264,4,"cuda:0"],[766,767,0,2359296,4,"cuda:0"],"<None>",[1,1],[1,1],[1,1],1], "input_shapes": [[128,512,7,7],[512,512,3,3],[],[[],[]],[[],[]],[[],[]],[]], "input_types": ["Tensor(float)","Tensor(float)","None","GenericList[Int,Int]","GenericList[Int,Int]","GenericList[Int,Int]","Int"],
+      "outputs": [[761,772,0,3211264,4,"cuda:0"]], "output_shapes": [[128,512,7,7]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::add_", "id": 777, "rf_id": 340, "parent": 2, "fw_parent": 0, "seq_id": 793, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::add_.Tensor(Tensor(a!) self, Tensor other, *, Scalar alpha=1) -> Tensor(a!)",
+      "inputs": [[773,774,0,1,8,"cuda:0"],[775,776,0,1,8,"cpu"],1], "input_shapes": [[],[],[]], "input_types": ["Tensor(long int)","Tensor(long int)","Int"],
+      "outputs": [[773,774,0,1,8,"cuda:0"]], "output_shapes": [[]], "output_types": ["Tensor(long int)"]
+    },
+    {
+      "name": "aten::empty", "id": 790, "rf_id": 345, "parent": 789, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[128,512,7,7],6,0,"cuda:0","<None>",0], "input_shapes": [[[],[],[],[]],[],[],[],[],[]], "input_types": ["GenericList[Int,Int,Int,Int]","Int","Int","Device","None","Int"],
+      "outputs": [[775,791,0,3211264,4,"cuda:0"]], "output_shapes": [[128,512,7,7]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty_like", "id": 789, "rf_id": 344, "parent": 788, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty_like(Tensor self, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[761,772,0,3211264,4,"cuda:0"],6,0,"cuda:0","<None>",0], "input_shapes": [[128,512,7,7],[],[],[],[],[]], "input_types": ["Tensor(float)","Int","Int","Device","None","Int"],
+      "outputs": [[775,791,0,3211264,4,"cuda:0"]], "output_shapes": [[128,512,7,7]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::view", "id": 792, "rf_id": 346, "parent": 788, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::view(Tensor(a) self, SymInt[] size) -> Tensor(a)",
+      "inputs": [[778,779,0,512,4,"cuda:0"],[1,512,1,1]], "input_shapes": [[512],[[],[],[],[]]], "input_types": ["Tensor(float)","GenericList[Int,Int,Int,Int]"],
+      "outputs": [[793,779,0,512,4,"cuda:0"]], "output_shapes": [[1,512,1,1]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty", "id": 794, "rf_id": 347, "parent": 788, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[512],6,0,"cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","Int","Device","None","None"],
+      "outputs": [[793,795,0,512,4,"cuda:0"]], "output_shapes": [[512]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty", "id": 796, "rf_id": 348, "parent": 788, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[512],6,0,"cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","Int","Device","None","None"],
+      "outputs": [[797,798,0,512,4,"cuda:0"]], "output_shapes": [[512]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty", "id": 799, "rf_id": 349, "parent": 788, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[0],0,0,"cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","Int","Device","None","None"],
+      "outputs": [[800,57,0,0,1,"cuda:0"]], "output_shapes": [[0]], "output_types": ["Tensor(unsigned char)"]
+    },
+    {
+      "name": "aten::empty", "id": 801, "rf_id": 350, "parent": 788, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[0],0,0,"cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","Int","Device","None","None"],
+      "outputs": [[802,57,0,0,1,"cuda:0"]], "output_shapes": [[0]], "output_types": ["Tensor(unsigned char)"]
+    },
+    {
+      "name": "aten::cudnn_batch_norm", "id": 788, "rf_id": 343, "parent": 787, "fw_parent": 0, "seq_id": 793, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::cudnn_batch_norm(Tensor input, Tensor weight, Tensor? bias, Tensor? running_mean, Tensor? running_var, bool training, float exponential_average_factor, float epsilon) -> (Tensor, Tensor, Tensor, Tensor)",
+      "inputs": [[761,772,0,3211264,4,"cuda:0"],[778,779,0,512,4,"cuda:0"],[780,781,0,512,4,"cuda:0"],[782,783,0,512,4,"cuda:0"],[784,785,0,512,4,"cuda:0"],true,0.100000,0.000010], "input_shapes": [[128,512,7,7],[512],[512],[512],[512],[],[],[]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Bool","Double","Double"],
+      "outputs": [[775,791,0,3211264,4,"cuda:0"],[793,795,0,512,4,"cuda:0"],[797,798,0,512,4,"cuda:0"],[802,57,0,0,1,"cuda:0"]], "output_shapes": [[128,512,7,7],[512],[512],[0]], "output_types": ["Tensor(float)","Tensor(float)","Tensor(float)","Tensor(unsigned char)"]
+    },
+    {
+      "name": "aten::_batch_norm_impl_index", "id": 787, "rf_id": 342, "parent": 786, "fw_parent": 0, "seq_id": 793, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::_batch_norm_impl_index(Tensor input, Tensor? weight, Tensor? bias, Tensor? running_mean, Tensor? running_var, bool training, float momentum, float eps, bool cudnn_enabled) -> (Tensor, Tensor, Tensor, Tensor, int)",
+      "inputs": [[761,772,0,3211264,4,"cuda:0"],[778,779,0,512,4,"cuda:0"],[780,781,0,512,4,"cuda:0"],[782,783,0,512,4,"cuda:0"],[784,785,0,512,4,"cuda:0"],true,0.100000,0.000010,true], "input_shapes": [[128,512,7,7],[512],[512],[512],[512],[],[],[],[]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Bool","Double","Double","Bool"],
+      "outputs": [[775,791,0,3211264,4,"cuda:0"],[793,795,0,512,4,"cuda:0"],[797,798,0,512,4,"cuda:0"],[802,57,0,0,1,"cuda:0"],1], "output_shapes": [[128,512,7,7],[512],[512],[0],[]], "output_types": ["Tensor(float)","Tensor(float)","Tensor(float)","Tensor(unsigned char)","Int"]
+    },
+    {
+      "name": "aten::batch_norm", "id": 786, "rf_id": 341, "parent": 2, "fw_parent": 0, "seq_id": 793, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::batch_norm(Tensor input, Tensor? weight, Tensor? bias, Tensor? running_mean, Tensor? running_var, bool training, float momentum, float eps, bool cudnn_enabled) -> Tensor",
+      "inputs": [[761,772,0,3211264,4,"cuda:0"],[778,779,0,512,4,"cuda:0"],[780,781,0,512,4,"cuda:0"],[782,783,0,512,4,"cuda:0"],[784,785,0,512,4,"cuda:0"],true,0.100000,0.000010,true], "input_shapes": [[128,512,7,7],[512],[512],[512],[512],[],[],[],[]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Bool","Double","Double","Bool"],
+      "outputs": [[775,791,0,3211264,4,"cuda:0"]], "output_shapes": [[128,512,7,7]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::add_", "id": 803, "rf_id": 351, "parent": 2, "fw_parent": 0, "seq_id": 794, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::add_.Tensor(Tensor(a!) self, Tensor other, *, Scalar alpha=1) -> Tensor(a!)",
+      "inputs": [[775,791,0,3211264,4,"cuda:0"],[661,677,0,3211264,4,"cuda:0"],1], "input_shapes": [[128,512,7,7],[128,512,7,7],[]], "input_types": ["Tensor(float)","Tensor(float)","Int"],
+      "outputs": [[775,791,0,3211264,4,"cuda:0"]], "output_shapes": [[128,512,7,7]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::clamp_min_", "id": 805, "rf_id": 353, "parent": 804, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::clamp_min_(Tensor(a!) self, Scalar min) -> Tensor(a!)",
+      "inputs": [[775,791,0,3211264,4,"cuda:0"],0], "input_shapes": [[128,512,7,7],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [[775,791,0,3211264,4,"cuda:0"]], "output_shapes": [[128,512,7,7]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::relu_", "id": 804, "rf_id": 352, "parent": 2, "fw_parent": 0, "seq_id": 795, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::relu_(Tensor(a!) self) -> Tensor(a!)",
+      "inputs": [[775,791,0,3211264,4,"cuda:0"]], "input_shapes": [[128,512,7,7]], "input_types": ["Tensor(float)"],
+      "outputs": [[775,791,0,3211264,4,"cuda:0"]], "output_shapes": [[128,512,7,7]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::mean", "id": 807, "rf_id": 355, "parent": 806, "fw_parent": 0, "seq_id": 796, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::mean.dim(Tensor self, int[1]? dim, bool keepdim=False, *, ScalarType? dtype=None) -> Tensor",
+      "inputs": [[775,791,0,3211264,4,"cuda:0"],[-1,-2],true,"<None>"], "input_shapes": [[128,512,7,7],[[],[]],[],[]], "input_types": ["Tensor(float)","GenericList[Int,Int]","Bool","None"],
+      "outputs": [[800,808,0,65536,4,"cuda:0"]], "output_shapes": [[128,512,1,1]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::adaptive_avg_pool2d", "id": 806, "rf_id": 354, "parent": 2, "fw_parent": 0, "seq_id": 796, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::adaptive_avg_pool2d(Tensor self, SymInt[2] output_size) -> Tensor",
+      "inputs": [[775,791,0,3211264,4,"cuda:0"],[1,1]], "input_shapes": [[128,512,7,7],[[],[]]], "input_types": ["Tensor(float)","GenericList[Int,Int]"],
+      "outputs": [[800,808,0,65536,4,"cuda:0"]], "output_shapes": [[128,512,1,1]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::_reshape_alias", "id": 810, "rf_id": 357, "parent": 809, "fw_parent": 0, "seq_id": 797, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::_reshape_alias(Tensor(a) self, SymInt[] size, SymInt[] stride) -> Tensor(a)",
+      "inputs": [[800,808,0,65536,4,"cuda:0"],[128,512],[512,1]], "input_shapes": [[128,512,1,1],[[],[]],[[],[]]], "input_types": ["Tensor(float)","GenericList[Int,Int]","GenericList[Int,Int]"],
+      "outputs": [[811,808,0,65536,4,"cuda:0"]], "output_shapes": [[128,512]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::flatten", "id": 809, "rf_id": 356, "parent": 2, "fw_parent": 0, "seq_id": 797, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::flatten.using_ints(Tensor(a) self, int start_dim=0, int end_dim=-1) -> Tensor(a)",
+      "inputs": [[800,808,0,65536,4,"cuda:0"],1,-1], "input_shapes": [[128,512,1,1],[],[]], "input_types": ["Tensor(float)","Int","Int"],
+      "outputs": [[811,808,0,65536,4,"cuda:0"]], "output_shapes": [[128,512]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::as_strided", "id": 819, "rf_id": 361, "parent": 818, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::as_strided(Tensor(a) self, SymInt[] size, SymInt[] stride, SymInt? storage_offset=None) -> Tensor(a)",
+      "inputs": [[812,813,0,512000,4,"cuda:0"],[512,1000],[1,512],"<None>"], "input_shapes": [[1000,512],[[],[]],[[],[]],[]], "input_types": ["Tensor(float)","GenericList[Int,Int]","GenericList[Int,Int]","None"],
+      "outputs": [[820,813,0,512000,4,"cuda:0"]], "output_shapes": [[512,1000]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::transpose", "id": 818, "rf_id": 360, "parent": 817, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::transpose.int(Tensor(a) self, int dim0, int dim1) -> Tensor(a)",
+      "inputs": [[812,813,0,512000,4,"cuda:0"],0,1], "input_shapes": [[1000,512],[],[]], "input_types": ["Tensor(float)","Int","Int"],
+      "outputs": [[820,813,0,512000,4,"cuda:0"]], "output_shapes": [[512,1000]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::t", "id": 817, "rf_id": 359, "parent": 816, "fw_parent": 0, "seq_id": 798, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::t(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[812,813,0,512000,4,"cuda:0"]], "input_shapes": [[1000,512]], "input_types": ["Tensor(float)"],
+      "outputs": [[820,813,0,512000,4,"cuda:0"]], "output_shapes": [[512,1000]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty", "id": 822, "rf_id": 363, "parent": 821, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[1048576],0,"<None>","cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","None","Device","None","None"],
+      "outputs": [[823,824,0,1048576,1,"cuda:0"]], "output_shapes": [[1048576]], "output_types": ["Tensor(unsigned char)"]
+    },
+    {
+      "name": "aten::addmm", "id": 821, "rf_id": 362, "parent": 816, "fw_parent": 0, "seq_id": 799, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::addmm(Tensor self, Tensor mat1, Tensor mat2, *, Scalar beta=1, Scalar alpha=1) -> Tensor",
+      "inputs": [[814,815,0,1000,4,"cuda:0"],[811,808,0,65536,4,"cuda:0"],[820,813,0,512000,4,"cuda:0"],1,1], "input_shapes": [[1000],[128,512],[512,1000],[],[]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(float)","Int","Int"],
+      "outputs": [[825,826,0,128000,4,"cuda:0"]], "output_shapes": [[128,1000]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::linear", "id": 816, "rf_id": 358, "parent": 2, "fw_parent": 0, "seq_id": 798, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::linear(Tensor input, Tensor weight, Tensor? bias=None) -> Tensor",
+      "inputs": [[811,808,0,65536,4,"cuda:0"],[812,813,0,512000,4,"cuda:0"],[814,815,0,1000,4,"cuda:0"]], "input_shapes": [[128,512],[1000,512],[1000]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(float)"],
+      "outputs": [[825,826,0,128000,4,"cuda:0"]], "output_shapes": [[128,1000]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::to", "id": 829, "rf_id": 366, "parent": 828, "fw_parent": 0, "seq_id": 800, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::to.dtype_layout(Tensor(a) self, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, bool non_blocking=False, bool copy=False, MemoryFormat? memory_format=None) -> Tensor(a)",
+      "inputs": [[825,826,0,128000,4,"cuda:0"],6,0,"cuda:0","<None>",false,false,"<None>"], "input_shapes": [[128,1000],[],[],[],[],[],[],[]], "input_types": ["Tensor(float)","Int","Int","Device","None","Bool","Bool","None"],
+      "outputs": [[825,826,0,128000,4,"cuda:0"]], "output_shapes": [[128,1000]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::_log_softmax", "id": 830, "rf_id": 367, "parent": 828, "fw_parent": 0, "seq_id": 800, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::_log_softmax(Tensor self, int dim, bool half_to_float) -> Tensor",
+      "inputs": [[825,826,0,128000,4,"cuda:0"],1,false], "input_shapes": [[128,1000],[],[]], "input_types": ["Tensor(float)","Int","Bool"],
+      "outputs": [[831,832,0,128000,4,"cuda:0"]], "output_shapes": [[128,1000]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::log_softmax", "id": 828, "rf_id": 365, "parent": 827, "fw_parent": 0, "seq_id": 800, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::log_softmax.int(Tensor self, int dim, ScalarType? dtype=None) -> Tensor",
+      "inputs": [[825,826,0,128000,4,"cuda:0"],1,6], "input_shapes": [[128,1000],[],[]], "input_types": ["Tensor(float)","Int","Int"],
+      "outputs": [[831,832,0,128000,4,"cuda:0"]], "output_shapes": [[128,1000]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::resize_", "id": 838, "rf_id": 371, "parent": 835, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::resize_(Tensor(a!) self, SymInt[] size, *, MemoryFormat? memory_format=None) -> Tensor(a!)",
+      "inputs": [[836,837,0,1,4,"cuda:0"],[],"<None>"], "input_shapes": [[],[],[]], "input_types": ["Tensor(float)","GenericList[]","None"],
+      "outputs": [[836,837,0,1,4,"cuda:0"]], "output_shapes": [[]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::nll_loss_forward", "id": 835, "rf_id": 370, "parent": 834, "fw_parent": 0, "seq_id": 801, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::nll_loss_forward(Tensor self, Tensor target, Tensor? weight, int reduction, SymInt ignore_index) -> (Tensor output, Tensor total_weight)",
+      "inputs": [[831,832,0,128000,4,"cuda:0"],[16,17,0,128,8,"cuda:0"],[23,0,0,0,0,""],1,-100], "input_shapes": [[128,1000],[128],[],[],[]], "input_types": ["Tensor(float)","Tensor(long int)","Tensor(nullptr (uninitialized))","Int","Int"],
+      "outputs": [[839,840,0,1,4,"cuda:0"],[836,837,0,1,4,"cuda:0"]], "output_shapes": [[],[]], "output_types": ["Tensor(float)","Tensor(float)"]
+    },
+    {
+      "name": "aten::nll_loss", "id": 834, "rf_id": 369, "parent": 833, "fw_parent": 0, "seq_id": 801, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::nll_loss(Tensor self, Tensor target, Tensor? weight=None, int reduction=1, SymInt ignore_index=-100) -> Tensor",
+      "inputs": [[831,832,0,128000,4,"cuda:0"],[16,17,0,128,8,"cuda:0"],"<None>",1,-100], "input_shapes": [[128,1000],[128],[],[],[]], "input_types": ["Tensor(float)","Tensor(long int)","None","Int","Int"],
+      "outputs": [[839,840,0,1,4,"cuda:0"]], "output_shapes": [[]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::nll_loss_nd", "id": 833, "rf_id": 368, "parent": 827, "fw_parent": 0, "seq_id": 801, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::nll_loss_nd(Tensor self, Tensor target, Tensor? weight=None, int reduction=1, SymInt ignore_index=-100) -> Tensor",
+      "inputs": [[831,832,0,128000,4,"cuda:0"],[16,17,0,128,8,"cuda:0"],"<None>",1,-100], "input_shapes": [[128,1000],[128],[],[],[]], "input_types": ["Tensor(float)","Tensor(long int)","None","Int","Int"],
+      "outputs": [[839,840,0,1,4,"cuda:0"]], "output_shapes": [[]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::cross_entropy_loss", "id": 827, "rf_id": 364, "parent": 2, "fw_parent": 0, "seq_id": 800, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::cross_entropy_loss(Tensor self, Tensor target, Tensor? weight=None, int reduction=1, SymInt ignore_index=-100, float label_smoothing=0.) -> Tensor",
+      "inputs": [[825,826,0,128000,4,"cuda:0"],[16,17,0,128,8,"cuda:0"],"<None>",1,-100,0.000000], "input_shapes": [[128,1000],[128],[],[],[],[]], "input_types": ["Tensor(float)","Tensor(long int)","None","Int","Int","Double"],
+      "outputs": [[839,840,0,1,4,"cuda:0"]], "output_shapes": [[]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty_strided", "id": 843, "rf_id": 374, "parent": 842, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty_strided(SymInt[] size, SymInt[] stride, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor",
+      "inputs": [[],[],6,0,"cuda:0",false], "input_shapes": [[],[],[],[],[],[]], "input_types": ["GenericList[]","GenericList[]","Int","Int","Device","Bool"],
+      "outputs": [[844,845,0,1,4,"cuda:0"]], "output_shapes": [[]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty_like", "id": 842, "rf_id": 373, "parent": 841, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty_like(Tensor self, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[839,840,0,1,4,"cuda:0"],6,0,"cuda:0",false,1], "input_shapes": [[],[],[],[],[],[]], "input_types": ["Tensor(float)","Int","Int","Device","Bool","Int"],
+      "outputs": [[844,845,0,1,4,"cuda:0"]], "output_shapes": [[]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::fill_", "id": 846, "rf_id": 375, "parent": 841, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::fill_.Scalar(Tensor(a!) self, Scalar value) -> Tensor(a!)",
+      "inputs": [[844,845,0,1,4,"cuda:0"],1.000000], "input_shapes": [[],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [[844,845,0,1,4,"cuda:0"]], "output_shapes": [[]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::ones_like", "id": 841, "rf_id": 372, "parent": 2, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::ones_like(Tensor self, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[839,840,0,1,4,"cuda:0"],6,0,"cuda:0",false,1], "input_shapes": [[],[],[],[],[],[]], "input_types": ["Tensor(float)","Int","Int","Device","Bool","Int"],
+      "outputs": [[844,845,0,1,4,"cuda:0"]], "output_shapes": [[]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "[pytorch|profiler|execution_graph|thread]", "id": 847, "rf_id": 0, "parent": 1, "fw_parent": 0, "seq_id": -1, "scope": 7, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::fill_", "id": 853, "rf_id": 380, "parent": 852, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::fill_.Scalar(Tensor(a!) self, Scalar value) -> Tensor(a!)",
+      "inputs": [[851,824,0,128000,4,"cuda:0"],0], "input_shapes": [[128,1000],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [[851,824,0,128000,4,"cuda:0"]], "output_shapes": [[128,1000]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::zero_", "id": 852, "rf_id": 379, "parent": 850, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::zero_(Tensor(a!) self) -> Tensor(a!)",
+      "inputs": [[851,824,0,128000,4,"cuda:0"]], "input_shapes": [[128,1000]], "input_types": ["Tensor(float)"],
+      "outputs": [[851,824,0,128000,4,"cuda:0"]], "output_shapes": [[128,1000]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::nll_loss_backward", "id": 850, "rf_id": 378, "parent": 849, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::nll_loss_backward(Tensor grad_output, Tensor self, Tensor target, Tensor? weight, int reduction, SymInt ignore_index, Tensor total_weight) -> Tensor",
+      "inputs": [[844,845,0,1,4,"cuda:0"],[831,832,0,128000,4,"cuda:0"],[16,17,0,128,8,"cuda:0"],[23,0,0,0,0,""],1,-100,[836,837,0,1,4,"cuda:0"]], "input_shapes": [[],[128,1000],[128],[],[],[],[]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(long int)","Tensor(nullptr (uninitialized))","Int","Int","Tensor(float)"],
+      "outputs": [[851,824,0,128000,4,"cuda:0"]], "output_shapes": [[128,1000]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "NllLossBackward0", "id": 849, "rf_id": 377, "parent": 848, "fw_parent": 2, "seq_id": 801, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[844,845,0,1,4,"cuda:0"]], "input_shapes": [[]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: NllLossBackward0", "id": 848, "rf_id": 376, "parent": 847, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::_log_softmax_backward_data", "id": 856, "rf_id": 383, "parent": 855, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::_log_softmax_backward_data(Tensor grad_output, Tensor output, int dim, ScalarType input_dtype) -> Tensor",
+      "inputs": [[851,824,0,128000,4,"cuda:0"],[831,832,0,128000,4,"cuda:0"],1,6], "input_shapes": [[128,1000],[128,1000],[],[]], "input_types": ["Tensor(float)","Tensor(float)","Int","Int"],
+      "outputs": [[857,858,0,128000,4,"cuda:0"]], "output_shapes": [[128,1000]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "LogSoftmaxBackward0", "id": 855, "rf_id": 382, "parent": 854, "fw_parent": 2, "seq_id": 800, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[851,824,0,128000,4,"cuda:0"]], "input_shapes": [[128,1000]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: LogSoftmaxBackward0", "id": 854, "rf_id": 381, "parent": 847, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::as_strided", "id": 863, "rf_id": 388, "parent": 862, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::as_strided(Tensor(a) self, SymInt[] size, SymInt[] stride, SymInt? storage_offset=None) -> Tensor(a)",
+      "inputs": [[820,813,0,512000,4,"cuda:0"],[1000,512],[512,1],"<None>"], "input_shapes": [[512,1000],[[],[]],[[],[]],[]], "input_types": ["Tensor(float)","GenericList[Int,Int]","GenericList[Int,Int]","None"],
+      "outputs": [[851,813,0,512000,4,"cuda:0"]], "output_shapes": [[1000,512]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::transpose", "id": 862, "rf_id": 387, "parent": 861, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::transpose.int(Tensor(a) self, int dim0, int dim1) -> Tensor(a)",
+      "inputs": [[820,813,0,512000,4,"cuda:0"],0,1], "input_shapes": [[512,1000],[],[]], "input_types": ["Tensor(float)","Int","Int"],
+      "outputs": [[851,813,0,512000,4,"cuda:0"]], "output_shapes": [[1000,512]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::t", "id": 861, "rf_id": 386, "parent": 860, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::t(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[820,813,0,512000,4,"cuda:0"]], "input_shapes": [[512,1000]], "input_types": ["Tensor(float)"],
+      "outputs": [[851,813,0,512000,4,"cuda:0"]], "output_shapes": [[1000,512]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::mm", "id": 864, "rf_id": 389, "parent": 860, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::mm(Tensor self, Tensor mat2) -> Tensor",
+      "inputs": [[857,858,0,128000,4,"cuda:0"],[851,813,0,512000,4,"cuda:0"]], "input_shapes": [[128,1000],[1000,512]], "input_types": ["Tensor(float)","Tensor(float)"],
+      "outputs": [[831,865,0,65536,4,"cuda:0"]], "output_shapes": [[128,512]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::as_strided", "id": 868, "rf_id": 392, "parent": 867, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::as_strided(Tensor(a) self, SymInt[] size, SymInt[] stride, SymInt? storage_offset=None) -> Tensor(a)",
+      "inputs": [[857,858,0,128000,4,"cuda:0"],[1000,128],[1,1000],"<None>"], "input_shapes": [[128,1000],[[],[]],[[],[]],[]], "input_types": ["Tensor(float)","GenericList[Int,Int]","GenericList[Int,Int]","None"],
+      "outputs": [[851,858,0,128000,4,"cuda:0"]], "output_shapes": [[1000,128]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::transpose", "id": 867, "rf_id": 391, "parent": 866, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::transpose.int(Tensor(a) self, int dim0, int dim1) -> Tensor(a)",
+      "inputs": [[857,858,0,128000,4,"cuda:0"],0,1], "input_shapes": [[128,1000],[],[]], "input_types": ["Tensor(float)","Int","Int"],
+      "outputs": [[851,858,0,128000,4,"cuda:0"]], "output_shapes": [[1000,128]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::t", "id": 866, "rf_id": 390, "parent": 860, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::t(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[857,858,0,128000,4,"cuda:0"]], "input_shapes": [[128,1000]], "input_types": ["Tensor(float)"],
+      "outputs": [[851,858,0,128000,4,"cuda:0"]], "output_shapes": [[1000,128]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::mm", "id": 869, "rf_id": 393, "parent": 860, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::mm(Tensor self, Tensor mat2) -> Tensor",
+      "inputs": [[851,858,0,128000,4,"cuda:0"],[811,808,0,65536,4,"cuda:0"]], "input_shapes": [[1000,128],[128,512]], "input_types": ["Tensor(float)","Tensor(float)"],
+      "outputs": [[870,871,0,512000,4,"cuda:0"]], "output_shapes": [[1000,512]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::as_strided", "id": 874, "rf_id": 396, "parent": 873, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::as_strided(Tensor(a) self, SymInt[] size, SymInt[] stride, SymInt? storage_offset=None) -> Tensor(a)",
+      "inputs": [[870,871,0,512000,4,"cuda:0"],[512,1000],[1,512],"<None>"], "input_shapes": [[1000,512],[[],[]],[[],[]],[]], "input_types": ["Tensor(float)","GenericList[Int,Int]","GenericList[Int,Int]","None"],
+      "outputs": [[875,871,0,512000,4,"cuda:0"]], "output_shapes": [[512,1000]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::transpose", "id": 873, "rf_id": 395, "parent": 872, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::transpose.int(Tensor(a) self, int dim0, int dim1) -> Tensor(a)",
+      "inputs": [[870,871,0,512000,4,"cuda:0"],0,1], "input_shapes": [[1000,512],[],[]], "input_types": ["Tensor(float)","Int","Int"],
+      "outputs": [[875,871,0,512000,4,"cuda:0"]], "output_shapes": [[512,1000]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::t", "id": 872, "rf_id": 394, "parent": 860, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::t(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[870,871,0,512000,4,"cuda:0"]], "input_shapes": [[1000,512]], "input_types": ["Tensor(float)"],
+      "outputs": [[875,871,0,512000,4,"cuda:0"]], "output_shapes": [[512,1000]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "AddmmBackward0", "id": 860, "rf_id": 385, "parent": 859, "fw_parent": 2, "seq_id": 799, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[857,858,0,128000,4,"cuda:0"]], "input_shapes": [[128,1000]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::sum", "id": 876, "rf_id": 397, "parent": 859, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::sum.dim_IntList(Tensor self, int[1]? dim, bool keepdim=False, *, ScalarType? dtype=None) -> Tensor",
+      "inputs": [[857,858,0,128000,4,"cuda:0"],[0],true,"<None>"], "input_shapes": [[128,1000],[[]],[],[]], "input_types": ["Tensor(float)","GenericList[Int]","Bool","None"],
+      "outputs": [[851,837,0,1000,4,"cuda:0"]], "output_shapes": [[1,1000]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::view", "id": 877, "rf_id": 398, "parent": 859, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::view(Tensor(a) self, SymInt[] size) -> Tensor(a)",
+      "inputs": [[851,837,0,1000,4,"cuda:0"],[1000]], "input_shapes": [[1,1000],[[]]], "input_types": ["Tensor(float)","GenericList[Int]"],
+      "outputs": [[878,837,0,1000,4,"cuda:0"]], "output_shapes": [[1000]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "autograd::engine::evaluate_function: AddmmBackward0", "id": 859, "rf_id": 384, "parent": 847, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "detach", "id": 882, "rf_id": 402, "parent": 881, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [[878,837,0,1000,4,"cuda:0"]], "input_shapes": [[1000]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::detach", "id": 881, "rf_id": 401, "parent": 880, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::detach(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[878,837,0,1000,4,"cuda:0"]], "input_shapes": [[1000]], "input_types": ["Tensor(float)"],
+      "outputs": [[800,837,0,1000,4,"cuda:0"]], "output_shapes": [[1000]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "torch::autograd::AccumulateGrad", "id": 880, "rf_id": 400, "parent": 879, "fw_parent": 2, "seq_id": -1, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[878,837,0,1000,4,"cuda:0"]], "input_shapes": [[1000]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: torch::autograd::AccumulateGrad", "id": 879, "rf_id": 399, "parent": 847, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::as_strided", "id": 887, "rf_id": 407, "parent": 886, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::as_strided(Tensor(a) self, SymInt[] size, SymInt[] stride, SymInt? storage_offset=None) -> Tensor(a)",
+      "inputs": [[875,871,0,512000,4,"cuda:0"],[1000,512],[512,1],"<None>"], "input_shapes": [[512,1000],[[],[]],[[],[]],[]], "input_types": ["Tensor(float)","GenericList[Int,Int]","GenericList[Int,Int]","None"],
+      "outputs": [[878,871,0,512000,4,"cuda:0"]], "output_shapes": [[1000,512]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::transpose", "id": 886, "rf_id": 406, "parent": 885, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::transpose.int(Tensor(a) self, int dim0, int dim1) -> Tensor(a)",
+      "inputs": [[875,871,0,512000,4,"cuda:0"],0,1], "input_shapes": [[512,1000],[],[]], "input_types": ["Tensor(float)","Int","Int"],
+      "outputs": [[878,871,0,512000,4,"cuda:0"]], "output_shapes": [[1000,512]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::t", "id": 885, "rf_id": 405, "parent": 884, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::t(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[875,871,0,512000,4,"cuda:0"]], "input_shapes": [[512,1000]], "input_types": ["Tensor(float)"],
+      "outputs": [[878,871,0,512000,4,"cuda:0"]], "output_shapes": [[1000,512]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "TBackward0", "id": 884, "rf_id": 404, "parent": 883, "fw_parent": 2, "seq_id": 798, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[875,871,0,512000,4,"cuda:0"]], "input_shapes": [[512,1000]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: TBackward0", "id": 883, "rf_id": 403, "parent": 847, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "detach", "id": 891, "rf_id": 411, "parent": 890, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [[878,871,0,512000,4,"cuda:0"]], "input_shapes": [[1000,512]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::detach", "id": 890, "rf_id": 410, "parent": 889, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::detach(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[878,871,0,512000,4,"cuda:0"]], "input_shapes": [[1000,512]], "input_types": ["Tensor(float)"],
+      "outputs": [[851,871,0,512000,4,"cuda:0"]], "output_shapes": [[1000,512]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "torch::autograd::AccumulateGrad", "id": 889, "rf_id": 409, "parent": 888, "fw_parent": 2, "seq_id": -1, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[878,871,0,512000,4,"cuda:0"]], "input_shapes": [[1000,512]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: torch::autograd::AccumulateGrad", "id": 888, "rf_id": 408, "parent": 847, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::_reshape_alias", "id": 895, "rf_id": 415, "parent": 894, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::_reshape_alias(Tensor(a) self, SymInt[] size, SymInt[] stride) -> Tensor(a)",
+      "inputs": [[831,865,0,65536,4,"cuda:0"],[128,512,1,1],[512,1,1,1]], "input_shapes": [[128,512],[[],[],[],[]],[[],[],[],[]]], "input_types": ["Tensor(float)","GenericList[Int,Int,Int,Int]","GenericList[Int,Int,Int,Int]"],
+      "outputs": [[870,865,0,65536,4,"cuda:0"]], "output_shapes": [[128,512,1,1]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::reshape", "id": 894, "rf_id": 414, "parent": 893, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::reshape(Tensor(a) self, SymInt[] shape) -> Tensor(a)",
+      "inputs": [[831,865,0,65536,4,"cuda:0"],[128,512,1,1]], "input_shapes": [[128,512],[[],[],[],[]]], "input_types": ["Tensor(float)","GenericList[Int,Int,Int,Int]"],
+      "outputs": [[870,865,0,65536,4,"cuda:0"]], "output_shapes": [[128,512,1,1]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "ReshapeAliasBackward0", "id": 893, "rf_id": 413, "parent": 892, "fw_parent": 2, "seq_id": 797, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[831,865,0,65536,4,"cuda:0"]], "input_shapes": [[128,512]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: ReshapeAliasBackward0", "id": 892, "rf_id": 412, "parent": 847, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::as_strided", "id": 899, "rf_id": 419, "parent": 898, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::as_strided(Tensor(a) self, SymInt[] size, SymInt[] stride, SymInt? storage_offset=None) -> Tensor(a)",
+      "inputs": [[870,865,0,65536,4,"cuda:0"],[128,512,7,7],[512,1,0,0],"<None>"], "input_shapes": [[128,512,1,1],[[],[],[],[]],[[],[],[],[]],[]], "input_types": ["Tensor(float)","GenericList[Int,Int,Int,Int]","GenericList[Int,Int,Int,Int]","None"],
+      "outputs": [[875,865,0,3211264,4,"cuda:0"]], "output_shapes": [[128,512,7,7]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::expand", "id": 898, "rf_id": 418, "parent": 897, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::expand(Tensor(a) self, SymInt[] size, *, bool implicit=False) -> Tensor(a)",
+      "inputs": [[870,865,0,65536,4,"cuda:0"],[128,512,7,7],false], "input_shapes": [[128,512,1,1],[[],[],[],[]],[]], "input_types": ["Tensor(float)","GenericList[Int,Int,Int,Int]","Bool"],
+      "outputs": [[875,865,0,3211264,4,"cuda:0"]], "output_shapes": [[128,512,7,7]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::div", "id": 902, "rf_id": 421, "parent": 900, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::div.Tensor(Tensor self, Tensor other) -> Tensor",
+      "inputs": [[875,865,0,3211264,4,"cuda:0"],[811,901,0,1,8,"cpu"]], "input_shapes": [[128,512,7,7],[]], "input_types": ["Tensor(float)","Tensor(long int)"],
+      "outputs": [[820,903,0,3211264,4,"cuda:0"]], "output_shapes": [[128,512,7,7]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::div", "id": 900, "rf_id": 420, "parent": 897, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::div.Scalar(Tensor self, Scalar other) -> Tensor",
+      "inputs": [[875,865,0,3211264,4,"cuda:0"],49], "input_shapes": [[128,512,7,7],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [[820,903,0,3211264,4,"cuda:0"]], "output_shapes": [[128,512,7,7]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "MeanBackward1", "id": 897, "rf_id": 417, "parent": 896, "fw_parent": 2, "seq_id": 796, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[870,865,0,65536,4,"cuda:0"]], "input_shapes": [[128,512,1,1]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: MeanBackward1", "id": 896, "rf_id": 416, "parent": 847, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::threshold_backward", "id": 906, "rf_id": 424, "parent": 905, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::threshold_backward(Tensor grad_output, Tensor self, Scalar threshold) -> Tensor",
+      "inputs": [[820,903,0,3211264,4,"cuda:0"],[870,791,0,3211264,4,"cuda:0"],0], "input_shapes": [[128,512,7,7],[128,512,7,7],[]], "input_types": ["Tensor(float)","Tensor(float)","Int"],
+      "outputs": [[831,907,0,3211264,4,"cuda:0"]], "output_shapes": [[128,512,7,7]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "ReluBackward0", "id": 905, "rf_id": 423, "parent": 904, "fw_parent": 2, "seq_id": 795, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[820,903,0,3211264,4,"cuda:0"]], "input_shapes": [[128,512,7,7]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: ReluBackward0", "id": 904, "rf_id": 422, "parent": 847, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "AddBackward0", "id": 909, "rf_id": 426, "parent": 908, "fw_parent": 2, "seq_id": 794, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[831,907,0,3211264,4,"cuda:0"]], "input_shapes": [[128,512,7,7]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: AddBackward0", "id": 908, "rf_id": 425, "parent": 847, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::empty", "id": 913, "rf_id": 430, "parent": 912, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[128,512,7,7],6,0,"cuda:0","<None>",0], "input_shapes": [[[],[],[],[]],[],[],[],[],[]], "input_types": ["GenericList[Int,Int,Int,Int]","Int","Int","Device","None","Int"],
+      "outputs": [[820,791,0,3211264,4,"cuda:0"]], "output_shapes": [[128,512,7,7]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty", "id": 914, "rf_id": 431, "parent": 912, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[512],6,0,"cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","Int","Device","None","None"],
+      "outputs": [[870,915,0,512,4,"cuda:0"]], "output_shapes": [[512]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty", "id": 916, "rf_id": 432, "parent": 912, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[512],6,0,"cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","Int","Device","None","None"],
+      "outputs": [[875,917,0,512,4,"cuda:0"]], "output_shapes": [[512]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::view", "id": 918, "rf_id": 433, "parent": 912, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::view(Tensor(a) self, SymInt[] size) -> Tensor(a)",
+      "inputs": [[778,779,0,512,4,"cuda:0"],[1,512,1,1]], "input_shapes": [[512],[[],[],[],[]]], "input_types": ["Tensor(float)","GenericList[Int,Int,Int,Int]"],
+      "outputs": [[811,779,0,512,4,"cuda:0"]], "output_shapes": [[1,512,1,1]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty", "id": 919, "rf_id": 434, "parent": 912, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[0],0,0,"cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","Int","Device","None","None"],
+      "outputs": [[811,57,0,0,1,"cuda:0"]], "output_shapes": [[0]], "output_types": ["Tensor(unsigned char)"]
+    },
+    {
+      "name": "aten::cudnn_batch_norm_backward", "id": 912, "rf_id": 429, "parent": 911, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::cudnn_batch_norm_backward(Tensor input, Tensor grad_output, Tensor weight, Tensor? running_mean, Tensor? running_var, Tensor? save_mean, Tensor? save_var, float epsilon, Tensor reserveSpace) -> (Tensor, Tensor, Tensor)",
+      "inputs": [[761,772,0,3211264,4,"cuda:0"],[831,907,0,3211264,4,"cuda:0"],[778,779,0,512,4,"cuda:0"],[782,783,0,512,4,"cuda:0"],[784,785,0,512,4,"cuda:0"],[793,795,0,512,4,"cuda:0"],[797,798,0,512,4,"cuda:0"],0.000010,[802,57,0,0,1,"cuda:0"]], "input_shapes": [[128,512,7,7],[128,512,7,7],[512],[512],[512],[512],[512],[],[0]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Double","Tensor(unsigned char)"],
+      "outputs": [[820,791,0,3211264,4,"cuda:0"],[870,915,0,512,4,"cuda:0"],[875,917,0,512,4,"cuda:0"]], "output_shapes": [[128,512,7,7],[512],[512]], "output_types": ["Tensor(float)","Tensor(float)","Tensor(float)"]
+    },
+    {
+      "name": "CudnnBatchNormBackward0", "id": 911, "rf_id": 428, "parent": 910, "fw_parent": 2, "seq_id": 793, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[831,907,0,3211264,4,"cuda:0"]], "input_shapes": [[128,512,7,7]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: CudnnBatchNormBackward0", "id": 910, "rf_id": 427, "parent": 847, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "detach", "id": 923, "rf_id": 438, "parent": 922, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [[870,915,0,512,4,"cuda:0"]], "input_shapes": [[512]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::detach", "id": 922, "rf_id": 437, "parent": 921, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::detach(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[870,915,0,512,4,"cuda:0"]], "input_shapes": [[512]], "input_types": ["Tensor(float)"],
+      "outputs": [[793,915,0,512,4,"cuda:0"]], "output_shapes": [[512]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "torch::autograd::AccumulateGrad", "id": 921, "rf_id": 436, "parent": 920, "fw_parent": 2, "seq_id": -1, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[870,915,0,512,4,"cuda:0"]], "input_shapes": [[512]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: torch::autograd::AccumulateGrad", "id": 920, "rf_id": 435, "parent": 847, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "detach", "id": 927, "rf_id": 442, "parent": 926, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [[875,917,0,512,4,"cuda:0"]], "input_shapes": [[512]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::detach", "id": 926, "rf_id": 441, "parent": 925, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::detach(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[875,917,0,512,4,"cuda:0"]], "input_shapes": [[512]], "input_types": ["Tensor(float)"],
+      "outputs": [[797,917,0,512,4,"cuda:0"]], "output_shapes": [[512]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "torch::autograd::AccumulateGrad", "id": 925, "rf_id": 440, "parent": 924, "fw_parent": 2, "seq_id": -1, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[875,917,0,512,4,"cuda:0"]], "input_shapes": [[512]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: torch::autograd::AccumulateGrad", "id": 924, "rf_id": 439, "parent": 847, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::empty", "id": 931, "rf_id": 446, "parent": 930, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[512,512,3,3],6,0,"cuda:0","<None>",0], "input_shapes": [[[],[],[],[]],[],[],[],[],[]], "input_types": ["GenericList[Int,Int,Int,Int]","Int","Int","Device","None","Int"],
+      "outputs": [[870,932,0,2359296,4,"cuda:0"]], "output_shapes": [[512,512,3,3]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::convolution_backward", "id": 930, "rf_id": 445, "parent": 929, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::convolution_backward(Tensor grad_output, Tensor input, Tensor weight, SymInt[]? bias_sizes, int[] stride, SymInt[] padding, int[] dilation, bool transposed, SymInt[] output_padding, int groups, bool[3] output_mask) -> (Tensor, Tensor, Tensor)",
+      "inputs": [[820,791,0,3211264,4,"cuda:0"],[723,752,0,3211264,4,"cuda:0"],[766,767,0,2359296,4,"cuda:0"],[0],[1,1],[1,1],[1,1],false,[0,0],1,[true,true,false]], "input_shapes": [[128,512,7,7],[128,512,7,7],[512,512,3,3],[[]],[[],[]],[[],[]],[[],[]],[],[[],[]],[],[[],[],[]]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(float)","GenericList[Int]","GenericList[Int,Int]","GenericList[Int,Int]","GenericList[Int,Int]","Bool","GenericList[Int,Int]","Int","GenericList[Bool,Bool,Bool]"],
+      "outputs": [[875,772,0,3211264,4,"cuda:0"],[870,932,0,2359296,4,"cuda:0"],[23,0,0,0,0,""]], "output_shapes": [[128,512,7,7],[512,512,3,3],[]], "output_types": ["Tensor(float)","Tensor(float)","Tensor(nullptr (uninitialized))"]
+    },
+    {
+      "name": "ConvolutionBackward0", "id": 929, "rf_id": 444, "parent": 928, "fw_parent": 2, "seq_id": 792, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[820,791,0,3211264,4,"cuda:0"]], "input_shapes": [[128,512,7,7]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: ConvolutionBackward0", "id": 928, "rf_id": 443, "parent": 847, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "detach", "id": 936, "rf_id": 450, "parent": 935, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [[870,932,0,2359296,4,"cuda:0"]], "input_shapes": [[512,512,3,3]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::detach", "id": 935, "rf_id": 449, "parent": 934, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::detach(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[870,932,0,2359296,4,"cuda:0"]], "input_shapes": [[512,512,3,3]], "input_types": ["Tensor(float)"],
+      "outputs": [[820,932,0,2359296,4,"cuda:0"]], "output_shapes": [[512,512,3,3]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "torch::autograd::AccumulateGrad", "id": 934, "rf_id": 448, "parent": 933, "fw_parent": 2, "seq_id": -1, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[870,932,0,2359296,4,"cuda:0"]], "input_shapes": [[512,512,3,3]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: torch::autograd::AccumulateGrad", "id": 933, "rf_id": 447, "parent": 847, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::threshold_backward", "id": 939, "rf_id": 453, "parent": 938, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::threshold_backward(Tensor grad_output, Tensor self, Scalar threshold) -> Tensor",
+      "inputs": [[875,772,0,3211264,4,"cuda:0"],[870,752,0,3211264,4,"cuda:0"],0], "input_shapes": [[128,512,7,7],[128,512,7,7],[]], "input_types": ["Tensor(float)","Tensor(float)","Int"],
+      "outputs": [[723,791,0,3211264,4,"cuda:0"]], "output_shapes": [[128,512,7,7]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "ReluBackward0", "id": 938, "rf_id": 452, "parent": 937, "fw_parent": 2, "seq_id": 791, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[875,772,0,3211264,4,"cuda:0"]], "input_shapes": [[128,512,7,7]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: ReluBackward0", "id": 937, "rf_id": 451, "parent": 847, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::empty", "id": 943, "rf_id": 457, "parent": 942, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[128,512,7,7],6,0,"cuda:0","<None>",0], "input_shapes": [[[],[],[],[]],[],[],[],[],[]], "input_types": ["GenericList[Int,Int,Int,Int]","Int","Int","Device","None","Int"],
+      "outputs": [[875,903,0,3211264,4,"cuda:0"]], "output_shapes": [[128,512,7,7]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty", "id": 944, "rf_id": 458, "parent": 942, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[512],6,0,"cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","Int","Device","None","None"],
+      "outputs": [[870,795,0,512,4,"cuda:0"]], "output_shapes": [[512]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty", "id": 945, "rf_id": 459, "parent": 942, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[512],6,0,"cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","Int","Device","None","None"],
+      "outputs": [[761,798,0,512,4,"cuda:0"]], "output_shapes": [[512]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::view", "id": 946, "rf_id": 460, "parent": 942, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::view(Tensor(a) self, SymInt[] size) -> Tensor(a)",
+      "inputs": [[739,740,0,512,4,"cuda:0"],[1,512,1,1]], "input_shapes": [[512],[[],[],[],[]]], "input_types": ["Tensor(float)","GenericList[Int,Int,Int,Int]"],
+      "outputs": [[811,740,0,512,4,"cuda:0"]], "output_shapes": [[1,512,1,1]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty", "id": 947, "rf_id": 461, "parent": 942, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[0],0,0,"cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","Int","Device","None","None"],
+      "outputs": [[811,57,0,0,1,"cuda:0"]], "output_shapes": [[0]], "output_types": ["Tensor(unsigned char)"]
+    },
+    {
+      "name": "aten::cudnn_batch_norm_backward", "id": 942, "rf_id": 456, "parent": 941, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::cudnn_batch_norm_backward(Tensor input, Tensor grad_output, Tensor weight, Tensor? running_mean, Tensor? running_var, Tensor? save_mean, Tensor? save_var, float epsilon, Tensor reserveSpace) -> (Tensor, Tensor, Tensor)",
+      "inputs": [[686,714,0,3211264,4,"cuda:0"],[723,791,0,3211264,4,"cuda:0"],[739,740,0,512,4,"cuda:0"],[743,744,0,512,4,"cuda:0"],[745,746,0,512,4,"cuda:0"],[754,756,0,512,4,"cuda:0"],[758,759,0,512,4,"cuda:0"],0.000010,[763,57,0,0,1,"cuda:0"]], "input_shapes": [[128,512,7,7],[128,512,7,7],[512],[512],[512],[512],[512],[],[0]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Double","Tensor(unsigned char)"],
+      "outputs": [[875,903,0,3211264,4,"cuda:0"],[870,795,0,512,4,"cuda:0"],[761,798,0,512,4,"cuda:0"]], "output_shapes": [[128,512,7,7],[512],[512]], "output_types": ["Tensor(float)","Tensor(float)","Tensor(float)"]
+    },
+    {
+      "name": "CudnnBatchNormBackward0", "id": 941, "rf_id": 455, "parent": 940, "fw_parent": 2, "seq_id": 790, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[723,791,0,3211264,4,"cuda:0"]], "input_shapes": [[128,512,7,7]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: CudnnBatchNormBackward0", "id": 940, "rf_id": 454, "parent": 847, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "detach", "id": 951, "rf_id": 465, "parent": 950, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [[870,795,0,512,4,"cuda:0"]], "input_shapes": [[512]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::detach", "id": 950, "rf_id": 464, "parent": 949, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::detach(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[870,795,0,512,4,"cuda:0"]], "input_shapes": [[512]], "input_types": ["Tensor(float)"],
+      "outputs": [[686,795,0,512,4,"cuda:0"]], "output_shapes": [[512]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "torch::autograd::AccumulateGrad", "id": 949, "rf_id": 463, "parent": 948, "fw_parent": 2, "seq_id": -1, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[870,795,0,512,4,"cuda:0"]], "input_shapes": [[512]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: torch::autograd::AccumulateGrad", "id": 948, "rf_id": 462, "parent": 847, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "detach", "id": 955, "rf_id": 469, "parent": 954, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [[761,798,0,512,4,"cuda:0"]], "input_shapes": [[512]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::detach", "id": 954, "rf_id": 468, "parent": 953, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::detach(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[761,798,0,512,4,"cuda:0"]], "input_shapes": [[512]], "input_types": ["Tensor(float)"],
+      "outputs": [[754,798,0,512,4,"cuda:0"]], "output_shapes": [[512]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "torch::autograd::AccumulateGrad", "id": 953, "rf_id": 467, "parent": 952, "fw_parent": 2, "seq_id": -1, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[761,798,0,512,4,"cuda:0"]], "input_shapes": [[512]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: torch::autograd::AccumulateGrad", "id": 952, "rf_id": 466, "parent": 847, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::empty", "id": 959, "rf_id": 473, "parent": 958, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[512,512,3,3],6,0,"cuda:0","<None>",0], "input_shapes": [[[],[],[],[]],[],[],[],[],[]], "input_types": ["GenericList[Int,Int,Int,Int]","Int","Int","Device","None","Int"],
+      "outputs": [[870,960,0,2359296,4,"cuda:0"]], "output_shapes": [[512,512,3,3]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::convolution_backward", "id": 958, "rf_id": 472, "parent": 957, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::convolution_backward(Tensor grad_output, Tensor input, Tensor weight, SymInt[]? bias_sizes, int[] stride, SymInt[] padding, int[] dilation, bool transposed, SymInt[] output_padding, int groups, bool[3] output_mask) -> (Tensor, Tensor, Tensor)",
+      "inputs": [[875,903,0,3211264,4,"cuda:0"],[661,677,0,3211264,4,"cuda:0"],[729,730,0,2359296,4,"cuda:0"],[0],[1,1],[1,1],[1,1],false,[0,0],1,[true,true,false]], "input_shapes": [[128,512,7,7],[128,512,7,7],[512,512,3,3],[[]],[[],[]],[[],[]],[[],[]],[],[[],[]],[],[[],[],[]]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(float)","GenericList[Int]","GenericList[Int,Int]","GenericList[Int,Int]","GenericList[Int,Int]","Bool","GenericList[Int,Int]","Int","GenericList[Bool,Bool,Bool]"],
+      "outputs": [[761,714,0,3211264,4,"cuda:0"],[870,960,0,2359296,4,"cuda:0"],[23,0,0,0,0,""]], "output_shapes": [[128,512,7,7],[512,512,3,3],[]], "output_types": ["Tensor(float)","Tensor(float)","Tensor(nullptr (uninitialized))"]
+    },
+    {
+      "name": "ConvolutionBackward0", "id": 957, "rf_id": 471, "parent": 956, "fw_parent": 2, "seq_id": 789, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[875,903,0,3211264,4,"cuda:0"]], "input_shapes": [[128,512,7,7]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::add_", "id": 961, "rf_id": 474, "parent": 956, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::add_.Tensor(Tensor(a!) self, Tensor other, *, Scalar alpha=1) -> Tensor(a!)",
+      "inputs": [[831,907,0,3211264,4,"cuda:0"],[761,714,0,3211264,4,"cuda:0"],1], "input_shapes": [[128,512,7,7],[128,512,7,7],[]], "input_types": ["Tensor(float)","Tensor(float)","Int"],
+      "outputs": [[831,907,0,3211264,4,"cuda:0"]], "output_shapes": [[128,512,7,7]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "autograd::engine::evaluate_function: ConvolutionBackward0", "id": 956, "rf_id": 470, "parent": 847, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "detach", "id": 965, "rf_id": 478, "parent": 964, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [[870,960,0,2359296,4,"cuda:0"]], "input_shapes": [[512,512,3,3]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::detach", "id": 964, "rf_id": 477, "parent": 963, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::detach(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[870,960,0,2359296,4,"cuda:0"]], "input_shapes": [[512,512,3,3]], "input_types": ["Tensor(float)"],
+      "outputs": [[875,960,0,2359296,4,"cuda:0"]], "output_shapes": [[512,512,3,3]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "torch::autograd::AccumulateGrad", "id": 963, "rf_id": 476, "parent": 962, "fw_parent": 2, "seq_id": -1, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[870,960,0,2359296,4,"cuda:0"]], "input_shapes": [[512,512,3,3]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: torch::autograd::AccumulateGrad", "id": 962, "rf_id": 475, "parent": 847, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::threshold_backward", "id": 968, "rf_id": 481, "parent": 967, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::threshold_backward(Tensor grad_output, Tensor self, Scalar threshold) -> Tensor",
+      "inputs": [[831,907,0,3211264,4,"cuda:0"],[870,677,0,3211264,4,"cuda:0"],0], "input_shapes": [[128,512,7,7],[128,512,7,7],[]], "input_types": ["Tensor(float)","Tensor(float)","Int"],
+      "outputs": [[661,714,0,3211264,4,"cuda:0"]], "output_shapes": [[128,512,7,7]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "ReluBackward0", "id": 967, "rf_id": 480, "parent": 966, "fw_parent": 2, "seq_id": 788, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[831,907,0,3211264,4,"cuda:0"]], "input_shapes": [[128,512,7,7]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: ReluBackward0", "id": 966, "rf_id": 479, "parent": 847, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "AddBackward0", "id": 970, "rf_id": 483, "parent": 969, "fw_parent": 2, "seq_id": 787, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[661,714,0,3211264,4,"cuda:0"]], "input_shapes": [[128,512,7,7]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: AddBackward0", "id": 969, "rf_id": 482, "parent": 847, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::empty", "id": 974, "rf_id": 487, "parent": 973, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[128,512,7,7],6,0,"cuda:0","<None>",0], "input_shapes": [[[],[],[],[]],[],[],[],[],[]], "input_types": ["GenericList[Int,Int,Int,Int]","Int","Int","Device","None","Int"],
+      "outputs": [[831,677,0,3211264,4,"cuda:0"]], "output_shapes": [[128,512,7,7]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty", "id": 975, "rf_id": 488, "parent": 973, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[512],6,0,"cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","Int","Device","None","None"],
+      "outputs": [[870,756,0,512,4,"cuda:0"]], "output_shapes": [[512]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty", "id": 976, "rf_id": 489, "parent": 973, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[512],6,0,"cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","Int","Device","None","None"],
+      "outputs": [[723,759,0,512,4,"cuda:0"]], "output_shapes": [[512]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::view", "id": 977, "rf_id": 490, "parent": 973, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::view(Tensor(a) self, SymInt[] size) -> Tensor(a)",
+      "inputs": [[701,702,0,512,4,"cuda:0"],[1,512,1,1]], "input_shapes": [[512],[[],[],[],[]]], "input_types": ["Tensor(float)","GenericList[Int,Int,Int,Int]"],
+      "outputs": [[811,702,0,512,4,"cuda:0"]], "output_shapes": [[1,512,1,1]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty", "id": 978, "rf_id": 491, "parent": 973, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[0],0,0,"cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","Int","Device","None","None"],
+      "outputs": [[811,57,0,0,1,"cuda:0"]], "output_shapes": [[0]], "output_types": ["Tensor(unsigned char)"]
+    },
+    {
+      "name": "aten::cudnn_batch_norm_backward", "id": 973, "rf_id": 486, "parent": 972, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::cudnn_batch_norm_backward(Tensor input, Tensor grad_output, Tensor weight, Tensor? running_mean, Tensor? running_var, Tensor? save_mean, Tensor? save_var, float epsilon, Tensor reserveSpace) -> (Tensor, Tensor, Tensor)",
+      "inputs": [[695,696,0,3211264,4,"cuda:0"],[661,714,0,3211264,4,"cuda:0"],[701,702,0,512,4,"cuda:0"],[705,706,0,512,4,"cuda:0"],[707,708,0,512,4,"cuda:0"],[716,718,0,512,4,"cuda:0"],[720,721,0,512,4,"cuda:0"],0.000010,[725,57,0,0,1,"cuda:0"]], "input_shapes": [[128,512,7,7],[128,512,7,7],[512],[512],[512],[512],[512],[],[0]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Double","Tensor(unsigned char)"],
+      "outputs": [[831,677,0,3211264,4,"cuda:0"],[870,756,0,512,4,"cuda:0"],[723,759,0,512,4,"cuda:0"]], "output_shapes": [[128,512,7,7],[512],[512]], "output_types": ["Tensor(float)","Tensor(float)","Tensor(float)"]
+    },
+    {
+      "name": "CudnnBatchNormBackward0", "id": 972, "rf_id": 485, "parent": 971, "fw_parent": 2, "seq_id": 786, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[661,714,0,3211264,4,"cuda:0"]], "input_shapes": [[128,512,7,7]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: CudnnBatchNormBackward0", "id": 971, "rf_id": 484, "parent": 847, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "detach", "id": 982, "rf_id": 495, "parent": 981, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [[870,756,0,512,4,"cuda:0"]], "input_shapes": [[512]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::detach", "id": 981, "rf_id": 494, "parent": 980, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::detach(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[870,756,0,512,4,"cuda:0"]], "input_shapes": [[512]], "input_types": ["Tensor(float)"],
+      "outputs": [[716,756,0,512,4,"cuda:0"]], "output_shapes": [[512]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "torch::autograd::AccumulateGrad", "id": 980, "rf_id": 493, "parent": 979, "fw_parent": 2, "seq_id": -1, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[870,756,0,512,4,"cuda:0"]], "input_shapes": [[512]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: torch::autograd::AccumulateGrad", "id": 979, "rf_id": 492, "parent": 847, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "detach", "id": 986, "rf_id": 499, "parent": 985, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [[723,759,0,512,4,"cuda:0"]], "input_shapes": [[512]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::detach", "id": 985, "rf_id": 498, "parent": 984, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::detach(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[723,759,0,512,4,"cuda:0"]], "input_shapes": [[512]], "input_types": ["Tensor(float)"],
+      "outputs": [[720,759,0,512,4,"cuda:0"]], "output_shapes": [[512]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "torch::autograd::AccumulateGrad", "id": 984, "rf_id": 497, "parent": 983, "fw_parent": 2, "seq_id": -1, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[723,759,0,512,4,"cuda:0"]], "input_shapes": [[512]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: torch::autograd::AccumulateGrad", "id": 983, "rf_id": 496, "parent": 847, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::empty", "id": 990, "rf_id": 503, "parent": 989, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[512,256,1,1],6,0,"cuda:0","<None>",0], "input_shapes": [[[],[],[],[]],[],[],[],[],[]], "input_types": ["GenericList[Int,Int,Int,Int]","Int","Int","Device","None","Int"],
+      "outputs": [[870,824,0,131072,4,"cuda:0"]], "output_shapes": [[512,256,1,1]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::convolution_backward", "id": 989, "rf_id": 502, "parent": 988, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::convolution_backward(Tensor grad_output, Tensor input, Tensor weight, SymInt[]? bias_sizes, int[] stride, SymInt[] padding, int[] dilation, bool transposed, SymInt[] output_padding, int groups, bool[3] output_mask) -> (Tensor, Tensor, Tensor)",
+      "inputs": [[831,677,0,3211264,4,"cuda:0"],[582,598,0,6422528,4,"cuda:0"],[689,690,0,131072,4,"cuda:0"],[0],[2,2],[0,0],[1,1],false,[0,0],1,[true,true,false]], "input_shapes": [[128,512,7,7],[128,256,14,14],[512,256,1,1],[[]],[[],[]],[[],[]],[[],[]],[],[[],[]],[],[[],[],[]]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(float)","GenericList[Int]","GenericList[Int,Int]","GenericList[Int,Int]","GenericList[Int,Int]","Bool","GenericList[Int,Int]","Int","GenericList[Bool,Bool,Bool]"],
+      "outputs": [[723,752,0,6422528,4,"cuda:0"],[870,824,0,131072,4,"cuda:0"],[23,0,0,0,0,""]], "output_shapes": [[128,256,14,14],[512,256,1,1],[]], "output_types": ["Tensor(float)","Tensor(float)","Tensor(nullptr (uninitialized))"]
+    },
+    {
+      "name": "ConvolutionBackward0", "id": 988, "rf_id": 501, "parent": 987, "fw_parent": 2, "seq_id": 785, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[831,677,0,3211264,4,"cuda:0"]], "input_shapes": [[128,512,7,7]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: ConvolutionBackward0", "id": 987, "rf_id": 500, "parent": 847, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "detach", "id": 994, "rf_id": 507, "parent": 993, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [[870,824,0,131072,4,"cuda:0"]], "input_shapes": [[512,256,1,1]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::detach", "id": 993, "rf_id": 506, "parent": 992, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::detach(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[870,824,0,131072,4,"cuda:0"]], "input_shapes": [[512,256,1,1]], "input_types": ["Tensor(float)"],
+      "outputs": [[695,824,0,131072,4,"cuda:0"]], "output_shapes": [[512,256,1,1]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "torch::autograd::AccumulateGrad", "id": 992, "rf_id": 505, "parent": 991, "fw_parent": 2, "seq_id": -1, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[870,824,0,131072,4,"cuda:0"]], "input_shapes": [[512,256,1,1]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: torch::autograd::AccumulateGrad", "id": 991, "rf_id": 504, "parent": 847, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::empty", "id": 998, "rf_id": 511, "parent": 997, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[128,512,7,7],6,0,"cuda:0","<None>",0], "input_shapes": [[[],[],[],[]],[],[],[],[],[]], "input_types": ["GenericList[Int,Int,Int,Int]","Int","Int","Device","None","Int"],
+      "outputs": [[870,677,0,3211264,4,"cuda:0"]], "output_shapes": [[128,512,7,7]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty", "id": 999, "rf_id": 512, "parent": 997, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[512],6,0,"cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","Int","Device","None","None"],
+      "outputs": [[831,718,0,512,4,"cuda:0"]], "output_shapes": [[512]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty", "id": 1000, "rf_id": 513, "parent": 997, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[512],6,0,"cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","Int","Device","None","None"],
+      "outputs": [[811,721,0,512,4,"cuda:0"]], "output_shapes": [[512]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::view", "id": 1001, "rf_id": 514, "parent": 997, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::view(Tensor(a) self, SymInt[] size) -> Tensor(a)",
+      "inputs": [[664,665,0,512,4,"cuda:0"],[1,512,1,1]], "input_shapes": [[512],[[],[],[],[]]], "input_types": ["Tensor(float)","GenericList[Int,Int,Int,Int]"],
+      "outputs": [[857,665,0,512,4,"cuda:0"]], "output_shapes": [[1,512,1,1]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty", "id": 1002, "rf_id": 515, "parent": 997, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[0],0,0,"cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","Int","Device","None","None"],
+      "outputs": [[857,57,0,0,1,"cuda:0"]], "output_shapes": [[0]], "output_types": ["Tensor(unsigned char)"]
+    },
+    {
+      "name": "aten::cudnn_batch_norm_backward", "id": 997, "rf_id": 510, "parent": 996, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::cudnn_batch_norm_backward(Tensor input, Tensor grad_output, Tensor weight, Tensor? running_mean, Tensor? running_var, Tensor? save_mean, Tensor? save_var, float epsilon, Tensor reserveSpace) -> (Tensor, Tensor, Tensor)",
+      "inputs": [[647,658,0,3211264,4,"cuda:0"],[661,714,0,3211264,4,"cuda:0"],[664,665,0,512,4,"cuda:0"],[668,669,0,512,4,"cuda:0"],[670,671,0,512,4,"cuda:0"],[679,681,0,512,4,"cuda:0"],[683,684,0,512,4,"cuda:0"],0.000010,[688,57,0,0,1,"cuda:0"]], "input_shapes": [[128,512,7,7],[128,512,7,7],[512],[512],[512],[512],[512],[],[0]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Double","Tensor(unsigned char)"],
+      "outputs": [[870,677,0,3211264,4,"cuda:0"],[831,718,0,512,4,"cuda:0"],[811,721,0,512,4,"cuda:0"]], "output_shapes": [[128,512,7,7],[512],[512]], "output_types": ["Tensor(float)","Tensor(float)","Tensor(float)"]
+    },
+    {
+      "name": "CudnnBatchNormBackward0", "id": 996, "rf_id": 509, "parent": 995, "fw_parent": 2, "seq_id": 784, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[661,714,0,3211264,4,"cuda:0"]], "input_shapes": [[128,512,7,7]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: CudnnBatchNormBackward0", "id": 995, "rf_id": 508, "parent": 847, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "detach", "id": 1006, "rf_id": 519, "parent": 1005, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [[831,718,0,512,4,"cuda:0"]], "input_shapes": [[512]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::detach", "id": 1005, "rf_id": 518, "parent": 1004, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::detach(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[831,718,0,512,4,"cuda:0"]], "input_shapes": [[512]], "input_types": ["Tensor(float)"],
+      "outputs": [[679,718,0,512,4,"cuda:0"]], "output_shapes": [[512]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "torch::autograd::AccumulateGrad", "id": 1004, "rf_id": 517, "parent": 1003, "fw_parent": 2, "seq_id": -1, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[831,718,0,512,4,"cuda:0"]], "input_shapes": [[512]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: torch::autograd::AccumulateGrad", "id": 1003, "rf_id": 516, "parent": 847, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "detach", "id": 1010, "rf_id": 523, "parent": 1009, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [[811,721,0,512,4,"cuda:0"]], "input_shapes": [[512]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::detach", "id": 1009, "rf_id": 522, "parent": 1008, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::detach(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[811,721,0,512,4,"cuda:0"]], "input_shapes": [[512]], "input_types": ["Tensor(float)"],
+      "outputs": [[683,721,0,512,4,"cuda:0"]], "output_shapes": [[512]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "torch::autograd::AccumulateGrad", "id": 1008, "rf_id": 521, "parent": 1007, "fw_parent": 2, "seq_id": -1, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[811,721,0,512,4,"cuda:0"]], "input_shapes": [[512]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: torch::autograd::AccumulateGrad", "id": 1007, "rf_id": 520, "parent": 847, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::empty", "id": 1014, "rf_id": 527, "parent": 1013, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[512,512,3,3],6,0,"cuda:0","<None>",0], "input_shapes": [[[],[],[],[]],[],[],[],[],[]], "input_types": ["GenericList[Int,Int,Int,Int]","Int","Int","Device","None","Int"],
+      "outputs": [[831,1015,0,2359296,4,"cuda:0"]], "output_shapes": [[512,512,3,3]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::convolution_backward", "id": 1013, "rf_id": 526, "parent": 1012, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::convolution_backward(Tensor grad_output, Tensor input, Tensor weight, SymInt[]? bias_sizes, int[] stride, SymInt[] padding, int[] dilation, bool transposed, SymInt[] output_padding, int groups, bool[3] output_mask) -> (Tensor, Tensor, Tensor)",
+      "inputs": [[870,677,0,3211264,4,"cuda:0"],[622,638,0,3211264,4,"cuda:0"],[652,653,0,2359296,4,"cuda:0"],[0],[1,1],[1,1],[1,1],false,[0,0],1,[true,true,false]], "input_shapes": [[128,512,7,7],[128,512,7,7],[512,512,3,3],[[]],[[],[]],[[],[]],[[],[]],[],[[],[]],[],[[],[],[]]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(float)","GenericList[Int]","GenericList[Int,Int]","GenericList[Int,Int]","GenericList[Int,Int]","Bool","GenericList[Int,Int]","Int","GenericList[Bool,Bool,Bool]"],
+      "outputs": [[811,658,0,3211264,4,"cuda:0"],[831,1015,0,2359296,4,"cuda:0"],[23,0,0,0,0,""]], "output_shapes": [[128,512,7,7],[512,512,3,3],[]], "output_types": ["Tensor(float)","Tensor(float)","Tensor(nullptr (uninitialized))"]
+    },
+    {
+      "name": "ConvolutionBackward0", "id": 1012, "rf_id": 525, "parent": 1011, "fw_parent": 2, "seq_id": 783, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[870,677,0,3211264,4,"cuda:0"]], "input_shapes": [[128,512,7,7]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: ConvolutionBackward0", "id": 1011, "rf_id": 524, "parent": 847, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "detach", "id": 1019, "rf_id": 531, "parent": 1018, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [[831,1015,0,2359296,4,"cuda:0"]], "input_shapes": [[512,512,3,3]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::detach", "id": 1018, "rf_id": 530, "parent": 1017, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::detach(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[831,1015,0,2359296,4,"cuda:0"]], "input_shapes": [[512,512,3,3]], "input_types": ["Tensor(float)"],
+      "outputs": [[870,1015,0,2359296,4,"cuda:0"]], "output_shapes": [[512,512,3,3]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "torch::autograd::AccumulateGrad", "id": 1017, "rf_id": 529, "parent": 1016, "fw_parent": 2, "seq_id": -1, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[831,1015,0,2359296,4,"cuda:0"]], "input_shapes": [[512,512,3,3]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: torch::autograd::AccumulateGrad", "id": 1016, "rf_id": 528, "parent": 847, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::threshold_backward", "id": 1022, "rf_id": 534, "parent": 1021, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::threshold_backward(Tensor grad_output, Tensor self, Scalar threshold) -> Tensor",
+      "inputs": [[811,658,0,3211264,4,"cuda:0"],[831,638,0,3211264,4,"cuda:0"],0], "input_shapes": [[128,512,7,7],[128,512,7,7],[]], "input_types": ["Tensor(float)","Tensor(float)","Int"],
+      "outputs": [[622,677,0,3211264,4,"cuda:0"]], "output_shapes": [[128,512,7,7]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "ReluBackward0", "id": 1021, "rf_id": 533, "parent": 1020, "fw_parent": 2, "seq_id": 782, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[811,658,0,3211264,4,"cuda:0"]], "input_shapes": [[128,512,7,7]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: ReluBackward0", "id": 1020, "rf_id": 532, "parent": 847, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::empty", "id": 1026, "rf_id": 538, "parent": 1025, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[128,512,7,7],6,0,"cuda:0","<None>",0], "input_shapes": [[[],[],[],[]],[],[],[],[],[]], "input_types": ["GenericList[Int,Int,Int,Int]","Int","Int","Device","None","Int"],
+      "outputs": [[811,638,0,3211264,4,"cuda:0"]], "output_shapes": [[128,512,7,7]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty", "id": 1027, "rf_id": 539, "parent": 1025, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[512],6,0,"cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","Int","Device","None","None"],
+      "outputs": [[831,681,0,512,4,"cuda:0"]], "output_shapes": [[512]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty", "id": 1028, "rf_id": 540, "parent": 1025, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[512],6,0,"cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","Int","Device","None","None"],
+      "outputs": [[647,684,0,512,4,"cuda:0"]], "output_shapes": [[512]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::view", "id": 1029, "rf_id": 541, "parent": 1025, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::view(Tensor(a) self, SymInt[] size) -> Tensor(a)",
+      "inputs": [[625,626,0,512,4,"cuda:0"],[1,512,1,1]], "input_shapes": [[512],[[],[],[],[]]], "input_types": ["Tensor(float)","GenericList[Int,Int,Int,Int]"],
+      "outputs": [[661,626,0,512,4,"cuda:0"]], "output_shapes": [[1,512,1,1]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty", "id": 1030, "rf_id": 542, "parent": 1025, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[0],0,0,"cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","Int","Device","None","None"],
+      "outputs": [[661,57,0,0,1,"cuda:0"]], "output_shapes": [[0]], "output_types": ["Tensor(unsigned char)"]
+    },
+    {
+      "name": "aten::cudnn_batch_norm_backward", "id": 1025, "rf_id": 537, "parent": 1024, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::cudnn_batch_norm_backward(Tensor input, Tensor grad_output, Tensor weight, Tensor? running_mean, Tensor? running_var, Tensor? save_mean, Tensor? save_var, float epsilon, Tensor reserveSpace) -> (Tensor, Tensor, Tensor)",
+      "inputs": [[607,619,0,3211264,4,"cuda:0"],[622,677,0,3211264,4,"cuda:0"],[625,626,0,512,4,"cuda:0"],[629,630,0,512,4,"cuda:0"],[631,632,0,512,4,"cuda:0"],[640,642,0,512,4,"cuda:0"],[644,645,0,512,4,"cuda:0"],0.000010,[649,57,0,0,1,"cuda:0"]], "input_shapes": [[128,512,7,7],[128,512,7,7],[512],[512],[512],[512],[512],[],[0]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Double","Tensor(unsigned char)"],
+      "outputs": [[811,638,0,3211264,4,"cuda:0"],[831,681,0,512,4,"cuda:0"],[647,684,0,512,4,"cuda:0"]], "output_shapes": [[128,512,7,7],[512],[512]], "output_types": ["Tensor(float)","Tensor(float)","Tensor(float)"]
+    },
+    {
+      "name": "CudnnBatchNormBackward0", "id": 1024, "rf_id": 536, "parent": 1023, "fw_parent": 2, "seq_id": 781, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[622,677,0,3211264,4,"cuda:0"]], "input_shapes": [[128,512,7,7]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: CudnnBatchNormBackward0", "id": 1023, "rf_id": 535, "parent": 847, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "detach", "id": 1034, "rf_id": 546, "parent": 1033, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [[831,681,0,512,4,"cuda:0"]], "input_shapes": [[512]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::detach", "id": 1033, "rf_id": 545, "parent": 1032, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::detach(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[831,681,0,512,4,"cuda:0"]], "input_shapes": [[512]], "input_types": ["Tensor(float)"],
+      "outputs": [[607,681,0,512,4,"cuda:0"]], "output_shapes": [[512]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "torch::autograd::AccumulateGrad", "id": 1032, "rf_id": 544, "parent": 1031, "fw_parent": 2, "seq_id": -1, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[831,681,0,512,4,"cuda:0"]], "input_shapes": [[512]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: torch::autograd::AccumulateGrad", "id": 1031, "rf_id": 543, "parent": 847, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "detach", "id": 1038, "rf_id": 550, "parent": 1037, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [[647,684,0,512,4,"cuda:0"]], "input_shapes": [[512]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::detach", "id": 1037, "rf_id": 549, "parent": 1036, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::detach(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[647,684,0,512,4,"cuda:0"]], "input_shapes": [[512]], "input_types": ["Tensor(float)"],
+      "outputs": [[640,684,0,512,4,"cuda:0"]], "output_shapes": [[512]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "torch::autograd::AccumulateGrad", "id": 1036, "rf_id": 548, "parent": 1035, "fw_parent": 2, "seq_id": -1, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[647,684,0,512,4,"cuda:0"]], "input_shapes": [[512]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: torch::autograd::AccumulateGrad", "id": 1035, "rf_id": 547, "parent": 847, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::empty", "id": 1042, "rf_id": 554, "parent": 1041, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[512,256,3,3],6,0,"cuda:0","<None>",0], "input_shapes": [[[],[],[],[]],[],[],[],[],[]], "input_types": ["GenericList[Int,Int,Int,Int]","Int","Int","Device","None","Int"],
+      "outputs": [[831,1043,0,1179648,4,"cuda:0"]], "output_shapes": [[512,256,3,3]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::convolution_backward", "id": 1041, "rf_id": 553, "parent": 1040, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::convolution_backward(Tensor grad_output, Tensor input, Tensor weight, SymInt[]? bias_sizes, int[] stride, SymInt[] padding, int[] dilation, bool transposed, SymInt[] output_padding, int groups, bool[3] output_mask) -> (Tensor, Tensor, Tensor)",
+      "inputs": [[811,638,0,3211264,4,"cuda:0"],[582,598,0,6422528,4,"cuda:0"],[613,614,0,1179648,4,"cuda:0"],[0],[2,2],[1,1],[1,1],false,[0,0],1,[true,true,false]], "input_shapes": [[128,512,7,7],[128,256,14,14],[512,256,3,3],[[]],[[],[]],[[],[]],[[],[]],[],[[],[]],[],[[],[],[]]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(float)","GenericList[Int]","GenericList[Int,Int]","GenericList[Int,Int]","GenericList[Int,Int]","Bool","GenericList[Int,Int]","Int","GenericList[Bool,Bool,Bool]"],
+      "outputs": [[647,658,0,6422528,4,"cuda:0"],[831,1043,0,1179648,4,"cuda:0"],[23,0,0,0,0,""]], "output_shapes": [[128,256,14,14],[512,256,3,3],[]], "output_types": ["Tensor(float)","Tensor(float)","Tensor(nullptr (uninitialized))"]
+    },
+    {
+      "name": "ConvolutionBackward0", "id": 1040, "rf_id": 552, "parent": 1039, "fw_parent": 2, "seq_id": 780, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[811,638,0,3211264,4,"cuda:0"]], "input_shapes": [[128,512,7,7]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::add_", "id": 1044, "rf_id": 555, "parent": 1039, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::add_.Tensor(Tensor(a!) self, Tensor other, *, Scalar alpha=1) -> Tensor(a!)",
+      "inputs": [[723,752,0,6422528,4,"cuda:0"],[647,658,0,6422528,4,"cuda:0"],1], "input_shapes": [[128,256,14,14],[128,256,14,14],[]], "input_types": ["Tensor(float)","Tensor(float)","Int"],
+      "outputs": [[723,752,0,6422528,4,"cuda:0"]], "output_shapes": [[128,256,14,14]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "autograd::engine::evaluate_function: ConvolutionBackward0", "id": 1039, "rf_id": 551, "parent": 847, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "detach", "id": 1048, "rf_id": 559, "parent": 1047, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [[831,1043,0,1179648,4,"cuda:0"]], "input_shapes": [[512,256,3,3]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::detach", "id": 1047, "rf_id": 558, "parent": 1046, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::detach(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[831,1043,0,1179648,4,"cuda:0"]], "input_shapes": [[512,256,3,3]], "input_types": ["Tensor(float)"],
+      "outputs": [[811,1043,0,1179648,4,"cuda:0"]], "output_shapes": [[512,256,3,3]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "torch::autograd::AccumulateGrad", "id": 1046, "rf_id": 557, "parent": 1045, "fw_parent": 2, "seq_id": -1, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[831,1043,0,1179648,4,"cuda:0"]], "input_shapes": [[512,256,3,3]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: torch::autograd::AccumulateGrad", "id": 1045, "rf_id": 556, "parent": 847, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::threshold_backward", "id": 1051, "rf_id": 562, "parent": 1050, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::threshold_backward(Tensor grad_output, Tensor self, Scalar threshold) -> Tensor",
+      "inputs": [[723,752,0,6422528,4,"cuda:0"],[831,598,0,6422528,4,"cuda:0"],0], "input_shapes": [[128,256,14,14],[128,256,14,14],[]], "input_types": ["Tensor(float)","Tensor(float)","Int"],
+      "outputs": [[582,619,0,6422528,4,"cuda:0"]], "output_shapes": [[128,256,14,14]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "ReluBackward0", "id": 1050, "rf_id": 561, "parent": 1049, "fw_parent": 2, "seq_id": 779, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[723,752,0,6422528,4,"cuda:0"]], "input_shapes": [[128,256,14,14]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: ReluBackward0", "id": 1049, "rf_id": 560, "parent": 847, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "AddBackward0", "id": 1053, "rf_id": 564, "parent": 1052, "fw_parent": 2, "seq_id": 778, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[582,619,0,6422528,4,"cuda:0"]], "input_shapes": [[128,256,14,14]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: AddBackward0", "id": 1052, "rf_id": 563, "parent": 847, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::empty", "id": 1057, "rf_id": 568, "parent": 1056, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[128,256,14,14],6,0,"cuda:0","<None>",0], "input_shapes": [[[],[],[],[]],[],[],[],[],[]], "input_types": ["GenericList[Int,Int,Int,Int]","Int","Int","Device","None","Int"],
+      "outputs": [[723,598,0,6422528,4,"cuda:0"]], "output_shapes": [[128,256,14,14]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty", "id": 1058, "rf_id": 569, "parent": 1056, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[256],6,0,"cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","Int","Device","None","None"],
+      "outputs": [[831,642,0,256,4,"cuda:0"]], "output_shapes": [[256]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty", "id": 1059, "rf_id": 570, "parent": 1056, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[256],6,0,"cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","Int","Device","None","None"],
+      "outputs": [[622,1060,0,256,4,"cuda:0"]], "output_shapes": [[256]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::view", "id": 1061, "rf_id": 571, "parent": 1056, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::view(Tensor(a) self, SymInt[] size) -> Tensor(a)",
+      "inputs": [[585,586,0,256,4,"cuda:0"],[1,256,1,1]], "input_shapes": [[256],[[],[],[],[]]], "input_types": ["Tensor(float)","GenericList[Int,Int,Int,Int]"],
+      "outputs": [[661,586,0,256,4,"cuda:0"]], "output_shapes": [[1,256,1,1]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty", "id": 1062, "rf_id": 572, "parent": 1056, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[0],0,0,"cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","Int","Device","None","None"],
+      "outputs": [[661,57,0,0,1,"cuda:0"]], "output_shapes": [[0]], "output_types": ["Tensor(unsigned char)"]
+    },
+    {
+      "name": "aten::cudnn_batch_norm_backward", "id": 1056, "rf_id": 567, "parent": 1055, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::cudnn_batch_norm_backward(Tensor input, Tensor grad_output, Tensor weight, Tensor? running_mean, Tensor? running_var, Tensor? save_mean, Tensor? save_var, float epsilon, Tensor reserveSpace) -> (Tensor, Tensor, Tensor)",
+      "inputs": [[568,579,0,6422528,4,"cuda:0"],[582,619,0,6422528,4,"cuda:0"],[585,586,0,256,4,"cuda:0"],[589,590,0,256,4,"cuda:0"],[591,592,0,256,4,"cuda:0"],[600,602,0,256,4,"cuda:0"],[604,605,0,256,4,"cuda:0"],0.000010,[609,57,0,0,1,"cuda:0"]], "input_shapes": [[128,256,14,14],[128,256,14,14],[256],[256],[256],[256],[256],[],[0]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Double","Tensor(unsigned char)"],
+      "outputs": [[723,598,0,6422528,4,"cuda:0"],[831,642,0,256,4,"cuda:0"],[622,1060,0,256,4,"cuda:0"]], "output_shapes": [[128,256,14,14],[256],[256]], "output_types": ["Tensor(float)","Tensor(float)","Tensor(float)"]
+    },
+    {
+      "name": "CudnnBatchNormBackward0", "id": 1055, "rf_id": 566, "parent": 1054, "fw_parent": 2, "seq_id": 777, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[582,619,0,6422528,4,"cuda:0"]], "input_shapes": [[128,256,14,14]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: CudnnBatchNormBackward0", "id": 1054, "rf_id": 565, "parent": 847, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "detach", "id": 1066, "rf_id": 576, "parent": 1065, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [[831,642,0,256,4,"cuda:0"]], "input_shapes": [[256]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::detach", "id": 1065, "rf_id": 575, "parent": 1064, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::detach(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[831,642,0,256,4,"cuda:0"]], "input_shapes": [[256]], "input_types": ["Tensor(float)"],
+      "outputs": [[600,642,0,256,4,"cuda:0"]], "output_shapes": [[256]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "torch::autograd::AccumulateGrad", "id": 1064, "rf_id": 574, "parent": 1063, "fw_parent": 2, "seq_id": -1, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[831,642,0,256,4,"cuda:0"]], "input_shapes": [[256]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: torch::autograd::AccumulateGrad", "id": 1063, "rf_id": 573, "parent": 847, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "detach", "id": 1070, "rf_id": 580, "parent": 1069, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [[622,1060,0,256,4,"cuda:0"]], "input_shapes": [[256]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::detach", "id": 1069, "rf_id": 579, "parent": 1068, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::detach(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[622,1060,0,256,4,"cuda:0"]], "input_shapes": [[256]], "input_types": ["Tensor(float)"],
+      "outputs": [[604,1060,0,256,4,"cuda:0"]], "output_shapes": [[256]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "torch::autograd::AccumulateGrad", "id": 1068, "rf_id": 578, "parent": 1067, "fw_parent": 2, "seq_id": -1, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[622,1060,0,256,4,"cuda:0"]], "input_shapes": [[256]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: torch::autograd::AccumulateGrad", "id": 1067, "rf_id": 577, "parent": 847, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::empty", "id": 1074, "rf_id": 584, "parent": 1073, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[256,256,3,3],6,0,"cuda:0","<None>",0], "input_shapes": [[[],[],[],[]],[],[],[],[],[]], "input_types": ["GenericList[Int,Int,Int,Int]","Int","Int","Device","None","Int"],
+      "outputs": [[831,1075,0,589824,4,"cuda:0"]], "output_shapes": [[256,256,3,3]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::convolution_backward", "id": 1073, "rf_id": 583, "parent": 1072, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::convolution_backward(Tensor grad_output, Tensor input, Tensor weight, SymInt[]? bias_sizes, int[] stride, SymInt[] padding, int[] dilation, bool transposed, SymInt[] output_padding, int groups, bool[3] output_mask) -> (Tensor, Tensor, Tensor)",
+      "inputs": [[723,598,0,6422528,4,"cuda:0"],[530,559,0,6422528,4,"cuda:0"],[573,574,0,589824,4,"cuda:0"],[0],[1,1],[1,1],[1,1],false,[0,0],1,[true,true,false]], "input_shapes": [[128,256,14,14],[128,256,14,14],[256,256,3,3],[[]],[[],[]],[[],[]],[[],[]],[],[[],[]],[],[[],[],[]]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(float)","GenericList[Int]","GenericList[Int,Int]","GenericList[Int,Int]","GenericList[Int,Int]","Bool","GenericList[Int,Int]","Int","GenericList[Bool,Bool,Bool]"],
+      "outputs": [[622,579,0,6422528,4,"cuda:0"],[831,1075,0,589824,4,"cuda:0"],[23,0,0,0,0,""]], "output_shapes": [[128,256,14,14],[256,256,3,3],[]], "output_types": ["Tensor(float)","Tensor(float)","Tensor(nullptr (uninitialized))"]
+    },
+    {
+      "name": "ConvolutionBackward0", "id": 1072, "rf_id": 582, "parent": 1071, "fw_parent": 2, "seq_id": 776, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[723,598,0,6422528,4,"cuda:0"]], "input_shapes": [[128,256,14,14]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: ConvolutionBackward0", "id": 1071, "rf_id": 581, "parent": 847, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "detach", "id": 1079, "rf_id": 588, "parent": 1078, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [[831,1075,0,589824,4,"cuda:0"]], "input_shapes": [[256,256,3,3]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::detach", "id": 1078, "rf_id": 587, "parent": 1077, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::detach(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[831,1075,0,589824,4,"cuda:0"]], "input_shapes": [[256,256,3,3]], "input_types": ["Tensor(float)"],
+      "outputs": [[723,1075,0,589824,4,"cuda:0"]], "output_shapes": [[256,256,3,3]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "torch::autograd::AccumulateGrad", "id": 1077, "rf_id": 586, "parent": 1076, "fw_parent": 2, "seq_id": -1, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[831,1075,0,589824,4,"cuda:0"]], "input_shapes": [[256,256,3,3]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: torch::autograd::AccumulateGrad", "id": 1076, "rf_id": 585, "parent": 847, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::threshold_backward", "id": 1082, "rf_id": 591, "parent": 1081, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::threshold_backward(Tensor grad_output, Tensor self, Scalar threshold) -> Tensor",
+      "inputs": [[622,579,0,6422528,4,"cuda:0"],[831,559,0,6422528,4,"cuda:0"],0], "input_shapes": [[128,256,14,14],[128,256,14,14],[]], "input_types": ["Tensor(float)","Tensor(float)","Int"],
+      "outputs": [[530,598,0,6422528,4,"cuda:0"]], "output_shapes": [[128,256,14,14]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "ReluBackward0", "id": 1081, "rf_id": 590, "parent": 1080, "fw_parent": 2, "seq_id": 775, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[622,579,0,6422528,4,"cuda:0"]], "input_shapes": [[128,256,14,14]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: ReluBackward0", "id": 1080, "rf_id": 589, "parent": 847, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::empty", "id": 1086, "rf_id": 595, "parent": 1085, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[128,256,14,14],6,0,"cuda:0","<None>",0], "input_shapes": [[[],[],[],[]],[],[],[],[],[]], "input_types": ["GenericList[Int,Int,Int,Int]","Int","Int","Device","None","Int"],
+      "outputs": [[622,579,0,6422528,4,"cuda:0"]], "output_shapes": [[128,256,14,14]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty", "id": 1087, "rf_id": 596, "parent": 1085, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[256],6,0,"cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","Int","Device","None","None"],
+      "outputs": [[831,602,0,256,4,"cuda:0"]], "output_shapes": [[256]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty", "id": 1088, "rf_id": 597, "parent": 1085, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[256],6,0,"cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","Int","Device","None","None"],
+      "outputs": [[568,605,0,256,4,"cuda:0"]], "output_shapes": [[256]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::view", "id": 1089, "rf_id": 598, "parent": 1085, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::view(Tensor(a) self, SymInt[] size) -> Tensor(a)",
+      "inputs": [[546,547,0,256,4,"cuda:0"],[1,256,1,1]], "input_shapes": [[256],[[],[],[],[]]], "input_types": ["Tensor(float)","GenericList[Int,Int,Int,Int]"],
+      "outputs": [[661,547,0,256,4,"cuda:0"]], "output_shapes": [[1,256,1,1]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty", "id": 1090, "rf_id": 599, "parent": 1085, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[0],0,0,"cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","Int","Device","None","None"],
+      "outputs": [[661,57,0,0,1,"cuda:0"]], "output_shapes": [[0]], "output_types": ["Tensor(unsigned char)"]
+    },
+    {
+      "name": "aten::cudnn_batch_norm_backward", "id": 1085, "rf_id": 594, "parent": 1084, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::cudnn_batch_norm_backward(Tensor input, Tensor grad_output, Tensor weight, Tensor? running_mean, Tensor? running_var, Tensor? save_mean, Tensor? save_var, float epsilon, Tensor reserveSpace) -> (Tensor, Tensor, Tensor)",
+      "inputs": [[493,521,0,6422528,4,"cuda:0"],[530,598,0,6422528,4,"cuda:0"],[546,547,0,256,4,"cuda:0"],[550,551,0,256,4,"cuda:0"],[552,553,0,256,4,"cuda:0"],[561,563,0,256,4,"cuda:0"],[565,566,0,256,4,"cuda:0"],0.000010,[570,57,0,0,1,"cuda:0"]], "input_shapes": [[128,256,14,14],[128,256,14,14],[256],[256],[256],[256],[256],[],[0]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Double","Tensor(unsigned char)"],
+      "outputs": [[622,579,0,6422528,4,"cuda:0"],[831,602,0,256,4,"cuda:0"],[568,605,0,256,4,"cuda:0"]], "output_shapes": [[128,256,14,14],[256],[256]], "output_types": ["Tensor(float)","Tensor(float)","Tensor(float)"]
+    },
+    {
+      "name": "CudnnBatchNormBackward0", "id": 1084, "rf_id": 593, "parent": 1083, "fw_parent": 2, "seq_id": 774, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[530,598,0,6422528,4,"cuda:0"]], "input_shapes": [[128,256,14,14]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: CudnnBatchNormBackward0", "id": 1083, "rf_id": 592, "parent": 847, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "detach", "id": 1094, "rf_id": 603, "parent": 1093, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [[831,602,0,256,4,"cuda:0"]], "input_shapes": [[256]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::detach", "id": 1093, "rf_id": 602, "parent": 1092, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::detach(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[831,602,0,256,4,"cuda:0"]], "input_shapes": [[256]], "input_types": ["Tensor(float)"],
+      "outputs": [[493,602,0,256,4,"cuda:0"]], "output_shapes": [[256]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "torch::autograd::AccumulateGrad", "id": 1092, "rf_id": 601, "parent": 1091, "fw_parent": 2, "seq_id": -1, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[831,602,0,256,4,"cuda:0"]], "input_shapes": [[256]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: torch::autograd::AccumulateGrad", "id": 1091, "rf_id": 600, "parent": 847, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "detach", "id": 1098, "rf_id": 607, "parent": 1097, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [[568,605,0,256,4,"cuda:0"]], "input_shapes": [[256]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::detach", "id": 1097, "rf_id": 606, "parent": 1096, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::detach(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[568,605,0,256,4,"cuda:0"]], "input_shapes": [[256]], "input_types": ["Tensor(float)"],
+      "outputs": [[561,605,0,256,4,"cuda:0"]], "output_shapes": [[256]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "torch::autograd::AccumulateGrad", "id": 1096, "rf_id": 605, "parent": 1095, "fw_parent": 2, "seq_id": -1, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[568,605,0,256,4,"cuda:0"]], "input_shapes": [[256]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: torch::autograd::AccumulateGrad", "id": 1095, "rf_id": 604, "parent": 847, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::empty", "id": 1102, "rf_id": 611, "parent": 1101, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[256,256,3,3],6,0,"cuda:0","<None>",0], "input_shapes": [[[],[],[],[]],[],[],[],[],[]], "input_types": ["GenericList[Int,Int,Int,Int]","Int","Int","Device","None","Int"],
+      "outputs": [[831,1103,0,589824,4,"cuda:0"]], "output_shapes": [[256,256,3,3]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::convolution_backward", "id": 1101, "rf_id": 610, "parent": 1100, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::convolution_backward(Tensor grad_output, Tensor input, Tensor weight, SymInt[]? bias_sizes, int[] stride, SymInt[] padding, int[] dilation, bool transposed, SymInt[] output_padding, int groups, bool[3] output_mask) -> (Tensor, Tensor, Tensor)",
+      "inputs": [[622,579,0,6422528,4,"cuda:0"],[468,484,0,6422528,4,"cuda:0"],[536,537,0,589824,4,"cuda:0"],[0],[1,1],[1,1],[1,1],false,[0,0],1,[true,true,false]], "input_shapes": [[128,256,14,14],[128,256,14,14],[256,256,3,3],[[]],[[],[]],[[],[]],[[],[]],[],[[],[]],[],[[],[],[]]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(float)","GenericList[Int]","GenericList[Int,Int]","GenericList[Int,Int]","GenericList[Int,Int]","Bool","GenericList[Int,Int]","Int","GenericList[Bool,Bool,Bool]"],
+      "outputs": [[568,598,0,6422528,4,"cuda:0"],[831,1103,0,589824,4,"cuda:0"],[23,0,0,0,0,""]], "output_shapes": [[128,256,14,14],[256,256,3,3],[]], "output_types": ["Tensor(float)","Tensor(float)","Tensor(nullptr (uninitialized))"]
+    },
+    {
+      "name": "ConvolutionBackward0", "id": 1100, "rf_id": 609, "parent": 1099, "fw_parent": 2, "seq_id": 773, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[622,579,0,6422528,4,"cuda:0"]], "input_shapes": [[128,256,14,14]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::add_", "id": 1104, "rf_id": 612, "parent": 1099, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::add_.Tensor(Tensor(a!) self, Tensor other, *, Scalar alpha=1) -> Tensor(a!)",
+      "inputs": [[582,619,0,6422528,4,"cuda:0"],[568,598,0,6422528,4,"cuda:0"],1], "input_shapes": [[128,256,14,14],[128,256,14,14],[]], "input_types": ["Tensor(float)","Tensor(float)","Int"],
+      "outputs": [[582,619,0,6422528,4,"cuda:0"]], "output_shapes": [[128,256,14,14]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "autograd::engine::evaluate_function: ConvolutionBackward0", "id": 1099, "rf_id": 608, "parent": 847, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "detach", "id": 1108, "rf_id": 616, "parent": 1107, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [[831,1103,0,589824,4,"cuda:0"]], "input_shapes": [[256,256,3,3]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::detach", "id": 1107, "rf_id": 615, "parent": 1106, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::detach(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[831,1103,0,589824,4,"cuda:0"]], "input_shapes": [[256,256,3,3]], "input_types": ["Tensor(float)"],
+      "outputs": [[622,1103,0,589824,4,"cuda:0"]], "output_shapes": [[256,256,3,3]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "torch::autograd::AccumulateGrad", "id": 1106, "rf_id": 614, "parent": 1105, "fw_parent": 2, "seq_id": -1, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[831,1103,0,589824,4,"cuda:0"]], "input_shapes": [[256,256,3,3]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: torch::autograd::AccumulateGrad", "id": 1105, "rf_id": 613, "parent": 847, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::threshold_backward", "id": 1111, "rf_id": 619, "parent": 1110, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::threshold_backward(Tensor grad_output, Tensor self, Scalar threshold) -> Tensor",
+      "inputs": [[582,619,0,6422528,4,"cuda:0"],[831,484,0,6422528,4,"cuda:0"],0], "input_shapes": [[128,256,14,14],[128,256,14,14],[]], "input_types": ["Tensor(float)","Tensor(float)","Int"],
+      "outputs": [[468,579,0,6422528,4,"cuda:0"]], "output_shapes": [[128,256,14,14]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "ReluBackward0", "id": 1110, "rf_id": 618, "parent": 1109, "fw_parent": 2, "seq_id": 772, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[582,619,0,6422528,4,"cuda:0"]], "input_shapes": [[128,256,14,14]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: ReluBackward0", "id": 1109, "rf_id": 617, "parent": 847, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "AddBackward0", "id": 1113, "rf_id": 621, "parent": 1112, "fw_parent": 2, "seq_id": 771, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[468,579,0,6422528,4,"cuda:0"]], "input_shapes": [[128,256,14,14]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: AddBackward0", "id": 1112, "rf_id": 620, "parent": 847, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::empty", "id": 1117, "rf_id": 625, "parent": 1116, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[128,256,14,14],6,0,"cuda:0","<None>",0], "input_shapes": [[[],[],[],[]],[],[],[],[],[]], "input_types": ["GenericList[Int,Int,Int,Int]","Int","Int","Device","None","Int"],
+      "outputs": [[582,484,0,6422528,4,"cuda:0"]], "output_shapes": [[128,256,14,14]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty", "id": 1118, "rf_id": 626, "parent": 1116, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[256],6,0,"cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","Int","Device","None","None"],
+      "outputs": [[831,563,0,256,4,"cuda:0"]], "output_shapes": [[256]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty", "id": 1119, "rf_id": 627, "parent": 1116, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[256],6,0,"cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","Int","Device","None","None"],
+      "outputs": [[530,566,0,256,4,"cuda:0"]], "output_shapes": [[256]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::view", "id": 1120, "rf_id": 628, "parent": 1116, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::view(Tensor(a) self, SymInt[] size) -> Tensor(a)",
+      "inputs": [[508,509,0,256,4,"cuda:0"],[1,256,1,1]], "input_shapes": [[256],[[],[],[],[]]], "input_types": ["Tensor(float)","GenericList[Int,Int,Int,Int]"],
+      "outputs": [[661,509,0,256,4,"cuda:0"]], "output_shapes": [[1,256,1,1]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty", "id": 1121, "rf_id": 629, "parent": 1116, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[0],0,0,"cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","Int","Device","None","None"],
+      "outputs": [[661,57,0,0,1,"cuda:0"]], "output_shapes": [[0]], "output_types": ["Tensor(unsigned char)"]
+    },
+    {
+      "name": "aten::cudnn_batch_norm_backward", "id": 1116, "rf_id": 624, "parent": 1115, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::cudnn_batch_norm_backward(Tensor input, Tensor grad_output, Tensor weight, Tensor? running_mean, Tensor? running_var, Tensor? save_mean, Tensor? save_var, float epsilon, Tensor reserveSpace) -> (Tensor, Tensor, Tensor)",
+      "inputs": [[502,503,0,6422528,4,"cuda:0"],[468,579,0,6422528,4,"cuda:0"],[508,509,0,256,4,"cuda:0"],[512,513,0,256,4,"cuda:0"],[514,515,0,256,4,"cuda:0"],[523,525,0,256,4,"cuda:0"],[527,528,0,256,4,"cuda:0"],0.000010,[532,57,0,0,1,"cuda:0"]], "input_shapes": [[128,256,14,14],[128,256,14,14],[256],[256],[256],[256],[256],[],[0]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Double","Tensor(unsigned char)"],
+      "outputs": [[582,484,0,6422528,4,"cuda:0"],[831,563,0,256,4,"cuda:0"],[530,566,0,256,4,"cuda:0"]], "output_shapes": [[128,256,14,14],[256],[256]], "output_types": ["Tensor(float)","Tensor(float)","Tensor(float)"]
+    },
+    {
+      "name": "CudnnBatchNormBackward0", "id": 1115, "rf_id": 623, "parent": 1114, "fw_parent": 2, "seq_id": 770, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[468,579,0,6422528,4,"cuda:0"]], "input_shapes": [[128,256,14,14]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: CudnnBatchNormBackward0", "id": 1114, "rf_id": 622, "parent": 847, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "detach", "id": 1125, "rf_id": 633, "parent": 1124, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [[831,563,0,256,4,"cuda:0"]], "input_shapes": [[256]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::detach", "id": 1124, "rf_id": 632, "parent": 1123, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::detach(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[831,563,0,256,4,"cuda:0"]], "input_shapes": [[256]], "input_types": ["Tensor(float)"],
+      "outputs": [[523,563,0,256,4,"cuda:0"]], "output_shapes": [[256]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "torch::autograd::AccumulateGrad", "id": 1123, "rf_id": 631, "parent": 1122, "fw_parent": 2, "seq_id": -1, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[831,563,0,256,4,"cuda:0"]], "input_shapes": [[256]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: torch::autograd::AccumulateGrad", "id": 1122, "rf_id": 630, "parent": 847, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "detach", "id": 1129, "rf_id": 637, "parent": 1128, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [[530,566,0,256,4,"cuda:0"]], "input_shapes": [[256]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::detach", "id": 1128, "rf_id": 636, "parent": 1127, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::detach(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[530,566,0,256,4,"cuda:0"]], "input_shapes": [[256]], "input_types": ["Tensor(float)"],
+      "outputs": [[527,566,0,256,4,"cuda:0"]], "output_shapes": [[256]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "torch::autograd::AccumulateGrad", "id": 1127, "rf_id": 635, "parent": 1126, "fw_parent": 2, "seq_id": -1, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[530,566,0,256,4,"cuda:0"]], "input_shapes": [[256]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: torch::autograd::AccumulateGrad", "id": 1126, "rf_id": 634, "parent": 847, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::empty", "id": 1133, "rf_id": 641, "parent": 1132, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[256,128,1,1],6,0,"cuda:0","<None>",0], "input_shapes": [[[],[],[],[]],[],[],[],[],[]], "input_types": ["GenericList[Int,Int,Int,Int]","Int","Int","Device","None","Int"],
+      "outputs": [[831,1134,0,32768,4,"cuda:0"]], "output_shapes": [[256,128,1,1]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::convolution_backward", "id": 1132, "rf_id": 640, "parent": 1131, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::convolution_backward(Tensor grad_output, Tensor input, Tensor weight, SymInt[]? bias_sizes, int[] stride, SymInt[] padding, int[] dilation, bool transposed, SymInt[] output_padding, int groups, bool[3] output_mask) -> (Tensor, Tensor, Tensor)",
+      "inputs": [[582,484,0,6422528,4,"cuda:0"],[389,405,0,12845056,4,"cuda:0"],[496,497,0,32768,4,"cuda:0"],[0],[2,2],[0,0],[1,1],false,[0,0],1,[true,true,false]], "input_shapes": [[128,256,14,14],[128,128,28,28],[256,128,1,1],[[]],[[],[]],[[],[]],[[],[]],[],[[],[]],[],[[],[],[]]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(float)","GenericList[Int]","GenericList[Int,Int]","GenericList[Int,Int]","GenericList[Int,Int]","Bool","GenericList[Int,Int]","Int","GenericList[Bool,Bool,Bool]"],
+      "outputs": [[530,503,0,12845056,4,"cuda:0"],[831,1134,0,32768,4,"cuda:0"],[23,0,0,0,0,""]], "output_shapes": [[128,128,28,28],[256,128,1,1],[]], "output_types": ["Tensor(float)","Tensor(float)","Tensor(nullptr (uninitialized))"]
+    },
+    {
+      "name": "ConvolutionBackward0", "id": 1131, "rf_id": 639, "parent": 1130, "fw_parent": 2, "seq_id": 769, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[582,484,0,6422528,4,"cuda:0"]], "input_shapes": [[128,256,14,14]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: ConvolutionBackward0", "id": 1130, "rf_id": 638, "parent": 847, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "detach", "id": 1138, "rf_id": 645, "parent": 1137, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [[831,1134,0,32768,4,"cuda:0"]], "input_shapes": [[256,128,1,1]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::detach", "id": 1137, "rf_id": 644, "parent": 1136, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::detach(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[831,1134,0,32768,4,"cuda:0"]], "input_shapes": [[256,128,1,1]], "input_types": ["Tensor(float)"],
+      "outputs": [[502,1134,0,32768,4,"cuda:0"]], "output_shapes": [[256,128,1,1]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "torch::autograd::AccumulateGrad", "id": 1136, "rf_id": 643, "parent": 1135, "fw_parent": 2, "seq_id": -1, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[831,1134,0,32768,4,"cuda:0"]], "input_shapes": [[256,128,1,1]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: torch::autograd::AccumulateGrad", "id": 1135, "rf_id": 642, "parent": 847, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::empty", "id": 1142, "rf_id": 649, "parent": 1141, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[128,256,14,14],6,0,"cuda:0","<None>",0], "input_shapes": [[[],[],[],[]],[],[],[],[],[]], "input_types": ["GenericList[Int,Int,Int,Int]","Int","Int","Device","None","Int"],
+      "outputs": [[831,484,0,6422528,4,"cuda:0"]], "output_shapes": [[128,256,14,14]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty", "id": 1143, "rf_id": 650, "parent": 1141, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[256],6,0,"cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","Int","Device","None","None"],
+      "outputs": [[582,525,0,256,4,"cuda:0"]], "output_shapes": [[256]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty", "id": 1144, "rf_id": 651, "parent": 1141, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[256],6,0,"cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","Int","Device","None","None"],
+      "outputs": [[661,528,0,256,4,"cuda:0"]], "output_shapes": [[256]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::view", "id": 1145, "rf_id": 652, "parent": 1141, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::view(Tensor(a) self, SymInt[] size) -> Tensor(a)",
+      "inputs": [[471,472,0,256,4,"cuda:0"],[1,256,1,1]], "input_shapes": [[256],[[],[],[],[]]], "input_types": ["Tensor(float)","GenericList[Int,Int,Int,Int]"],
+      "outputs": [[857,472,0,256,4,"cuda:0"]], "output_shapes": [[1,256,1,1]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty", "id": 1146, "rf_id": 653, "parent": 1141, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[0],0,0,"cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","Int","Device","None","None"],
+      "outputs": [[857,57,0,0,1,"cuda:0"]], "output_shapes": [[0]], "output_types": ["Tensor(unsigned char)"]
+    },
+    {
+      "name": "aten::cudnn_batch_norm_backward", "id": 1141, "rf_id": 648, "parent": 1140, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::cudnn_batch_norm_backward(Tensor input, Tensor grad_output, Tensor weight, Tensor? running_mean, Tensor? running_var, Tensor? save_mean, Tensor? save_var, float epsilon, Tensor reserveSpace) -> (Tensor, Tensor, Tensor)",
+      "inputs": [[454,465,0,6422528,4,"cuda:0"],[468,579,0,6422528,4,"cuda:0"],[471,472,0,256,4,"cuda:0"],[475,476,0,256,4,"cuda:0"],[477,478,0,256,4,"cuda:0"],[486,488,0,256,4,"cuda:0"],[490,491,0,256,4,"cuda:0"],0.000010,[495,57,0,0,1,"cuda:0"]], "input_shapes": [[128,256,14,14],[128,256,14,14],[256],[256],[256],[256],[256],[],[0]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Double","Tensor(unsigned char)"],
+      "outputs": [[831,484,0,6422528,4,"cuda:0"],[582,525,0,256,4,"cuda:0"],[661,528,0,256,4,"cuda:0"]], "output_shapes": [[128,256,14,14],[256],[256]], "output_types": ["Tensor(float)","Tensor(float)","Tensor(float)"]
+    },
+    {
+      "name": "CudnnBatchNormBackward0", "id": 1140, "rf_id": 647, "parent": 1139, "fw_parent": 2, "seq_id": 768, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[468,579,0,6422528,4,"cuda:0"]], "input_shapes": [[128,256,14,14]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: CudnnBatchNormBackward0", "id": 1139, "rf_id": 646, "parent": 847, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "detach", "id": 1150, "rf_id": 657, "parent": 1149, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [[582,525,0,256,4,"cuda:0"]], "input_shapes": [[256]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::detach", "id": 1149, "rf_id": 656, "parent": 1148, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::detach(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[582,525,0,256,4,"cuda:0"]], "input_shapes": [[256]], "input_types": ["Tensor(float)"],
+      "outputs": [[486,525,0,256,4,"cuda:0"]], "output_shapes": [[256]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "torch::autograd::AccumulateGrad", "id": 1148, "rf_id": 655, "parent": 1147, "fw_parent": 2, "seq_id": -1, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[582,525,0,256,4,"cuda:0"]], "input_shapes": [[256]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: torch::autograd::AccumulateGrad", "id": 1147, "rf_id": 654, "parent": 847, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "detach", "id": 1154, "rf_id": 661, "parent": 1153, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [[661,528,0,256,4,"cuda:0"]], "input_shapes": [[256]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::detach", "id": 1153, "rf_id": 660, "parent": 1152, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::detach(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[661,528,0,256,4,"cuda:0"]], "input_shapes": [[256]], "input_types": ["Tensor(float)"],
+      "outputs": [[490,528,0,256,4,"cuda:0"]], "output_shapes": [[256]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "torch::autograd::AccumulateGrad", "id": 1152, "rf_id": 659, "parent": 1151, "fw_parent": 2, "seq_id": -1, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[661,528,0,256,4,"cuda:0"]], "input_shapes": [[256]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: torch::autograd::AccumulateGrad", "id": 1151, "rf_id": 658, "parent": 847, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::empty", "id": 1158, "rf_id": 665, "parent": 1157, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[256,256,3,3],6,0,"cuda:0","<None>",0], "input_shapes": [[[],[],[],[]],[],[],[],[],[]], "input_types": ["GenericList[Int,Int,Int,Int]","Int","Int","Device","None","Int"],
+      "outputs": [[582,1159,0,589824,4,"cuda:0"]], "output_shapes": [[256,256,3,3]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::convolution_backward", "id": 1157, "rf_id": 664, "parent": 1156, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::convolution_backward(Tensor grad_output, Tensor input, Tensor weight, SymInt[]? bias_sizes, int[] stride, SymInt[] padding, int[] dilation, bool transposed, SymInt[] output_padding, int groups, bool[3] output_mask) -> (Tensor, Tensor, Tensor)",
+      "inputs": [[831,484,0,6422528,4,"cuda:0"],[429,445,0,6422528,4,"cuda:0"],[459,460,0,589824,4,"cuda:0"],[0],[1,1],[1,1],[1,1],false,[0,0],1,[true,true,false]], "input_shapes": [[128,256,14,14],[128,256,14,14],[256,256,3,3],[[]],[[],[]],[[],[]],[[],[]],[],[[],[]],[],[[],[],[]]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(float)","GenericList[Int]","GenericList[Int,Int]","GenericList[Int,Int]","GenericList[Int,Int]","Bool","GenericList[Int,Int]","Int","GenericList[Bool,Bool,Bool]"],
+      "outputs": [[661,465,0,6422528,4,"cuda:0"],[582,1159,0,589824,4,"cuda:0"],[23,0,0,0,0,""]], "output_shapes": [[128,256,14,14],[256,256,3,3],[]], "output_types": ["Tensor(float)","Tensor(float)","Tensor(nullptr (uninitialized))"]
+    },
+    {
+      "name": "ConvolutionBackward0", "id": 1156, "rf_id": 663, "parent": 1155, "fw_parent": 2, "seq_id": 767, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[831,484,0,6422528,4,"cuda:0"]], "input_shapes": [[128,256,14,14]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: ConvolutionBackward0", "id": 1155, "rf_id": 662, "parent": 847, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "detach", "id": 1163, "rf_id": 669, "parent": 1162, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [[582,1159,0,589824,4,"cuda:0"]], "input_shapes": [[256,256,3,3]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::detach", "id": 1162, "rf_id": 668, "parent": 1161, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::detach(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[582,1159,0,589824,4,"cuda:0"]], "input_shapes": [[256,256,3,3]], "input_types": ["Tensor(float)"],
+      "outputs": [[831,1159,0,589824,4,"cuda:0"]], "output_shapes": [[256,256,3,3]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "torch::autograd::AccumulateGrad", "id": 1161, "rf_id": 667, "parent": 1160, "fw_parent": 2, "seq_id": -1, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[582,1159,0,589824,4,"cuda:0"]], "input_shapes": [[256,256,3,3]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: torch::autograd::AccumulateGrad", "id": 1160, "rf_id": 666, "parent": 847, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::threshold_backward", "id": 1166, "rf_id": 672, "parent": 1165, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::threshold_backward(Tensor grad_output, Tensor self, Scalar threshold) -> Tensor",
+      "inputs": [[661,465,0,6422528,4,"cuda:0"],[582,445,0,6422528,4,"cuda:0"],0], "input_shapes": [[128,256,14,14],[128,256,14,14],[]], "input_types": ["Tensor(float)","Tensor(float)","Int"],
+      "outputs": [[429,484,0,6422528,4,"cuda:0"]], "output_shapes": [[128,256,14,14]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "ReluBackward0", "id": 1165, "rf_id": 671, "parent": 1164, "fw_parent": 2, "seq_id": 766, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[661,465,0,6422528,4,"cuda:0"]], "input_shapes": [[128,256,14,14]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: ReluBackward0", "id": 1164, "rf_id": 670, "parent": 847, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::empty", "id": 1170, "rf_id": 676, "parent": 1169, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[128,256,14,14],6,0,"cuda:0","<None>",0], "input_shapes": [[[],[],[],[]],[],[],[],[],[]], "input_types": ["GenericList[Int,Int,Int,Int]","Int","Int","Device","None","Int"],
+      "outputs": [[661,559,0,6422528,4,"cuda:0"]], "output_shapes": [[128,256,14,14]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty", "id": 1171, "rf_id": 677, "parent": 1169, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[256],6,0,"cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","Int","Device","None","None"],
+      "outputs": [[582,488,0,256,4,"cuda:0"]], "output_shapes": [[256]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty", "id": 1172, "rf_id": 678, "parent": 1169, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[256],6,0,"cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","Int","Device","None","None"],
+      "outputs": [[454,491,0,256,4,"cuda:0"]], "output_shapes": [[256]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::view", "id": 1173, "rf_id": 679, "parent": 1169, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::view(Tensor(a) self, SymInt[] size) -> Tensor(a)",
+      "inputs": [[432,433,0,256,4,"cuda:0"],[1,256,1,1]], "input_shapes": [[256],[[],[],[],[]]], "input_types": ["Tensor(float)","GenericList[Int,Int,Int,Int]"],
+      "outputs": [[468,433,0,256,4,"cuda:0"]], "output_shapes": [[1,256,1,1]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty", "id": 1174, "rf_id": 680, "parent": 1169, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[0],0,0,"cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","Int","Device","None","None"],
+      "outputs": [[468,57,0,0,1,"cuda:0"]], "output_shapes": [[0]], "output_types": ["Tensor(unsigned char)"]
+    },
+    {
+      "name": "aten::cudnn_batch_norm_backward", "id": 1169, "rf_id": 675, "parent": 1168, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::cudnn_batch_norm_backward(Tensor input, Tensor grad_output, Tensor weight, Tensor? running_mean, Tensor? running_var, Tensor? save_mean, Tensor? save_var, float epsilon, Tensor reserveSpace) -> (Tensor, Tensor, Tensor)",
+      "inputs": [[414,426,0,6422528,4,"cuda:0"],[429,484,0,6422528,4,"cuda:0"],[432,433,0,256,4,"cuda:0"],[436,437,0,256,4,"cuda:0"],[438,439,0,256,4,"cuda:0"],[447,449,0,256,4,"cuda:0"],[451,452,0,256,4,"cuda:0"],0.000010,[456,57,0,0,1,"cuda:0"]], "input_shapes": [[128,256,14,14],[128,256,14,14],[256],[256],[256],[256],[256],[],[0]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Double","Tensor(unsigned char)"],
+      "outputs": [[661,559,0,6422528,4,"cuda:0"],[582,488,0,256,4,"cuda:0"],[454,491,0,256,4,"cuda:0"]], "output_shapes": [[128,256,14,14],[256],[256]], "output_types": ["Tensor(float)","Tensor(float)","Tensor(float)"]
+    },
+    {
+      "name": "CudnnBatchNormBackward0", "id": 1168, "rf_id": 674, "parent": 1167, "fw_parent": 2, "seq_id": 765, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[429,484,0,6422528,4,"cuda:0"]], "input_shapes": [[128,256,14,14]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: CudnnBatchNormBackward0", "id": 1167, "rf_id": 673, "parent": 847, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "detach", "id": 1178, "rf_id": 684, "parent": 1177, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [[582,488,0,256,4,"cuda:0"]], "input_shapes": [[256]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::detach", "id": 1177, "rf_id": 683, "parent": 1176, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::detach(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[582,488,0,256,4,"cuda:0"]], "input_shapes": [[256]], "input_types": ["Tensor(float)"],
+      "outputs": [[414,488,0,256,4,"cuda:0"]], "output_shapes": [[256]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "torch::autograd::AccumulateGrad", "id": 1176, "rf_id": 682, "parent": 1175, "fw_parent": 2, "seq_id": -1, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[582,488,0,256,4,"cuda:0"]], "input_shapes": [[256]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: torch::autograd::AccumulateGrad", "id": 1175, "rf_id": 681, "parent": 847, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "detach", "id": 1182, "rf_id": 688, "parent": 1181, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [[454,491,0,256,4,"cuda:0"]], "input_shapes": [[256]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::detach", "id": 1181, "rf_id": 687, "parent": 1180, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::detach(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[454,491,0,256,4,"cuda:0"]], "input_shapes": [[256]], "input_types": ["Tensor(float)"],
+      "outputs": [[447,491,0,256,4,"cuda:0"]], "output_shapes": [[256]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "torch::autograd::AccumulateGrad", "id": 1180, "rf_id": 686, "parent": 1179, "fw_parent": 2, "seq_id": -1, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[454,491,0,256,4,"cuda:0"]], "input_shapes": [[256]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: torch::autograd::AccumulateGrad", "id": 1179, "rf_id": 685, "parent": 847, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::empty", "id": 1186, "rf_id": 692, "parent": 1185, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[256,128,3,3],6,0,"cuda:0","<None>",0], "input_shapes": [[[],[],[],[]],[],[],[],[],[]], "input_types": ["GenericList[Int,Int,Int,Int]","Int","Int","Device","None","Int"],
+      "outputs": [[582,1187,0,294912,4,"cuda:0"]], "output_shapes": [[256,128,3,3]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::convolution_backward", "id": 1185, "rf_id": 691, "parent": 1184, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::convolution_backward(Tensor grad_output, Tensor input, Tensor weight, SymInt[]? bias_sizes, int[] stride, SymInt[] padding, int[] dilation, bool transposed, SymInt[] output_padding, int groups, bool[3] output_mask) -> (Tensor, Tensor, Tensor)",
+      "inputs": [[661,559,0,6422528,4,"cuda:0"],[389,405,0,12845056,4,"cuda:0"],[420,421,0,294912,4,"cuda:0"],[0],[2,2],[1,1],[1,1],false,[0,0],1,[true,true,false]], "input_shapes": [[128,256,14,14],[128,128,28,28],[256,128,3,3],[[]],[[],[]],[[],[]],[[],[]],[],[[],[]],[],[[],[],[]]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(float)","GenericList[Int]","GenericList[Int,Int]","GenericList[Int,Int]","GenericList[Int,Int]","Bool","GenericList[Int,Int]","Int","GenericList[Bool,Bool,Bool]"],
+      "outputs": [[454,445,0,12845056,4,"cuda:0"],[582,1187,0,294912,4,"cuda:0"],[23,0,0,0,0,""]], "output_shapes": [[128,128,28,28],[256,128,3,3],[]], "output_types": ["Tensor(float)","Tensor(float)","Tensor(nullptr (uninitialized))"]
+    },
+    {
+      "name": "ConvolutionBackward0", "id": 1184, "rf_id": 690, "parent": 1183, "fw_parent": 2, "seq_id": 764, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[661,559,0,6422528,4,"cuda:0"]], "input_shapes": [[128,256,14,14]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::add_", "id": 1188, "rf_id": 693, "parent": 1183, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::add_.Tensor(Tensor(a!) self, Tensor other, *, Scalar alpha=1) -> Tensor(a!)",
+      "inputs": [[530,503,0,12845056,4,"cuda:0"],[454,445,0,12845056,4,"cuda:0"],1], "input_shapes": [[128,128,28,28],[128,128,28,28],[]], "input_types": ["Tensor(float)","Tensor(float)","Int"],
+      "outputs": [[530,503,0,12845056,4,"cuda:0"]], "output_shapes": [[128,128,28,28]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "autograd::engine::evaluate_function: ConvolutionBackward0", "id": 1183, "rf_id": 689, "parent": 847, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "detach", "id": 1192, "rf_id": 697, "parent": 1191, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [[582,1187,0,294912,4,"cuda:0"]], "input_shapes": [[256,128,3,3]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::detach", "id": 1191, "rf_id": 696, "parent": 1190, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::detach(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[582,1187,0,294912,4,"cuda:0"]], "input_shapes": [[256,128,3,3]], "input_types": ["Tensor(float)"],
+      "outputs": [[661,1187,0,294912,4,"cuda:0"]], "output_shapes": [[256,128,3,3]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "torch::autograd::AccumulateGrad", "id": 1190, "rf_id": 695, "parent": 1189, "fw_parent": 2, "seq_id": -1, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[582,1187,0,294912,4,"cuda:0"]], "input_shapes": [[256,128,3,3]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: torch::autograd::AccumulateGrad", "id": 1189, "rf_id": 694, "parent": 847, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::threshold_backward", "id": 1195, "rf_id": 700, "parent": 1194, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::threshold_backward(Tensor grad_output, Tensor self, Scalar threshold) -> Tensor",
+      "inputs": [[530,503,0,12845056,4,"cuda:0"],[582,405,0,12845056,4,"cuda:0"],0], "input_shapes": [[128,128,28,28],[128,128,28,28],[]], "input_types": ["Tensor(float)","Tensor(float)","Int"],
+      "outputs": [[389,445,0,12845056,4,"cuda:0"]], "output_shapes": [[128,128,28,28]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "ReluBackward0", "id": 1194, "rf_id": 699, "parent": 1193, "fw_parent": 2, "seq_id": 763, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[530,503,0,12845056,4,"cuda:0"]], "input_shapes": [[128,128,28,28]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: ReluBackward0", "id": 1193, "rf_id": 698, "parent": 847, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "AddBackward0", "id": 1197, "rf_id": 702, "parent": 1196, "fw_parent": 2, "seq_id": 762, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[389,445,0,12845056,4,"cuda:0"]], "input_shapes": [[128,128,28,28]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: AddBackward0", "id": 1196, "rf_id": 701, "parent": 847, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::empty", "id": 1201, "rf_id": 706, "parent": 1200, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[128,128,28,28],6,0,"cuda:0","<None>",0], "input_shapes": [[[],[],[],[]],[],[],[],[],[]], "input_types": ["GenericList[Int,Int,Int,Int]","Int","Int","Device","None","Int"],
+      "outputs": [[530,405,0,12845056,4,"cuda:0"]], "output_shapes": [[128,128,28,28]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty", "id": 1202, "rf_id": 707, "parent": 1200, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[128],6,0,"cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","Int","Device","None","None"],
+      "outputs": [[582,449,0,128,4,"cuda:0"]], "output_shapes": [[128]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty", "id": 1203, "rf_id": 708, "parent": 1200, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[128],6,0,"cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","Int","Device","None","None"],
+      "outputs": [[429,1204,0,128,4,"cuda:0"]], "output_shapes": [[128]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::view", "id": 1205, "rf_id": 709, "parent": 1200, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::view(Tensor(a) self, SymInt[] size) -> Tensor(a)",
+      "inputs": [[392,393,0,128,4,"cuda:0"],[1,128,1,1]], "input_shapes": [[128],[[],[],[],[]]], "input_types": ["Tensor(float)","GenericList[Int,Int,Int,Int]"],
+      "outputs": [[468,393,0,128,4,"cuda:0"]], "output_shapes": [[1,128,1,1]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty", "id": 1206, "rf_id": 710, "parent": 1200, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[0],0,0,"cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","Int","Device","None","None"],
+      "outputs": [[468,57,0,0,1,"cuda:0"]], "output_shapes": [[0]], "output_types": ["Tensor(unsigned char)"]
+    },
+    {
+      "name": "aten::cudnn_batch_norm_backward", "id": 1200, "rf_id": 705, "parent": 1199, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::cudnn_batch_norm_backward(Tensor input, Tensor grad_output, Tensor weight, Tensor? running_mean, Tensor? running_var, Tensor? save_mean, Tensor? save_var, float epsilon, Tensor reserveSpace) -> (Tensor, Tensor, Tensor)",
+      "inputs": [[375,386,0,12845056,4,"cuda:0"],[389,445,0,12845056,4,"cuda:0"],[392,393,0,128,4,"cuda:0"],[396,397,0,128,4,"cuda:0"],[398,399,0,128,4,"cuda:0"],[407,409,0,128,4,"cuda:0"],[411,412,0,128,4,"cuda:0"],0.000010,[416,57,0,0,1,"cuda:0"]], "input_shapes": [[128,128,28,28],[128,128,28,28],[128],[128],[128],[128],[128],[],[0]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Double","Tensor(unsigned char)"],
+      "outputs": [[530,405,0,12845056,4,"cuda:0"],[582,449,0,128,4,"cuda:0"],[429,1204,0,128,4,"cuda:0"]], "output_shapes": [[128,128,28,28],[128],[128]], "output_types": ["Tensor(float)","Tensor(float)","Tensor(float)"]
+    },
+    {
+      "name": "CudnnBatchNormBackward0", "id": 1199, "rf_id": 704, "parent": 1198, "fw_parent": 2, "seq_id": 761, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[389,445,0,12845056,4,"cuda:0"]], "input_shapes": [[128,128,28,28]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: CudnnBatchNormBackward0", "id": 1198, "rf_id": 703, "parent": 847, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "detach", "id": 1210, "rf_id": 714, "parent": 1209, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [[582,449,0,128,4,"cuda:0"]], "input_shapes": [[128]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::detach", "id": 1209, "rf_id": 713, "parent": 1208, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::detach(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[582,449,0,128,4,"cuda:0"]], "input_shapes": [[128]], "input_types": ["Tensor(float)"],
+      "outputs": [[407,449,0,128,4,"cuda:0"]], "output_shapes": [[128]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "torch::autograd::AccumulateGrad", "id": 1208, "rf_id": 712, "parent": 1207, "fw_parent": 2, "seq_id": -1, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[582,449,0,128,4,"cuda:0"]], "input_shapes": [[128]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: torch::autograd::AccumulateGrad", "id": 1207, "rf_id": 711, "parent": 847, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "detach", "id": 1214, "rf_id": 718, "parent": 1213, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [[429,1204,0,128,4,"cuda:0"]], "input_shapes": [[128]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::detach", "id": 1213, "rf_id": 717, "parent": 1212, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::detach(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[429,1204,0,128,4,"cuda:0"]], "input_shapes": [[128]], "input_types": ["Tensor(float)"],
+      "outputs": [[411,1204,0,128,4,"cuda:0"]], "output_shapes": [[128]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "torch::autograd::AccumulateGrad", "id": 1212, "rf_id": 716, "parent": 1211, "fw_parent": 2, "seq_id": -1, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[429,1204,0,128,4,"cuda:0"]], "input_shapes": [[128]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: torch::autograd::AccumulateGrad", "id": 1211, "rf_id": 715, "parent": 847, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::empty", "id": 1218, "rf_id": 722, "parent": 1217, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[128,128,3,3],6,0,"cuda:0","<None>",0], "input_shapes": [[[],[],[],[]],[],[],[],[],[]], "input_types": ["GenericList[Int,Int,Int,Int]","Int","Int","Device","None","Int"],
+      "outputs": [[582,1219,0,147456,4,"cuda:0"]], "output_shapes": [[128,128,3,3]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::convolution_backward", "id": 1217, "rf_id": 721, "parent": 1216, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::convolution_backward(Tensor grad_output, Tensor input, Tensor weight, SymInt[]? bias_sizes, int[] stride, SymInt[] padding, int[] dilation, bool transposed, SymInt[] output_padding, int groups, bool[3] output_mask) -> (Tensor, Tensor, Tensor)",
+      "inputs": [[530,405,0,12845056,4,"cuda:0"],[350,366,0,12845056,4,"cuda:0"],[380,381,0,147456,4,"cuda:0"],[0],[1,1],[1,1],[1,1],false,[0,0],1,[true,true,false]], "input_shapes": [[128,128,28,28],[128,128,28,28],[128,128,3,3],[[]],[[],[]],[[],[]],[[],[]],[],[[],[]],[],[[],[],[]]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(float)","GenericList[Int]","GenericList[Int,Int]","GenericList[Int,Int]","GenericList[Int,Int]","Bool","GenericList[Int,Int]","Int","GenericList[Bool,Bool,Bool]"],
+      "outputs": [[429,386,0,12845056,4,"cuda:0"],[582,1219,0,147456,4,"cuda:0"],[23,0,0,0,0,""]], "output_shapes": [[128,128,28,28],[128,128,3,3],[]], "output_types": ["Tensor(float)","Tensor(float)","Tensor(nullptr (uninitialized))"]
+    },
+    {
+      "name": "ConvolutionBackward0", "id": 1216, "rf_id": 720, "parent": 1215, "fw_parent": 2, "seq_id": 760, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[530,405,0,12845056,4,"cuda:0"]], "input_shapes": [[128,128,28,28]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: ConvolutionBackward0", "id": 1215, "rf_id": 719, "parent": 847, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "detach", "id": 1223, "rf_id": 726, "parent": 1222, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [[582,1219,0,147456,4,"cuda:0"]], "input_shapes": [[128,128,3,3]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::detach", "id": 1222, "rf_id": 725, "parent": 1221, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::detach(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[582,1219,0,147456,4,"cuda:0"]], "input_shapes": [[128,128,3,3]], "input_types": ["Tensor(float)"],
+      "outputs": [[530,1219,0,147456,4,"cuda:0"]], "output_shapes": [[128,128,3,3]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "torch::autograd::AccumulateGrad", "id": 1221, "rf_id": 724, "parent": 1220, "fw_parent": 2, "seq_id": -1, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[582,1219,0,147456,4,"cuda:0"]], "input_shapes": [[128,128,3,3]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: torch::autograd::AccumulateGrad", "id": 1220, "rf_id": 723, "parent": 847, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::threshold_backward", "id": 1226, "rf_id": 729, "parent": 1225, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::threshold_backward(Tensor grad_output, Tensor self, Scalar threshold) -> Tensor",
+      "inputs": [[429,386,0,12845056,4,"cuda:0"],[582,366,0,12845056,4,"cuda:0"],0], "input_shapes": [[128,128,28,28],[128,128,28,28],[]], "input_types": ["Tensor(float)","Tensor(float)","Int"],
+      "outputs": [[350,405,0,12845056,4,"cuda:0"]], "output_shapes": [[128,128,28,28]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "ReluBackward0", "id": 1225, "rf_id": 728, "parent": 1224, "fw_parent": 2, "seq_id": 759, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[429,386,0,12845056,4,"cuda:0"]], "input_shapes": [[128,128,28,28]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: ReluBackward0", "id": 1224, "rf_id": 727, "parent": 847, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::empty", "id": 1230, "rf_id": 733, "parent": 1229, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[128,128,28,28],6,0,"cuda:0","<None>",0], "input_shapes": [[[],[],[],[]],[],[],[],[],[]], "input_types": ["GenericList[Int,Int,Int,Int]","Int","Int","Device","None","Int"],
+      "outputs": [[429,366,0,12845056,4,"cuda:0"]], "output_shapes": [[128,128,28,28]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty", "id": 1231, "rf_id": 734, "parent": 1229, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[128],6,0,"cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","Int","Device","None","None"],
+      "outputs": [[582,409,0,128,4,"cuda:0"]], "output_shapes": [[128]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty", "id": 1232, "rf_id": 735, "parent": 1229, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[128],6,0,"cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","Int","Device","None","None"],
+      "outputs": [[375,412,0,128,4,"cuda:0"]], "output_shapes": [[128]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::view", "id": 1233, "rf_id": 736, "parent": 1229, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::view(Tensor(a) self, SymInt[] size) -> Tensor(a)",
+      "inputs": [[353,354,0,128,4,"cuda:0"],[1,128,1,1]], "input_shapes": [[128],[[],[],[],[]]], "input_types": ["Tensor(float)","GenericList[Int,Int,Int,Int]"],
+      "outputs": [[468,354,0,128,4,"cuda:0"]], "output_shapes": [[1,128,1,1]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty", "id": 1234, "rf_id": 737, "parent": 1229, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[0],0,0,"cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","Int","Device","None","None"],
+      "outputs": [[468,57,0,0,1,"cuda:0"]], "output_shapes": [[0]], "output_types": ["Tensor(unsigned char)"]
+    },
+    {
+      "name": "aten::cudnn_batch_norm_backward", "id": 1229, "rf_id": 732, "parent": 1228, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::cudnn_batch_norm_backward(Tensor input, Tensor grad_output, Tensor weight, Tensor? running_mean, Tensor? running_var, Tensor? save_mean, Tensor? save_var, float epsilon, Tensor reserveSpace) -> (Tensor, Tensor, Tensor)",
+      "inputs": [[299,327,0,12845056,4,"cuda:0"],[350,405,0,12845056,4,"cuda:0"],[353,354,0,128,4,"cuda:0"],[357,358,0,128,4,"cuda:0"],[359,360,0,128,4,"cuda:0"],[368,370,0,128,4,"cuda:0"],[372,373,0,128,4,"cuda:0"],0.000010,[377,57,0,0,1,"cuda:0"]], "input_shapes": [[128,128,28,28],[128,128,28,28],[128],[128],[128],[128],[128],[],[0]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Double","Tensor(unsigned char)"],
+      "outputs": [[429,366,0,12845056,4,"cuda:0"],[582,409,0,128,4,"cuda:0"],[375,412,0,128,4,"cuda:0"]], "output_shapes": [[128,128,28,28],[128],[128]], "output_types": ["Tensor(float)","Tensor(float)","Tensor(float)"]
+    },
+    {
+      "name": "CudnnBatchNormBackward0", "id": 1228, "rf_id": 731, "parent": 1227, "fw_parent": 2, "seq_id": 758, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[350,405,0,12845056,4,"cuda:0"]], "input_shapes": [[128,128,28,28]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: CudnnBatchNormBackward0", "id": 1227, "rf_id": 730, "parent": 847, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "detach", "id": 1238, "rf_id": 741, "parent": 1237, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [[582,409,0,128,4,"cuda:0"]], "input_shapes": [[128]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::detach", "id": 1237, "rf_id": 740, "parent": 1236, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::detach(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[582,409,0,128,4,"cuda:0"]], "input_shapes": [[128]], "input_types": ["Tensor(float)"],
+      "outputs": [[299,409,0,128,4,"cuda:0"]], "output_shapes": [[128]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "torch::autograd::AccumulateGrad", "id": 1236, "rf_id": 739, "parent": 1235, "fw_parent": 2, "seq_id": -1, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[582,409,0,128,4,"cuda:0"]], "input_shapes": [[128]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: torch::autograd::AccumulateGrad", "id": 1235, "rf_id": 738, "parent": 847, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "detach", "id": 1242, "rf_id": 745, "parent": 1241, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [[375,412,0,128,4,"cuda:0"]], "input_shapes": [[128]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::detach", "id": 1241, "rf_id": 744, "parent": 1240, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::detach(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[375,412,0,128,4,"cuda:0"]], "input_shapes": [[128]], "input_types": ["Tensor(float)"],
+      "outputs": [[368,412,0,128,4,"cuda:0"]], "output_shapes": [[128]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "torch::autograd::AccumulateGrad", "id": 1240, "rf_id": 743, "parent": 1239, "fw_parent": 2, "seq_id": -1, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[375,412,0,128,4,"cuda:0"]], "input_shapes": [[128]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: torch::autograd::AccumulateGrad", "id": 1239, "rf_id": 742, "parent": 847, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::empty", "id": 1246, "rf_id": 749, "parent": 1245, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[128,128,3,3],6,0,"cuda:0","<None>",0], "input_shapes": [[[],[],[],[]],[],[],[],[],[]], "input_types": ["GenericList[Int,Int,Int,Int]","Int","Int","Device","None","Int"],
+      "outputs": [[582,1247,0,147456,4,"cuda:0"]], "output_shapes": [[128,128,3,3]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::convolution_backward", "id": 1245, "rf_id": 748, "parent": 1244, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::convolution_backward(Tensor grad_output, Tensor input, Tensor weight, SymInt[]? bias_sizes, int[] stride, SymInt[] padding, int[] dilation, bool transposed, SymInt[] output_padding, int groups, bool[3] output_mask) -> (Tensor, Tensor, Tensor)",
+      "inputs": [[429,366,0,12845056,4,"cuda:0"],[274,290,0,12845056,4,"cuda:0"],[342,343,0,147456,4,"cuda:0"],[0],[1,1],[1,1],[1,1],false,[0,0],1,[true,true,false]], "input_shapes": [[128,128,28,28],[128,128,28,28],[128,128,3,3],[[]],[[],[]],[[],[]],[[],[]],[],[[],[]],[],[[],[],[]]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(float)","GenericList[Int]","GenericList[Int,Int]","GenericList[Int,Int]","GenericList[Int,Int]","Bool","GenericList[Int,Int]","Int","GenericList[Bool,Bool,Bool]"],
+      "outputs": [[375,327,0,12845056,4,"cuda:0"],[582,1247,0,147456,4,"cuda:0"],[23,0,0,0,0,""]], "output_shapes": [[128,128,28,28],[128,128,3,3],[]], "output_types": ["Tensor(float)","Tensor(float)","Tensor(nullptr (uninitialized))"]
+    },
+    {
+      "name": "ConvolutionBackward0", "id": 1244, "rf_id": 747, "parent": 1243, "fw_parent": 2, "seq_id": 757, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[429,366,0,12845056,4,"cuda:0"]], "input_shapes": [[128,128,28,28]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::add_", "id": 1248, "rf_id": 750, "parent": 1243, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::add_.Tensor(Tensor(a!) self, Tensor other, *, Scalar alpha=1) -> Tensor(a!)",
+      "inputs": [[389,445,0,12845056,4,"cuda:0"],[375,327,0,12845056,4,"cuda:0"],1], "input_shapes": [[128,128,28,28],[128,128,28,28],[]], "input_types": ["Tensor(float)","Tensor(float)","Int"],
+      "outputs": [[389,445,0,12845056,4,"cuda:0"]], "output_shapes": [[128,128,28,28]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "autograd::engine::evaluate_function: ConvolutionBackward0", "id": 1243, "rf_id": 746, "parent": 847, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "detach", "id": 1252, "rf_id": 754, "parent": 1251, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [[582,1247,0,147456,4,"cuda:0"]], "input_shapes": [[128,128,3,3]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::detach", "id": 1251, "rf_id": 753, "parent": 1250, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::detach(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[582,1247,0,147456,4,"cuda:0"]], "input_shapes": [[128,128,3,3]], "input_types": ["Tensor(float)"],
+      "outputs": [[429,1247,0,147456,4,"cuda:0"]], "output_shapes": [[128,128,3,3]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "torch::autograd::AccumulateGrad", "id": 1250, "rf_id": 752, "parent": 1249, "fw_parent": 2, "seq_id": -1, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[582,1247,0,147456,4,"cuda:0"]], "input_shapes": [[128,128,3,3]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: torch::autograd::AccumulateGrad", "id": 1249, "rf_id": 751, "parent": 847, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::threshold_backward", "id": 1255, "rf_id": 757, "parent": 1254, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::threshold_backward(Tensor grad_output, Tensor self, Scalar threshold) -> Tensor",
+      "inputs": [[389,445,0,12845056,4,"cuda:0"],[582,290,0,12845056,4,"cuda:0"],0], "input_shapes": [[128,128,28,28],[128,128,28,28],[]], "input_types": ["Tensor(float)","Tensor(float)","Int"],
+      "outputs": [[274,484,0,12845056,4,"cuda:0"]], "output_shapes": [[128,128,28,28]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "ReluBackward0", "id": 1254, "rf_id": 756, "parent": 1253, "fw_parent": 2, "seq_id": 756, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[389,445,0,12845056,4,"cuda:0"]], "input_shapes": [[128,128,28,28]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: ReluBackward0", "id": 1253, "rf_id": 755, "parent": 847, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "AddBackward0", "id": 1257, "rf_id": 759, "parent": 1256, "fw_parent": 2, "seq_id": 755, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[274,484,0,12845056,4,"cuda:0"]], "input_shapes": [[128,128,28,28]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: AddBackward0", "id": 1256, "rf_id": 758, "parent": 847, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::empty", "id": 1261, "rf_id": 763, "parent": 1260, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[128,128,28,28],6,0,"cuda:0","<None>",0], "input_shapes": [[[],[],[],[]],[],[],[],[],[]], "input_types": ["GenericList[Int,Int,Int,Int]","Int","Int","Device","None","Int"],
+      "outputs": [[389,290,0,12845056,4,"cuda:0"]], "output_shapes": [[128,128,28,28]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty", "id": 1262, "rf_id": 764, "parent": 1260, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[128],6,0,"cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","Int","Device","None","None"],
+      "outputs": [[582,370,0,128,4,"cuda:0"]], "output_shapes": [[128]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty", "id": 1263, "rf_id": 765, "parent": 1260, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[128],6,0,"cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","Int","Device","None","None"],
+      "outputs": [[350,373,0,128,4,"cuda:0"]], "output_shapes": [[128]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::view", "id": 1264, "rf_id": 766, "parent": 1260, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::view(Tensor(a) self, SymInt[] size) -> Tensor(a)",
+      "inputs": [[314,315,0,128,4,"cuda:0"],[1,128,1,1]], "input_shapes": [[128],[[],[],[],[]]], "input_types": ["Tensor(float)","GenericList[Int,Int,Int,Int]"],
+      "outputs": [[468,315,0,128,4,"cuda:0"]], "output_shapes": [[1,128,1,1]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty", "id": 1265, "rf_id": 767, "parent": 1260, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[0],0,0,"cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","Int","Device","None","None"],
+      "outputs": [[468,57,0,0,1,"cuda:0"]], "output_shapes": [[0]], "output_types": ["Tensor(unsigned char)"]
+    },
+    {
+      "name": "aten::cudnn_batch_norm_backward", "id": 1260, "rf_id": 762, "parent": 1259, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::cudnn_batch_norm_backward(Tensor input, Tensor grad_output, Tensor weight, Tensor? running_mean, Tensor? running_var, Tensor? save_mean, Tensor? save_var, float epsilon, Tensor reserveSpace) -> (Tensor, Tensor, Tensor)",
+      "inputs": [[308,309,0,12845056,4,"cuda:0"],[274,484,0,12845056,4,"cuda:0"],[314,315,0,128,4,"cuda:0"],[318,319,0,128,4,"cuda:0"],[320,321,0,128,4,"cuda:0"],[329,331,0,128,4,"cuda:0"],[333,334,0,128,4,"cuda:0"],0.000010,[338,57,0,0,1,"cuda:0"]], "input_shapes": [[128,128,28,28],[128,128,28,28],[128],[128],[128],[128],[128],[],[0]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Double","Tensor(unsigned char)"],
+      "outputs": [[389,290,0,12845056,4,"cuda:0"],[582,370,0,128,4,"cuda:0"],[350,373,0,128,4,"cuda:0"]], "output_shapes": [[128,128,28,28],[128],[128]], "output_types": ["Tensor(float)","Tensor(float)","Tensor(float)"]
+    },
+    {
+      "name": "CudnnBatchNormBackward0", "id": 1259, "rf_id": 761, "parent": 1258, "fw_parent": 2, "seq_id": 754, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[274,484,0,12845056,4,"cuda:0"]], "input_shapes": [[128,128,28,28]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: CudnnBatchNormBackward0", "id": 1258, "rf_id": 760, "parent": 847, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "detach", "id": 1269, "rf_id": 771, "parent": 1268, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [[582,370,0,128,4,"cuda:0"]], "input_shapes": [[128]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::detach", "id": 1268, "rf_id": 770, "parent": 1267, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::detach(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[582,370,0,128,4,"cuda:0"]], "input_shapes": [[128]], "input_types": ["Tensor(float)"],
+      "outputs": [[329,370,0,128,4,"cuda:0"]], "output_shapes": [[128]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "torch::autograd::AccumulateGrad", "id": 1267, "rf_id": 769, "parent": 1266, "fw_parent": 2, "seq_id": -1, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[582,370,0,128,4,"cuda:0"]], "input_shapes": [[128]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: torch::autograd::AccumulateGrad", "id": 1266, "rf_id": 768, "parent": 847, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "detach", "id": 1273, "rf_id": 775, "parent": 1272, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [[350,373,0,128,4,"cuda:0"]], "input_shapes": [[128]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::detach", "id": 1272, "rf_id": 774, "parent": 1271, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::detach(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[350,373,0,128,4,"cuda:0"]], "input_shapes": [[128]], "input_types": ["Tensor(float)"],
+      "outputs": [[333,373,0,128,4,"cuda:0"]], "output_shapes": [[128]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "torch::autograd::AccumulateGrad", "id": 1271, "rf_id": 773, "parent": 1270, "fw_parent": 2, "seq_id": -1, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[350,373,0,128,4,"cuda:0"]], "input_shapes": [[128]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: torch::autograd::AccumulateGrad", "id": 1270, "rf_id": 772, "parent": 847, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::empty", "id": 1277, "rf_id": 779, "parent": 1276, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[128,64,1,1],6,0,"cuda:0","<None>",0], "input_shapes": [[[],[],[],[]],[],[],[],[],[]], "input_types": ["GenericList[Int,Int,Int,Int]","Int","Int","Device","None","Int"],
+      "outputs": [[582,1278,0,8192,4,"cuda:0"]], "output_shapes": [[128,64,1,1]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::convolution_backward", "id": 1276, "rf_id": 778, "parent": 1275, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::convolution_backward(Tensor grad_output, Tensor input, Tensor weight, SymInt[]? bias_sizes, int[] stride, SymInt[] padding, int[] dilation, bool transposed, SymInt[] output_padding, int groups, bool[3] output_mask) -> (Tensor, Tensor, Tensor)",
+      "inputs": [[389,290,0,12845056,4,"cuda:0"],[195,211,0,25690112,4,"cuda:0"],[302,303,0,8192,4,"cuda:0"],[0],[2,2],[0,0],[1,1],false,[0,0],1,[true,true,false]], "input_shapes": [[128,128,28,28],[128,64,56,56],[128,64,1,1],[[]],[[],[]],[[],[]],[[],[]],[],[[],[]],[],[[],[],[]]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(float)","GenericList[Int]","GenericList[Int,Int]","GenericList[Int,Int]","GenericList[Int,Int]","Bool","GenericList[Int,Int]","Int","GenericList[Bool,Bool,Bool]"],
+      "outputs": [[350,309,0,25690112,4,"cuda:0"],[582,1278,0,8192,4,"cuda:0"],[23,0,0,0,0,""]], "output_shapes": [[128,64,56,56],[128,64,1,1],[]], "output_types": ["Tensor(float)","Tensor(float)","Tensor(nullptr (uninitialized))"]
+    },
+    {
+      "name": "ConvolutionBackward0", "id": 1275, "rf_id": 777, "parent": 1274, "fw_parent": 2, "seq_id": 753, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[389,290,0,12845056,4,"cuda:0"]], "input_shapes": [[128,128,28,28]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: ConvolutionBackward0", "id": 1274, "rf_id": 776, "parent": 847, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "detach", "id": 1282, "rf_id": 783, "parent": 1281, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [[582,1278,0,8192,4,"cuda:0"]], "input_shapes": [[128,64,1,1]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::detach", "id": 1281, "rf_id": 782, "parent": 1280, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::detach(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[582,1278,0,8192,4,"cuda:0"]], "input_shapes": [[128,64,1,1]], "input_types": ["Tensor(float)"],
+      "outputs": [[308,1278,0,8192,4,"cuda:0"]], "output_shapes": [[128,64,1,1]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "torch::autograd::AccumulateGrad", "id": 1280, "rf_id": 781, "parent": 1279, "fw_parent": 2, "seq_id": -1, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[582,1278,0,8192,4,"cuda:0"]], "input_shapes": [[128,64,1,1]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: torch::autograd::AccumulateGrad", "id": 1279, "rf_id": 780, "parent": 847, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::empty", "id": 1286, "rf_id": 787, "parent": 1285, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[128,128,28,28],6,0,"cuda:0","<None>",0], "input_shapes": [[[],[],[],[]],[],[],[],[],[]], "input_types": ["GenericList[Int,Int,Int,Int]","Int","Int","Device","None","Int"],
+      "outputs": [[582,290,0,12845056,4,"cuda:0"]], "output_shapes": [[128,128,28,28]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty", "id": 1287, "rf_id": 788, "parent": 1285, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[128],6,0,"cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","Int","Device","None","None"],
+      "outputs": [[389,331,0,128,4,"cuda:0"]], "output_shapes": [[128]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty", "id": 1288, "rf_id": 789, "parent": 1285, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[128],6,0,"cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","Int","Device","None","None"],
+      "outputs": [[468,334,0,128,4,"cuda:0"]], "output_shapes": [[128]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::view", "id": 1289, "rf_id": 790, "parent": 1285, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::view(Tensor(a) self, SymInt[] size) -> Tensor(a)",
+      "inputs": [[277,278,0,128,4,"cuda:0"],[1,128,1,1]], "input_shapes": [[128],[[],[],[],[]]], "input_types": ["Tensor(float)","GenericList[Int,Int,Int,Int]"],
+      "outputs": [[857,278,0,128,4,"cuda:0"]], "output_shapes": [[1,128,1,1]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty", "id": 1290, "rf_id": 791, "parent": 1285, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[0],0,0,"cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","Int","Device","None","None"],
+      "outputs": [[857,57,0,0,1,"cuda:0"]], "output_shapes": [[0]], "output_types": ["Tensor(unsigned char)"]
+    },
+    {
+      "name": "aten::cudnn_batch_norm_backward", "id": 1285, "rf_id": 786, "parent": 1284, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::cudnn_batch_norm_backward(Tensor input, Tensor grad_output, Tensor weight, Tensor? running_mean, Tensor? running_var, Tensor? save_mean, Tensor? save_var, float epsilon, Tensor reserveSpace) -> (Tensor, Tensor, Tensor)",
+      "inputs": [[260,271,0,12845056,4,"cuda:0"],[274,484,0,12845056,4,"cuda:0"],[277,278,0,128,4,"cuda:0"],[281,282,0,128,4,"cuda:0"],[283,284,0,128,4,"cuda:0"],[292,294,0,128,4,"cuda:0"],[296,297,0,128,4,"cuda:0"],0.000010,[301,57,0,0,1,"cuda:0"]], "input_shapes": [[128,128,28,28],[128,128,28,28],[128],[128],[128],[128],[128],[],[0]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Double","Tensor(unsigned char)"],
+      "outputs": [[582,290,0,12845056,4,"cuda:0"],[389,331,0,128,4,"cuda:0"],[468,334,0,128,4,"cuda:0"]], "output_shapes": [[128,128,28,28],[128],[128]], "output_types": ["Tensor(float)","Tensor(float)","Tensor(float)"]
+    },
+    {
+      "name": "CudnnBatchNormBackward0", "id": 1284, "rf_id": 785, "parent": 1283, "fw_parent": 2, "seq_id": 752, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[274,484,0,12845056,4,"cuda:0"]], "input_shapes": [[128,128,28,28]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: CudnnBatchNormBackward0", "id": 1283, "rf_id": 784, "parent": 847, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "detach", "id": 1294, "rf_id": 795, "parent": 1293, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [[389,331,0,128,4,"cuda:0"]], "input_shapes": [[128]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::detach", "id": 1293, "rf_id": 794, "parent": 1292, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::detach(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[389,331,0,128,4,"cuda:0"]], "input_shapes": [[128]], "input_types": ["Tensor(float)"],
+      "outputs": [[292,331,0,128,4,"cuda:0"]], "output_shapes": [[128]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "torch::autograd::AccumulateGrad", "id": 1292, "rf_id": 793, "parent": 1291, "fw_parent": 2, "seq_id": -1, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[389,331,0,128,4,"cuda:0"]], "input_shapes": [[128]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: torch::autograd::AccumulateGrad", "id": 1291, "rf_id": 792, "parent": 847, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "detach", "id": 1298, "rf_id": 799, "parent": 1297, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [[468,334,0,128,4,"cuda:0"]], "input_shapes": [[128]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::detach", "id": 1297, "rf_id": 798, "parent": 1296, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::detach(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[468,334,0,128,4,"cuda:0"]], "input_shapes": [[128]], "input_types": ["Tensor(float)"],
+      "outputs": [[296,334,0,128,4,"cuda:0"]], "output_shapes": [[128]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "torch::autograd::AccumulateGrad", "id": 1296, "rf_id": 797, "parent": 1295, "fw_parent": 2, "seq_id": -1, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[468,334,0,128,4,"cuda:0"]], "input_shapes": [[128]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: torch::autograd::AccumulateGrad", "id": 1295, "rf_id": 796, "parent": 847, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::empty", "id": 1302, "rf_id": 803, "parent": 1301, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[128,128,3,3],6,0,"cuda:0","<None>",0], "input_shapes": [[[],[],[],[]],[],[],[],[],[]], "input_types": ["GenericList[Int,Int,Int,Int]","Int","Int","Device","None","Int"],
+      "outputs": [[389,1303,0,147456,4,"cuda:0"]], "output_shapes": [[128,128,3,3]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::convolution_backward", "id": 1301, "rf_id": 802, "parent": 1300, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::convolution_backward(Tensor grad_output, Tensor input, Tensor weight, SymInt[]? bias_sizes, int[] stride, SymInt[] padding, int[] dilation, bool transposed, SymInt[] output_padding, int groups, bool[3] output_mask) -> (Tensor, Tensor, Tensor)",
+      "inputs": [[582,290,0,12845056,4,"cuda:0"],[235,251,0,12845056,4,"cuda:0"],[265,266,0,147456,4,"cuda:0"],[0],[1,1],[1,1],[1,1],false,[0,0],1,[true,true,false]], "input_shapes": [[128,128,28,28],[128,128,28,28],[128,128,3,3],[[]],[[],[]],[[],[]],[[],[]],[],[[],[]],[],[[],[],[]]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(float)","GenericList[Int]","GenericList[Int,Int]","GenericList[Int,Int]","GenericList[Int,Int]","Bool","GenericList[Int,Int]","Int","GenericList[Bool,Bool,Bool]"],
+      "outputs": [[468,271,0,12845056,4,"cuda:0"],[389,1303,0,147456,4,"cuda:0"],[23,0,0,0,0,""]], "output_shapes": [[128,128,28,28],[128,128,3,3],[]], "output_types": ["Tensor(float)","Tensor(float)","Tensor(nullptr (uninitialized))"]
+    },
+    {
+      "name": "ConvolutionBackward0", "id": 1300, "rf_id": 801, "parent": 1299, "fw_parent": 2, "seq_id": 751, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[582,290,0,12845056,4,"cuda:0"]], "input_shapes": [[128,128,28,28]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: ConvolutionBackward0", "id": 1299, "rf_id": 800, "parent": 847, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "detach", "id": 1307, "rf_id": 807, "parent": 1306, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [[389,1303,0,147456,4,"cuda:0"]], "input_shapes": [[128,128,3,3]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::detach", "id": 1306, "rf_id": 806, "parent": 1305, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::detach(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[389,1303,0,147456,4,"cuda:0"]], "input_shapes": [[128,128,3,3]], "input_types": ["Tensor(float)"],
+      "outputs": [[582,1303,0,147456,4,"cuda:0"]], "output_shapes": [[128,128,3,3]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "torch::autograd::AccumulateGrad", "id": 1305, "rf_id": 805, "parent": 1304, "fw_parent": 2, "seq_id": -1, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[389,1303,0,147456,4,"cuda:0"]], "input_shapes": [[128,128,3,3]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: torch::autograd::AccumulateGrad", "id": 1304, "rf_id": 804, "parent": 847, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::threshold_backward", "id": 1310, "rf_id": 810, "parent": 1309, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::threshold_backward(Tensor grad_output, Tensor self, Scalar threshold) -> Tensor",
+      "inputs": [[468,271,0,12845056,4,"cuda:0"],[389,251,0,12845056,4,"cuda:0"],0], "input_shapes": [[128,128,28,28],[128,128,28,28],[]], "input_types": ["Tensor(float)","Tensor(float)","Int"],
+      "outputs": [[235,290,0,12845056,4,"cuda:0"]], "output_shapes": [[128,128,28,28]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "ReluBackward0", "id": 1309, "rf_id": 809, "parent": 1308, "fw_parent": 2, "seq_id": 750, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[468,271,0,12845056,4,"cuda:0"]], "input_shapes": [[128,128,28,28]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: ReluBackward0", "id": 1308, "rf_id": 808, "parent": 847, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::empty", "id": 1314, "rf_id": 814, "parent": 1313, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[128,128,28,28],6,0,"cuda:0","<None>",0], "input_shapes": [[[],[],[],[]],[],[],[],[],[]], "input_types": ["GenericList[Int,Int,Int,Int]","Int","Int","Device","None","Int"],
+      "outputs": [[468,271,0,12845056,4,"cuda:0"]], "output_shapes": [[128,128,28,28]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty", "id": 1315, "rf_id": 815, "parent": 1313, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[128],6,0,"cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","Int","Device","None","None"],
+      "outputs": [[389,294,0,128,4,"cuda:0"]], "output_shapes": [[128]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty", "id": 1316, "rf_id": 816, "parent": 1313, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[128],6,0,"cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","Int","Device","None","None"],
+      "outputs": [[260,297,0,128,4,"cuda:0"]], "output_shapes": [[128]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::view", "id": 1317, "rf_id": 817, "parent": 1313, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::view(Tensor(a) self, SymInt[] size) -> Tensor(a)",
+      "inputs": [[238,239,0,128,4,"cuda:0"],[1,128,1,1]], "input_shapes": [[128],[[],[],[],[]]], "input_types": ["Tensor(float)","GenericList[Int,Int,Int,Int]"],
+      "outputs": [[274,239,0,128,4,"cuda:0"]], "output_shapes": [[1,128,1,1]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty", "id": 1318, "rf_id": 818, "parent": 1313, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[0],0,0,"cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","Int","Device","None","None"],
+      "outputs": [[274,57,0,0,1,"cuda:0"]], "output_shapes": [[0]], "output_types": ["Tensor(unsigned char)"]
+    },
+    {
+      "name": "aten::cudnn_batch_norm_backward", "id": 1313, "rf_id": 813, "parent": 1312, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::cudnn_batch_norm_backward(Tensor input, Tensor grad_output, Tensor weight, Tensor? running_mean, Tensor? running_var, Tensor? save_mean, Tensor? save_var, float epsilon, Tensor reserveSpace) -> (Tensor, Tensor, Tensor)",
+      "inputs": [[220,232,0,12845056,4,"cuda:0"],[235,290,0,12845056,4,"cuda:0"],[238,239,0,128,4,"cuda:0"],[242,243,0,128,4,"cuda:0"],[244,245,0,128,4,"cuda:0"],[253,255,0,128,4,"cuda:0"],[257,258,0,128,4,"cuda:0"],0.000010,[262,57,0,0,1,"cuda:0"]], "input_shapes": [[128,128,28,28],[128,128,28,28],[128],[128],[128],[128],[128],[],[0]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Double","Tensor(unsigned char)"],
+      "outputs": [[468,271,0,12845056,4,"cuda:0"],[389,294,0,128,4,"cuda:0"],[260,297,0,128,4,"cuda:0"]], "output_shapes": [[128,128,28,28],[128],[128]], "output_types": ["Tensor(float)","Tensor(float)","Tensor(float)"]
+    },
+    {
+      "name": "CudnnBatchNormBackward0", "id": 1312, "rf_id": 812, "parent": 1311, "fw_parent": 2, "seq_id": 749, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[235,290,0,12845056,4,"cuda:0"]], "input_shapes": [[128,128,28,28]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: CudnnBatchNormBackward0", "id": 1311, "rf_id": 811, "parent": 847, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "detach", "id": 1322, "rf_id": 822, "parent": 1321, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [[389,294,0,128,4,"cuda:0"]], "input_shapes": [[128]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::detach", "id": 1321, "rf_id": 821, "parent": 1320, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::detach(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[389,294,0,128,4,"cuda:0"]], "input_shapes": [[128]], "input_types": ["Tensor(float)"],
+      "outputs": [[220,294,0,128,4,"cuda:0"]], "output_shapes": [[128]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "torch::autograd::AccumulateGrad", "id": 1320, "rf_id": 820, "parent": 1319, "fw_parent": 2, "seq_id": -1, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[389,294,0,128,4,"cuda:0"]], "input_shapes": [[128]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: torch::autograd::AccumulateGrad", "id": 1319, "rf_id": 819, "parent": 847, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "detach", "id": 1326, "rf_id": 826, "parent": 1325, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [[260,297,0,128,4,"cuda:0"]], "input_shapes": [[128]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::detach", "id": 1325, "rf_id": 825, "parent": 1324, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::detach(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[260,297,0,128,4,"cuda:0"]], "input_shapes": [[128]], "input_types": ["Tensor(float)"],
+      "outputs": [[253,297,0,128,4,"cuda:0"]], "output_shapes": [[128]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "torch::autograd::AccumulateGrad", "id": 1324, "rf_id": 824, "parent": 1323, "fw_parent": 2, "seq_id": -1, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[260,297,0,128,4,"cuda:0"]], "input_shapes": [[128]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: torch::autograd::AccumulateGrad", "id": 1323, "rf_id": 823, "parent": 847, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::empty", "id": 1330, "rf_id": 830, "parent": 1329, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[128,64,3,3],6,0,"cuda:0","<None>",0], "input_shapes": [[[],[],[],[]],[],[],[],[],[]], "input_types": ["GenericList[Int,Int,Int,Int]","Int","Int","Device","None","Int"],
+      "outputs": [[389,865,0,73728,4,"cuda:0"]], "output_shapes": [[128,64,3,3]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::convolution_backward", "id": 1329, "rf_id": 829, "parent": 1328, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::convolution_backward(Tensor grad_output, Tensor input, Tensor weight, SymInt[]? bias_sizes, int[] stride, SymInt[] padding, int[] dilation, bool transposed, SymInt[] output_padding, int groups, bool[3] output_mask) -> (Tensor, Tensor, Tensor)",
+      "inputs": [[468,271,0,12845056,4,"cuda:0"],[195,211,0,25690112,4,"cuda:0"],[226,227,0,73728,4,"cuda:0"],[0],[2,2],[1,1],[1,1],false,[0,0],1,[true,true,false]], "input_shapes": [[128,128,28,28],[128,64,56,56],[128,64,3,3],[[]],[[],[]],[[],[]],[[],[]],[],[[],[]],[],[[],[],[]]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(float)","GenericList[Int]","GenericList[Int,Int]","GenericList[Int,Int]","GenericList[Int,Int]","Bool","GenericList[Int,Int]","Int","GenericList[Bool,Bool,Bool]"],
+      "outputs": [[260,366,0,25690112,4,"cuda:0"],[389,865,0,73728,4,"cuda:0"],[23,0,0,0,0,""]], "output_shapes": [[128,64,56,56],[128,64,3,3],[]], "output_types": ["Tensor(float)","Tensor(float)","Tensor(nullptr (uninitialized))"]
+    },
+    {
+      "name": "ConvolutionBackward0", "id": 1328, "rf_id": 828, "parent": 1327, "fw_parent": 2, "seq_id": 748, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[468,271,0,12845056,4,"cuda:0"]], "input_shapes": [[128,128,28,28]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::add_", "id": 1331, "rf_id": 831, "parent": 1327, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::add_.Tensor(Tensor(a!) self, Tensor other, *, Scalar alpha=1) -> Tensor(a!)",
+      "inputs": [[350,309,0,25690112,4,"cuda:0"],[260,366,0,25690112,4,"cuda:0"],1], "input_shapes": [[128,64,56,56],[128,64,56,56],[]], "input_types": ["Tensor(float)","Tensor(float)","Int"],
+      "outputs": [[350,309,0,25690112,4,"cuda:0"]], "output_shapes": [[128,64,56,56]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "autograd::engine::evaluate_function: ConvolutionBackward0", "id": 1327, "rf_id": 827, "parent": 847, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "detach", "id": 1335, "rf_id": 835, "parent": 1334, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [[389,865,0,73728,4,"cuda:0"]], "input_shapes": [[128,64,3,3]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::detach", "id": 1334, "rf_id": 834, "parent": 1333, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::detach(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[389,865,0,73728,4,"cuda:0"]], "input_shapes": [[128,64,3,3]], "input_types": ["Tensor(float)"],
+      "outputs": [[468,865,0,73728,4,"cuda:0"]], "output_shapes": [[128,64,3,3]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "torch::autograd::AccumulateGrad", "id": 1333, "rf_id": 833, "parent": 1332, "fw_parent": 2, "seq_id": -1, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[389,865,0,73728,4,"cuda:0"]], "input_shapes": [[128,64,3,3]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: torch::autograd::AccumulateGrad", "id": 1332, "rf_id": 832, "parent": 847, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::threshold_backward", "id": 1338, "rf_id": 838, "parent": 1337, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::threshold_backward(Tensor grad_output, Tensor self, Scalar threshold) -> Tensor",
+      "inputs": [[350,309,0,25690112,4,"cuda:0"],[389,211,0,25690112,4,"cuda:0"],0], "input_shapes": [[128,64,56,56],[128,64,56,56],[]], "input_types": ["Tensor(float)","Tensor(float)","Int"],
+      "outputs": [[195,366,0,25690112,4,"cuda:0"]], "output_shapes": [[128,64,56,56]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "ReluBackward0", "id": 1337, "rf_id": 837, "parent": 1336, "fw_parent": 2, "seq_id": 747, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[350,309,0,25690112,4,"cuda:0"]], "input_shapes": [[128,64,56,56]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: ReluBackward0", "id": 1336, "rf_id": 836, "parent": 847, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "AddBackward0", "id": 1340, "rf_id": 840, "parent": 1339, "fw_parent": 2, "seq_id": 746, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[195,366,0,25690112,4,"cuda:0"]], "input_shapes": [[128,64,56,56]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: AddBackward0", "id": 1339, "rf_id": 839, "parent": 847, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::empty", "id": 1344, "rf_id": 844, "parent": 1343, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[128,64,56,56],6,0,"cuda:0","<None>",0], "input_shapes": [[[],[],[],[]],[],[],[],[],[]], "input_types": ["GenericList[Int,Int,Int,Int]","Int","Int","Device","None","Int"],
+      "outputs": [[350,290,0,25690112,4,"cuda:0"]], "output_shapes": [[128,64,56,56]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty", "id": 1345, "rf_id": 845, "parent": 1343, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[64],6,0,"cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","Int","Device","None","None"],
+      "outputs": [[389,255,0,64,4,"cuda:0"]], "output_shapes": [[64]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty", "id": 1346, "rf_id": 846, "parent": 1343, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[64],6,0,"cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","Int","Device","None","None"],
+      "outputs": [[235,258,0,64,4,"cuda:0"]], "output_shapes": [[64]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::view", "id": 1347, "rf_id": 847, "parent": 1343, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::view(Tensor(a) self, SymInt[] size) -> Tensor(a)",
+      "inputs": [[198,199,0,64,4,"cuda:0"],[1,64,1,1]], "input_shapes": [[64],[[],[],[],[]]], "input_types": ["Tensor(float)","GenericList[Int,Int,Int,Int]"],
+      "outputs": [[274,199,0,64,4,"cuda:0"]], "output_shapes": [[1,64,1,1]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty", "id": 1348, "rf_id": 848, "parent": 1343, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[0],0,0,"cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","Int","Device","None","None"],
+      "outputs": [[274,57,0,0,1,"cuda:0"]], "output_shapes": [[0]], "output_types": ["Tensor(unsigned char)"]
+    },
+    {
+      "name": "aten::cudnn_batch_norm_backward", "id": 1343, "rf_id": 843, "parent": 1342, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::cudnn_batch_norm_backward(Tensor input, Tensor grad_output, Tensor weight, Tensor? running_mean, Tensor? running_var, Tensor? save_mean, Tensor? save_var, float epsilon, Tensor reserveSpace) -> (Tensor, Tensor, Tensor)",
+      "inputs": [[181,192,0,25690112,4,"cuda:0"],[195,366,0,25690112,4,"cuda:0"],[198,199,0,64,4,"cuda:0"],[202,203,0,64,4,"cuda:0"],[204,205,0,64,4,"cuda:0"],[213,215,0,64,4,"cuda:0"],[217,218,0,64,4,"cuda:0"],0.000010,[222,57,0,0,1,"cuda:0"]], "input_shapes": [[128,64,56,56],[128,64,56,56],[64],[64],[64],[64],[64],[],[0]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Double","Tensor(unsigned char)"],
+      "outputs": [[350,290,0,25690112,4,"cuda:0"],[389,255,0,64,4,"cuda:0"],[235,258,0,64,4,"cuda:0"]], "output_shapes": [[128,64,56,56],[64],[64]], "output_types": ["Tensor(float)","Tensor(float)","Tensor(float)"]
+    },
+    {
+      "name": "CudnnBatchNormBackward0", "id": 1342, "rf_id": 842, "parent": 1341, "fw_parent": 2, "seq_id": 745, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[195,366,0,25690112,4,"cuda:0"]], "input_shapes": [[128,64,56,56]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: CudnnBatchNormBackward0", "id": 1341, "rf_id": 841, "parent": 847, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "detach", "id": 1352, "rf_id": 852, "parent": 1351, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [[389,255,0,64,4,"cuda:0"]], "input_shapes": [[64]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::detach", "id": 1351, "rf_id": 851, "parent": 1350, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::detach(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[389,255,0,64,4,"cuda:0"]], "input_shapes": [[64]], "input_types": ["Tensor(float)"],
+      "outputs": [[213,255,0,64,4,"cuda:0"]], "output_shapes": [[64]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "torch::autograd::AccumulateGrad", "id": 1350, "rf_id": 850, "parent": 1349, "fw_parent": 2, "seq_id": -1, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[389,255,0,64,4,"cuda:0"]], "input_shapes": [[64]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: torch::autograd::AccumulateGrad", "id": 1349, "rf_id": 849, "parent": 847, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "detach", "id": 1356, "rf_id": 856, "parent": 1355, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [[235,258,0,64,4,"cuda:0"]], "input_shapes": [[64]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::detach", "id": 1355, "rf_id": 855, "parent": 1354, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::detach(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[235,258,0,64,4,"cuda:0"]], "input_shapes": [[64]], "input_types": ["Tensor(float)"],
+      "outputs": [[217,258,0,64,4,"cuda:0"]], "output_shapes": [[64]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "torch::autograd::AccumulateGrad", "id": 1354, "rf_id": 854, "parent": 1353, "fw_parent": 2, "seq_id": -1, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[235,258,0,64,4,"cuda:0"]], "input_shapes": [[64]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: torch::autograd::AccumulateGrad", "id": 1353, "rf_id": 853, "parent": 847, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::empty", "id": 1360, "rf_id": 860, "parent": 1359, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[64,64,3,3],6,0,"cuda:0","<None>",0], "input_shapes": [[[],[],[],[]],[],[],[],[],[]], "input_types": ["GenericList[Int,Int,Int,Int]","Int","Int","Device","None","Int"],
+      "outputs": [[389,808,0,36864,4,"cuda:0"]], "output_shapes": [[64,64,3,3]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::convolution_backward", "id": 1359, "rf_id": 859, "parent": 1358, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::convolution_backward(Tensor grad_output, Tensor input, Tensor weight, SymInt[]? bias_sizes, int[] stride, SymInt[] padding, int[] dilation, bool transposed, SymInt[] output_padding, int groups, bool[3] output_mask) -> (Tensor, Tensor, Tensor)",
+      "inputs": [[350,290,0,25690112,4,"cuda:0"],[156,172,0,25690112,4,"cuda:0"],[186,187,0,36864,4,"cuda:0"],[0],[1,1],[1,1],[1,1],false,[0,0],1,[true,true,false]], "input_shapes": [[128,64,56,56],[128,64,56,56],[64,64,3,3],[[]],[[],[]],[[],[]],[[],[]],[],[[],[]],[],[[],[],[]]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(float)","GenericList[Int]","GenericList[Int,Int]","GenericList[Int,Int]","GenericList[Int,Int]","Bool","GenericList[Int,Int]","Int","GenericList[Bool,Bool,Bool]"],
+      "outputs": [[235,405,0,25690112,4,"cuda:0"],[389,808,0,36864,4,"cuda:0"],[23,0,0,0,0,""]], "output_shapes": [[128,64,56,56],[64,64,3,3],[]], "output_types": ["Tensor(float)","Tensor(float)","Tensor(nullptr (uninitialized))"]
+    },
+    {
+      "name": "ConvolutionBackward0", "id": 1358, "rf_id": 858, "parent": 1357, "fw_parent": 2, "seq_id": 744, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[350,290,0,25690112,4,"cuda:0"]], "input_shapes": [[128,64,56,56]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: ConvolutionBackward0", "id": 1357, "rf_id": 857, "parent": 847, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "detach", "id": 1364, "rf_id": 864, "parent": 1363, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [[389,808,0,36864,4,"cuda:0"]], "input_shapes": [[64,64,3,3]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::detach", "id": 1363, "rf_id": 863, "parent": 1362, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::detach(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[389,808,0,36864,4,"cuda:0"]], "input_shapes": [[64,64,3,3]], "input_types": ["Tensor(float)"],
+      "outputs": [[350,808,0,36864,4,"cuda:0"]], "output_shapes": [[64,64,3,3]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "torch::autograd::AccumulateGrad", "id": 1362, "rf_id": 862, "parent": 1361, "fw_parent": 2, "seq_id": -1, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[389,808,0,36864,4,"cuda:0"]], "input_shapes": [[64,64,3,3]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: torch::autograd::AccumulateGrad", "id": 1361, "rf_id": 861, "parent": 847, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::threshold_backward", "id": 1367, "rf_id": 867, "parent": 1366, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::threshold_backward(Tensor grad_output, Tensor self, Scalar threshold) -> Tensor",
+      "inputs": [[235,405,0,25690112,4,"cuda:0"],[389,172,0,25690112,4,"cuda:0"],0], "input_shapes": [[128,64,56,56],[128,64,56,56],[]], "input_types": ["Tensor(float)","Tensor(float)","Int"],
+      "outputs": [[156,484,0,25690112,4,"cuda:0"]], "output_shapes": [[128,64,56,56]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "ReluBackward0", "id": 1366, "rf_id": 866, "parent": 1365, "fw_parent": 2, "seq_id": 743, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[235,405,0,25690112,4,"cuda:0"]], "input_shapes": [[128,64,56,56]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: ReluBackward0", "id": 1365, "rf_id": 865, "parent": 847, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::empty", "id": 1371, "rf_id": 871, "parent": 1370, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[128,64,56,56],6,0,"cuda:0","<None>",0], "input_shapes": [[[],[],[],[]],[],[],[],[],[]], "input_types": ["GenericList[Int,Int,Int,Int]","Int","Int","Device","None","Int"],
+      "outputs": [[235,405,0,25690112,4,"cuda:0"]], "output_shapes": [[128,64,56,56]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty", "id": 1372, "rf_id": 872, "parent": 1370, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[64],6,0,"cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","Int","Device","None","None"],
+      "outputs": [[389,215,0,64,4,"cuda:0"]], "output_shapes": [[64]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty", "id": 1373, "rf_id": 873, "parent": 1370, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[64],6,0,"cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","Int","Device","None","None"],
+      "outputs": [[181,218,0,64,4,"cuda:0"]], "output_shapes": [[64]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::view", "id": 1374, "rf_id": 874, "parent": 1370, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::view(Tensor(a) self, SymInt[] size) -> Tensor(a)",
+      "inputs": [[159,160,0,64,4,"cuda:0"],[1,64,1,1]], "input_shapes": [[64],[[],[],[],[]]], "input_types": ["Tensor(float)","GenericList[Int,Int,Int,Int]"],
+      "outputs": [[274,160,0,64,4,"cuda:0"]], "output_shapes": [[1,64,1,1]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty", "id": 1375, "rf_id": 875, "parent": 1370, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[0],0,0,"cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","Int","Device","None","None"],
+      "outputs": [[274,57,0,0,1,"cuda:0"]], "output_shapes": [[0]], "output_types": ["Tensor(unsigned char)"]
+    },
+    {
+      "name": "aten::cudnn_batch_norm_backward", "id": 1370, "rf_id": 870, "parent": 1369, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::cudnn_batch_norm_backward(Tensor input, Tensor grad_output, Tensor weight, Tensor? running_mean, Tensor? running_var, Tensor? save_mean, Tensor? save_var, float epsilon, Tensor reserveSpace) -> (Tensor, Tensor, Tensor)",
+      "inputs": [[141,153,0,25690112,4,"cuda:0"],[156,484,0,25690112,4,"cuda:0"],[159,160,0,64,4,"cuda:0"],[163,164,0,64,4,"cuda:0"],[165,166,0,64,4,"cuda:0"],[174,176,0,64,4,"cuda:0"],[178,179,0,64,4,"cuda:0"],0.000010,[183,57,0,0,1,"cuda:0"]], "input_shapes": [[128,64,56,56],[128,64,56,56],[64],[64],[64],[64],[64],[],[0]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Double","Tensor(unsigned char)"],
+      "outputs": [[235,405,0,25690112,4,"cuda:0"],[389,215,0,64,4,"cuda:0"],[181,218,0,64,4,"cuda:0"]], "output_shapes": [[128,64,56,56],[64],[64]], "output_types": ["Tensor(float)","Tensor(float)","Tensor(float)"]
+    },
+    {
+      "name": "CudnnBatchNormBackward0", "id": 1369, "rf_id": 869, "parent": 1368, "fw_parent": 2, "seq_id": 742, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[156,484,0,25690112,4,"cuda:0"]], "input_shapes": [[128,64,56,56]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: CudnnBatchNormBackward0", "id": 1368, "rf_id": 868, "parent": 847, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "detach", "id": 1379, "rf_id": 879, "parent": 1378, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [[389,215,0,64,4,"cuda:0"]], "input_shapes": [[64]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::detach", "id": 1378, "rf_id": 878, "parent": 1377, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::detach(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[389,215,0,64,4,"cuda:0"]], "input_shapes": [[64]], "input_types": ["Tensor(float)"],
+      "outputs": [[141,215,0,64,4,"cuda:0"]], "output_shapes": [[64]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "torch::autograd::AccumulateGrad", "id": 1377, "rf_id": 877, "parent": 1376, "fw_parent": 2, "seq_id": -1, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[389,215,0,64,4,"cuda:0"]], "input_shapes": [[64]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: torch::autograd::AccumulateGrad", "id": 1376, "rf_id": 876, "parent": 847, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "detach", "id": 1383, "rf_id": 883, "parent": 1382, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [[181,218,0,64,4,"cuda:0"]], "input_shapes": [[64]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::detach", "id": 1382, "rf_id": 882, "parent": 1381, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::detach(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[181,218,0,64,4,"cuda:0"]], "input_shapes": [[64]], "input_types": ["Tensor(float)"],
+      "outputs": [[174,218,0,64,4,"cuda:0"]], "output_shapes": [[64]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "torch::autograd::AccumulateGrad", "id": 1381, "rf_id": 881, "parent": 1380, "fw_parent": 2, "seq_id": -1, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[181,218,0,64,4,"cuda:0"]], "input_shapes": [[64]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: torch::autograd::AccumulateGrad", "id": 1380, "rf_id": 880, "parent": 847, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::empty", "id": 1387, "rf_id": 887, "parent": 1386, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[64,64,3,3],6,0,"cuda:0","<None>",0], "input_shapes": [[[],[],[],[]],[],[],[],[],[]], "input_types": ["GenericList[Int,Int,Int,Int]","Int","Int","Device","None","Int"],
+      "outputs": [[389,1388,0,36864,4,"cuda:0"]], "output_shapes": [[64,64,3,3]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::convolution_backward", "id": 1386, "rf_id": 886, "parent": 1385, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::convolution_backward(Tensor grad_output, Tensor input, Tensor weight, SymInt[]? bias_sizes, int[] stride, SymInt[] padding, int[] dilation, bool transposed, SymInt[] output_padding, int groups, bool[3] output_mask) -> (Tensor, Tensor, Tensor)",
+      "inputs": [[235,405,0,25690112,4,"cuda:0"],[116,132,0,25690112,4,"cuda:0"],[147,148,0,36864,4,"cuda:0"],[0],[1,1],[1,1],[1,1],false,[0,0],1,[true,true,false]], "input_shapes": [[128,64,56,56],[128,64,56,56],[64,64,3,3],[[]],[[],[]],[[],[]],[[],[]],[],[[],[]],[],[[],[],[]]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(float)","GenericList[Int]","GenericList[Int,Int]","GenericList[Int,Int]","GenericList[Int,Int]","Bool","GenericList[Int,Int]","Int","GenericList[Bool,Bool,Bool]"],
+      "outputs": [[181,484,0,25690112,4,"cuda:0"],[389,1388,0,36864,4,"cuda:0"],[23,0,0,0,0,""]], "output_shapes": [[128,64,56,56],[64,64,3,3],[]], "output_types": ["Tensor(float)","Tensor(float)","Tensor(nullptr (uninitialized))"]
+    },
+    {
+      "name": "ConvolutionBackward0", "id": 1385, "rf_id": 885, "parent": 1384, "fw_parent": 2, "seq_id": 741, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[235,405,0,25690112,4,"cuda:0"]], "input_shapes": [[128,64,56,56]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::add_", "id": 1389, "rf_id": 888, "parent": 1384, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::add_.Tensor(Tensor(a!) self, Tensor other, *, Scalar alpha=1) -> Tensor(a!)",
+      "inputs": [[195,366,0,25690112,4,"cuda:0"],[181,484,0,25690112,4,"cuda:0"],1], "input_shapes": [[128,64,56,56],[128,64,56,56],[]], "input_types": ["Tensor(float)","Tensor(float)","Int"],
+      "outputs": [[195,366,0,25690112,4,"cuda:0"]], "output_shapes": [[128,64,56,56]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "autograd::engine::evaluate_function: ConvolutionBackward0", "id": 1384, "rf_id": 884, "parent": 847, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "detach", "id": 1393, "rf_id": 892, "parent": 1392, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [[389,1388,0,36864,4,"cuda:0"]], "input_shapes": [[64,64,3,3]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::detach", "id": 1392, "rf_id": 891, "parent": 1391, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::detach(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[389,1388,0,36864,4,"cuda:0"]], "input_shapes": [[64,64,3,3]], "input_types": ["Tensor(float)"],
+      "outputs": [[235,1388,0,36864,4,"cuda:0"]], "output_shapes": [[64,64,3,3]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "torch::autograd::AccumulateGrad", "id": 1391, "rf_id": 890, "parent": 1390, "fw_parent": 2, "seq_id": -1, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[389,1388,0,36864,4,"cuda:0"]], "input_shapes": [[64,64,3,3]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: torch::autograd::AccumulateGrad", "id": 1390, "rf_id": 889, "parent": 847, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::threshold_backward", "id": 1396, "rf_id": 895, "parent": 1395, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::threshold_backward(Tensor grad_output, Tensor self, Scalar threshold) -> Tensor",
+      "inputs": [[195,366,0,25690112,4,"cuda:0"],[389,132,0,25690112,4,"cuda:0"],0], "input_shapes": [[128,64,56,56],[128,64,56,56],[]], "input_types": ["Tensor(float)","Tensor(float)","Int"],
+      "outputs": [[116,290,0,25690112,4,"cuda:0"]], "output_shapes": [[128,64,56,56]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "ReluBackward0", "id": 1395, "rf_id": 894, "parent": 1394, "fw_parent": 2, "seq_id": 740, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[195,366,0,25690112,4,"cuda:0"]], "input_shapes": [[128,64,56,56]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: ReluBackward0", "id": 1394, "rf_id": 893, "parent": 847, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "AddBackward0", "id": 1398, "rf_id": 897, "parent": 1397, "fw_parent": 2, "seq_id": 739, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[116,290,0,25690112,4,"cuda:0"]], "input_shapes": [[128,64,56,56]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: AddBackward0", "id": 1397, "rf_id": 896, "parent": 847, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::empty", "id": 1402, "rf_id": 901, "parent": 1401, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[128,64,56,56],6,0,"cuda:0","<None>",0], "input_shapes": [[[],[],[],[]],[],[],[],[],[]], "input_types": ["GenericList[Int,Int,Int,Int]","Int","Int","Device","None","Int"],
+      "outputs": [[195,132,0,25690112,4,"cuda:0"]], "output_shapes": [[128,64,56,56]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty", "id": 1403, "rf_id": 902, "parent": 1401, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[64],6,0,"cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","Int","Device","None","None"],
+      "outputs": [[389,176,0,64,4,"cuda:0"]], "output_shapes": [[64]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty", "id": 1404, "rf_id": 903, "parent": 1401, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[64],6,0,"cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","Int","Device","None","None"],
+      "outputs": [[156,179,0,64,4,"cuda:0"]], "output_shapes": [[64]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::view", "id": 1405, "rf_id": 904, "parent": 1401, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::view(Tensor(a) self, SymInt[] size) -> Tensor(a)",
+      "inputs": [[119,120,0,64,4,"cuda:0"],[1,64,1,1]], "input_shapes": [[64],[[],[],[],[]]], "input_types": ["Tensor(float)","GenericList[Int,Int,Int,Int]"],
+      "outputs": [[274,120,0,64,4,"cuda:0"]], "output_shapes": [[1,64,1,1]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty", "id": 1406, "rf_id": 905, "parent": 1401, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[0],0,0,"cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","Int","Device","None","None"],
+      "outputs": [[274,57,0,0,1,"cuda:0"]], "output_shapes": [[0]], "output_types": ["Tensor(unsigned char)"]
+    },
+    {
+      "name": "aten::cudnn_batch_norm_backward", "id": 1401, "rf_id": 900, "parent": 1400, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::cudnn_batch_norm_backward(Tensor input, Tensor grad_output, Tensor weight, Tensor? running_mean, Tensor? running_var, Tensor? save_mean, Tensor? save_var, float epsilon, Tensor reserveSpace) -> (Tensor, Tensor, Tensor)",
+      "inputs": [[102,113,0,25690112,4,"cuda:0"],[116,290,0,25690112,4,"cuda:0"],[119,120,0,64,4,"cuda:0"],[123,124,0,64,4,"cuda:0"],[125,126,0,64,4,"cuda:0"],[134,136,0,64,4,"cuda:0"],[138,139,0,64,4,"cuda:0"],0.000010,[143,57,0,0,1,"cuda:0"]], "input_shapes": [[128,64,56,56],[128,64,56,56],[64],[64],[64],[64],[64],[],[0]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Double","Tensor(unsigned char)"],
+      "outputs": [[195,132,0,25690112,4,"cuda:0"],[389,176,0,64,4,"cuda:0"],[156,179,0,64,4,"cuda:0"]], "output_shapes": [[128,64,56,56],[64],[64]], "output_types": ["Tensor(float)","Tensor(float)","Tensor(float)"]
+    },
+    {
+      "name": "CudnnBatchNormBackward0", "id": 1400, "rf_id": 899, "parent": 1399, "fw_parent": 2, "seq_id": 738, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[116,290,0,25690112,4,"cuda:0"]], "input_shapes": [[128,64,56,56]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: CudnnBatchNormBackward0", "id": 1399, "rf_id": 898, "parent": 847, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "detach", "id": 1410, "rf_id": 909, "parent": 1409, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [[389,176,0,64,4,"cuda:0"]], "input_shapes": [[64]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::detach", "id": 1409, "rf_id": 908, "parent": 1408, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::detach(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[389,176,0,64,4,"cuda:0"]], "input_shapes": [[64]], "input_types": ["Tensor(float)"],
+      "outputs": [[134,176,0,64,4,"cuda:0"]], "output_shapes": [[64]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "torch::autograd::AccumulateGrad", "id": 1408, "rf_id": 907, "parent": 1407, "fw_parent": 2, "seq_id": -1, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[389,176,0,64,4,"cuda:0"]], "input_shapes": [[64]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: torch::autograd::AccumulateGrad", "id": 1407, "rf_id": 906, "parent": 847, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "detach", "id": 1414, "rf_id": 913, "parent": 1413, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [[156,179,0,64,4,"cuda:0"]], "input_shapes": [[64]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::detach", "id": 1413, "rf_id": 912, "parent": 1412, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::detach(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[156,179,0,64,4,"cuda:0"]], "input_shapes": [[64]], "input_types": ["Tensor(float)"],
+      "outputs": [[138,179,0,64,4,"cuda:0"]], "output_shapes": [[64]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "torch::autograd::AccumulateGrad", "id": 1412, "rf_id": 911, "parent": 1411, "fw_parent": 2, "seq_id": -1, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[156,179,0,64,4,"cuda:0"]], "input_shapes": [[64]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: torch::autograd::AccumulateGrad", "id": 1411, "rf_id": 910, "parent": 847, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::empty", "id": 1418, "rf_id": 917, "parent": 1417, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[64,64,3,3],6,0,"cuda:0","<None>",0], "input_shapes": [[[],[],[],[]],[],[],[],[],[]], "input_types": ["GenericList[Int,Int,Int,Int]","Int","Int","Device","None","Int"],
+      "outputs": [[389,1419,0,36864,4,"cuda:0"]], "output_shapes": [[64,64,3,3]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::convolution_backward", "id": 1417, "rf_id": 916, "parent": 1416, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::convolution_backward(Tensor grad_output, Tensor input, Tensor weight, SymInt[]? bias_sizes, int[] stride, SymInt[] padding, int[] dilation, bool transposed, SymInt[] output_padding, int groups, bool[3] output_mask) -> (Tensor, Tensor, Tensor)",
+      "inputs": [[195,132,0,25690112,4,"cuda:0"],[77,93,0,25690112,4,"cuda:0"],[107,108,0,36864,4,"cuda:0"],[0],[1,1],[1,1],[1,1],false,[0,0],1,[true,true,false]], "input_shapes": [[128,64,56,56],[128,64,56,56],[64,64,3,3],[[]],[[],[]],[[],[]],[[],[]],[],[[],[]],[],[[],[],[]]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(float)","GenericList[Int]","GenericList[Int,Int]","GenericList[Int,Int]","GenericList[Int,Int]","Bool","GenericList[Int,Int]","Int","GenericList[Bool,Bool,Bool]"],
+      "outputs": [[156,113,0,25690112,4,"cuda:0"],[389,1419,0,36864,4,"cuda:0"],[23,0,0,0,0,""]], "output_shapes": [[128,64,56,56],[64,64,3,3],[]], "output_types": ["Tensor(float)","Tensor(float)","Tensor(nullptr (uninitialized))"]
+    },
+    {
+      "name": "ConvolutionBackward0", "id": 1416, "rf_id": 915, "parent": 1415, "fw_parent": 2, "seq_id": 737, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[195,132,0,25690112,4,"cuda:0"]], "input_shapes": [[128,64,56,56]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: ConvolutionBackward0", "id": 1415, "rf_id": 914, "parent": 847, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "detach", "id": 1423, "rf_id": 921, "parent": 1422, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [[389,1419,0,36864,4,"cuda:0"]], "input_shapes": [[64,64,3,3]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::detach", "id": 1422, "rf_id": 920, "parent": 1421, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::detach(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[389,1419,0,36864,4,"cuda:0"]], "input_shapes": [[64,64,3,3]], "input_types": ["Tensor(float)"],
+      "outputs": [[195,1419,0,36864,4,"cuda:0"]], "output_shapes": [[64,64,3,3]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "torch::autograd::AccumulateGrad", "id": 1421, "rf_id": 919, "parent": 1420, "fw_parent": 2, "seq_id": -1, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[389,1419,0,36864,4,"cuda:0"]], "input_shapes": [[64,64,3,3]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: torch::autograd::AccumulateGrad", "id": 1420, "rf_id": 918, "parent": 847, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::threshold_backward", "id": 1426, "rf_id": 924, "parent": 1425, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::threshold_backward(Tensor grad_output, Tensor self, Scalar threshold) -> Tensor",
+      "inputs": [[156,113,0,25690112,4,"cuda:0"],[389,93,0,25690112,4,"cuda:0"],0], "input_shapes": [[128,64,56,56],[128,64,56,56],[]], "input_types": ["Tensor(float)","Tensor(float)","Int"],
+      "outputs": [[77,132,0,25690112,4,"cuda:0"]], "output_shapes": [[128,64,56,56]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "ReluBackward0", "id": 1425, "rf_id": 923, "parent": 1424, "fw_parent": 2, "seq_id": 736, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[156,113,0,25690112,4,"cuda:0"]], "input_shapes": [[128,64,56,56]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: ReluBackward0", "id": 1424, "rf_id": 922, "parent": 847, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::empty", "id": 1430, "rf_id": 928, "parent": 1429, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[128,64,56,56],6,0,"cuda:0","<None>",0], "input_shapes": [[[],[],[],[]],[],[],[],[],[]], "input_types": ["GenericList[Int,Int,Int,Int]","Int","Int","Device","None","Int"],
+      "outputs": [[156,93,0,25690112,4,"cuda:0"]], "output_shapes": [[128,64,56,56]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty", "id": 1431, "rf_id": 929, "parent": 1429, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[64],6,0,"cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","Int","Device","None","None"],
+      "outputs": [[389,136,0,64,4,"cuda:0"]], "output_shapes": [[64]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty", "id": 1432, "rf_id": 930, "parent": 1429, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[64],6,0,"cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","Int","Device","None","None"],
+      "outputs": [[102,139,0,64,4,"cuda:0"]], "output_shapes": [[64]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::view", "id": 1433, "rf_id": 931, "parent": 1429, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::view(Tensor(a) self, SymInt[] size) -> Tensor(a)",
+      "inputs": [[80,81,0,64,4,"cuda:0"],[1,64,1,1]], "input_shapes": [[64],[[],[],[],[]]], "input_types": ["Tensor(float)","GenericList[Int,Int,Int,Int]"],
+      "outputs": [[274,81,0,64,4,"cuda:0"]], "output_shapes": [[1,64,1,1]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty", "id": 1434, "rf_id": 932, "parent": 1429, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[0],0,0,"cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","Int","Device","None","None"],
+      "outputs": [[274,57,0,0,1,"cuda:0"]], "output_shapes": [[0]], "output_types": ["Tensor(unsigned char)"]
+    },
+    {
+      "name": "aten::cudnn_batch_norm_backward", "id": 1429, "rf_id": 927, "parent": 1428, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::cudnn_batch_norm_backward(Tensor input, Tensor grad_output, Tensor weight, Tensor? running_mean, Tensor? running_var, Tensor? save_mean, Tensor? save_var, float epsilon, Tensor reserveSpace) -> (Tensor, Tensor, Tensor)",
+      "inputs": [[73,74,0,25690112,4,"cuda:0"],[77,132,0,25690112,4,"cuda:0"],[80,81,0,64,4,"cuda:0"],[84,85,0,64,4,"cuda:0"],[86,87,0,64,4,"cuda:0"],[95,97,0,64,4,"cuda:0"],[99,100,0,64,4,"cuda:0"],0.000010,[104,57,0,0,1,"cuda:0"]], "input_shapes": [[128,64,56,56],[128,64,56,56],[64],[64],[64],[64],[64],[],[0]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Double","Tensor(unsigned char)"],
+      "outputs": [[156,93,0,25690112,4,"cuda:0"],[389,136,0,64,4,"cuda:0"],[102,139,0,64,4,"cuda:0"]], "output_shapes": [[128,64,56,56],[64],[64]], "output_types": ["Tensor(float)","Tensor(float)","Tensor(float)"]
+    },
+    {
+      "name": "CudnnBatchNormBackward0", "id": 1428, "rf_id": 926, "parent": 1427, "fw_parent": 2, "seq_id": 735, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[77,132,0,25690112,4,"cuda:0"]], "input_shapes": [[128,64,56,56]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: CudnnBatchNormBackward0", "id": 1427, "rf_id": 925, "parent": 847, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "detach", "id": 1438, "rf_id": 936, "parent": 1437, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [[389,136,0,64,4,"cuda:0"]], "input_shapes": [[64]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::detach", "id": 1437, "rf_id": 935, "parent": 1436, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::detach(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[389,136,0,64,4,"cuda:0"]], "input_shapes": [[64]], "input_types": ["Tensor(float)"],
+      "outputs": [[73,136,0,64,4,"cuda:0"]], "output_shapes": [[64]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "torch::autograd::AccumulateGrad", "id": 1436, "rf_id": 934, "parent": 1435, "fw_parent": 2, "seq_id": -1, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[389,136,0,64,4,"cuda:0"]], "input_shapes": [[64]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: torch::autograd::AccumulateGrad", "id": 1435, "rf_id": 933, "parent": 847, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "detach", "id": 1442, "rf_id": 940, "parent": 1441, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [[102,139,0,64,4,"cuda:0"]], "input_shapes": [[64]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::detach", "id": 1441, "rf_id": 939, "parent": 1440, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::detach(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[102,139,0,64,4,"cuda:0"]], "input_shapes": [[64]], "input_types": ["Tensor(float)"],
+      "outputs": [[95,139,0,64,4,"cuda:0"]], "output_shapes": [[64]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "torch::autograd::AccumulateGrad", "id": 1440, "rf_id": 938, "parent": 1439, "fw_parent": 2, "seq_id": -1, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[102,139,0,64,4,"cuda:0"]], "input_shapes": [[64]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: torch::autograd::AccumulateGrad", "id": 1439, "rf_id": 937, "parent": 847, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::empty", "id": 1446, "rf_id": 944, "parent": 1445, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[64,64,3,3],6,0,"cuda:0","<None>",0], "input_shapes": [[[],[],[],[]],[],[],[],[],[]], "input_types": ["GenericList[Int,Int,Int,Int]","Int","Int","Device","None","Int"],
+      "outputs": [[389,832,0,36864,4,"cuda:0"]], "output_shapes": [[64,64,3,3]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::convolution_backward", "id": 1445, "rf_id": 943, "parent": 1444, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::convolution_backward(Tensor grad_output, Tensor input, Tensor weight, SymInt[]? bias_sizes, int[] stride, SymInt[] padding, int[] dilation, bool transposed, SymInt[] output_padding, int groups, bool[3] output_mask) -> (Tensor, Tensor, Tensor)",
+      "inputs": [[156,93,0,25690112,4,"cuda:0"],[56,64,0,25690112,4,"cuda:0"],[67,68,0,36864,4,"cuda:0"],[0],[1,1],[1,1],[1,1],false,[0,0],1,[true,true,false]], "input_shapes": [[128,64,56,56],[128,64,56,56],[64,64,3,3],[[]],[[],[]],[[],[]],[[],[]],[],[[],[]],[],[[],[],[]]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(float)","GenericList[Int]","GenericList[Int,Int]","GenericList[Int,Int]","GenericList[Int,Int]","Bool","GenericList[Int,Int]","Int","GenericList[Bool,Bool,Bool]"],
+      "outputs": [[102,113,0,25690112,4,"cuda:0"],[389,832,0,36864,4,"cuda:0"],[23,0,0,0,0,""]], "output_shapes": [[128,64,56,56],[64,64,3,3],[]], "output_types": ["Tensor(float)","Tensor(float)","Tensor(nullptr (uninitialized))"]
+    },
+    {
+      "name": "ConvolutionBackward0", "id": 1444, "rf_id": 942, "parent": 1443, "fw_parent": 2, "seq_id": 734, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[156,93,0,25690112,4,"cuda:0"]], "input_shapes": [[128,64,56,56]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::add_", "id": 1447, "rf_id": 945, "parent": 1443, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::add_.Tensor(Tensor(a!) self, Tensor other, *, Scalar alpha=1) -> Tensor(a!)",
+      "inputs": [[116,290,0,25690112,4,"cuda:0"],[102,113,0,25690112,4,"cuda:0"],1], "input_shapes": [[128,64,56,56],[128,64,56,56],[]], "input_types": ["Tensor(float)","Tensor(float)","Int"],
+      "outputs": [[116,290,0,25690112,4,"cuda:0"]], "output_shapes": [[128,64,56,56]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "autograd::engine::evaluate_function: ConvolutionBackward0", "id": 1443, "rf_id": 941, "parent": 847, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "detach", "id": 1451, "rf_id": 949, "parent": 1450, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [[389,832,0,36864,4,"cuda:0"]], "input_shapes": [[64,64,3,3]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::detach", "id": 1450, "rf_id": 948, "parent": 1449, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::detach(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[389,832,0,36864,4,"cuda:0"]], "input_shapes": [[64,64,3,3]], "input_types": ["Tensor(float)"],
+      "outputs": [[156,832,0,36864,4,"cuda:0"]], "output_shapes": [[64,64,3,3]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "torch::autograd::AccumulateGrad", "id": 1449, "rf_id": 947, "parent": 1448, "fw_parent": 2, "seq_id": -1, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[389,832,0,36864,4,"cuda:0"]], "input_shapes": [[64,64,3,3]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: torch::autograd::AccumulateGrad", "id": 1448, "rf_id": 946, "parent": 847, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::fill_", "id": 1456, "rf_id": 954, "parent": 1455, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::fill_.Scalar(Tensor(a!) self, Scalar value) -> Tensor(a!)",
+      "inputs": [[389,153,0,102760448,4,"cuda:0"],0], "input_shapes": [[128,64,112,112],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [[389,153,0,102760448,4,"cuda:0"]], "output_shapes": [[128,64,112,112]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::zero_", "id": 1455, "rf_id": 953, "parent": 1454, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::zero_(Tensor(a!) self) -> Tensor(a!)",
+      "inputs": [[389,153,0,102760448,4,"cuda:0"]], "input_shapes": [[128,64,112,112]], "input_types": ["Tensor(float)"],
+      "outputs": [[389,153,0,102760448,4,"cuda:0"]], "output_shapes": [[128,64,112,112]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::max_pool2d_with_indices_backward", "id": 1454, "rf_id": 952, "parent": 1453, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::max_pool2d_with_indices_backward(Tensor grad_output, Tensor self, int[2] kernel_size, int[2] stride, int[2] padding, int[2] dilation, bool ceil_mode, Tensor indices) -> Tensor",
+      "inputs": [[116,290,0,25690112,4,"cuda:0"],[31,47,0,102760448,4,"cuda:0"],[3,3],[2,2],[1,1],[1,1],false,[65,66,0,25690112,8,"cuda:0"]], "input_shapes": [[128,64,56,56],[128,64,112,112],[[],[]],[[],[]],[[],[]],[[],[]],[],[128,64,56,56]], "input_types": ["Tensor(float)","Tensor(float)","GenericList[Int,Int]","GenericList[Int,Int]","GenericList[Int,Int]","GenericList[Int,Int]","Bool","Tensor(long int)"],
+      "outputs": [[389,153,0,102760448,4,"cuda:0"]], "output_shapes": [[128,64,112,112]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "MaxPool2DWithIndicesBackward0", "id": 1453, "rf_id": 951, "parent": 1452, "fw_parent": 2, "seq_id": 733, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[116,290,0,25690112,4,"cuda:0"]], "input_shapes": [[128,64,56,56]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: MaxPool2DWithIndicesBackward0", "id": 1452, "rf_id": 950, "parent": 847, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::threshold_backward", "id": 1459, "rf_id": 957, "parent": 1458, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::threshold_backward(Tensor grad_output, Tensor self, Scalar threshold) -> Tensor",
+      "inputs": [[389,153,0,102760448,4,"cuda:0"],[116,47,0,102760448,4,"cuda:0"],0], "input_shapes": [[128,64,112,112],[128,64,112,112],[]], "input_types": ["Tensor(float)","Tensor(float)","Int"],
+      "outputs": [[56,290,0,102760448,4,"cuda:0"]], "output_shapes": [[128,64,112,112]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "ReluBackward0", "id": 1458, "rf_id": 956, "parent": 1457, "fw_parent": 2, "seq_id": 732, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[389,153,0,102760448,4,"cuda:0"]], "input_shapes": [[128,64,112,112]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: ReluBackward0", "id": 1457, "rf_id": 955, "parent": 847, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::empty", "id": 1463, "rf_id": 961, "parent": 1462, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[128,64,112,112],6,0,"cuda:0","<None>",0], "input_shapes": [[[],[],[],[]],[],[],[],[],[]], "input_types": ["GenericList[Int,Int,Int,Int]","Int","Int","Device","None","Int"],
+      "outputs": [[389,47,0,102760448,4,"cuda:0"]], "output_shapes": [[128,64,112,112]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty", "id": 1464, "rf_id": 962, "parent": 1462, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[64],6,0,"cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","Int","Device","None","None"],
+      "outputs": [[116,97,0,64,4,"cuda:0"]], "output_shapes": [[64]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty", "id": 1465, "rf_id": 963, "parent": 1462, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[64],6,0,"cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","Int","Device","None","None"],
+      "outputs": [[77,100,0,64,4,"cuda:0"]], "output_shapes": [[64]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::view", "id": 1466, "rf_id": 964, "parent": 1462, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::view(Tensor(a) self, SymInt[] size) -> Tensor(a)",
+      "inputs": [[34,35,0,64,4,"cuda:0"],[1,64,1,1]], "input_shapes": [[64],[[],[],[],[]]], "input_types": ["Tensor(float)","GenericList[Int,Int,Int,Int]"],
+      "outputs": [[274,35,0,64,4,"cuda:0"]], "output_shapes": [[1,64,1,1]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty", "id": 1467, "rf_id": 965, "parent": 1462, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[0],0,0,"cuda:0","<None>","<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","Int","Device","None","None"],
+      "outputs": [[274,57,0,0,1,"cuda:0"]], "output_shapes": [[0]], "output_types": ["Tensor(unsigned char)"]
+    },
+    {
+      "name": "aten::cudnn_batch_norm_backward", "id": 1462, "rf_id": 960, "parent": 1461, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::cudnn_batch_norm_backward(Tensor input, Tensor grad_output, Tensor weight, Tensor? running_mean, Tensor? running_var, Tensor? save_mean, Tensor? save_var, float epsilon, Tensor reserveSpace) -> (Tensor, Tensor, Tensor)",
+      "inputs": [[27,28,0,102760448,4,"cuda:0"],[56,290,0,102760448,4,"cuda:0"],[34,35,0,64,4,"cuda:0"],[38,39,0,64,4,"cuda:0"],[40,41,0,64,4,"cuda:0"],[49,51,0,64,4,"cuda:0"],[53,54,0,64,4,"cuda:0"],0.000010,[59,57,0,0,1,"cuda:0"]], "input_shapes": [[128,64,112,112],[128,64,112,112],[64],[64],[64],[64],[64],[],[0]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Tensor(float)","Double","Tensor(unsigned char)"],
+      "outputs": [[389,47,0,102760448,4,"cuda:0"],[116,97,0,64,4,"cuda:0"],[77,100,0,64,4,"cuda:0"]], "output_shapes": [[128,64,112,112],[64],[64]], "output_types": ["Tensor(float)","Tensor(float)","Tensor(float)"]
+    },
+    {
+      "name": "CudnnBatchNormBackward0", "id": 1461, "rf_id": 959, "parent": 1460, "fw_parent": 2, "seq_id": 731, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[56,290,0,102760448,4,"cuda:0"]], "input_shapes": [[128,64,112,112]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: CudnnBatchNormBackward0", "id": 1460, "rf_id": 958, "parent": 847, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "detach", "id": 1471, "rf_id": 969, "parent": 1470, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [[116,97,0,64,4,"cuda:0"]], "input_shapes": [[64]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::detach", "id": 1470, "rf_id": 968, "parent": 1469, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::detach(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[116,97,0,64,4,"cuda:0"]], "input_shapes": [[64]], "input_types": ["Tensor(float)"],
+      "outputs": [[27,97,0,64,4,"cuda:0"]], "output_shapes": [[64]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "torch::autograd::AccumulateGrad", "id": 1469, "rf_id": 967, "parent": 1468, "fw_parent": 2, "seq_id": -1, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[116,97,0,64,4,"cuda:0"]], "input_shapes": [[64]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: torch::autograd::AccumulateGrad", "id": 1468, "rf_id": 966, "parent": 847, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "detach", "id": 1475, "rf_id": 973, "parent": 1474, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [[77,100,0,64,4,"cuda:0"]], "input_shapes": [[64]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::detach", "id": 1474, "rf_id": 972, "parent": 1473, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::detach(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[77,100,0,64,4,"cuda:0"]], "input_shapes": [[64]], "input_types": ["Tensor(float)"],
+      "outputs": [[49,100,0,64,4,"cuda:0"]], "output_shapes": [[64]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "torch::autograd::AccumulateGrad", "id": 1473, "rf_id": 971, "parent": 1472, "fw_parent": 2, "seq_id": -1, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[77,100,0,64,4,"cuda:0"]], "input_shapes": [[64]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: torch::autograd::AccumulateGrad", "id": 1472, "rf_id": 970, "parent": 847, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::empty", "id": 1479, "rf_id": 977, "parent": 1478, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[64,3,7,7],6,0,"cuda:0","<None>",0], "input_shapes": [[[],[],[],[]],[],[],[],[],[]], "input_types": ["GenericList[Int,Int,Int,Int]","Int","Int","Device","None","Int"],
+      "outputs": [[77,1480,0,9408,4,"cuda:0"]], "output_shapes": [[64,3,7,7]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::convolution_backward", "id": 1478, "rf_id": 976, "parent": 1477, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::convolution_backward(Tensor grad_output, Tensor input, Tensor weight, SymInt[]? bias_sizes, int[] stride, SymInt[] padding, int[] dilation, bool transposed, SymInt[] output_padding, int groups, bool[3] output_mask) -> (Tensor, Tensor, Tensor)",
+      "inputs": [[389,47,0,102760448,4,"cuda:0"],[8,9,0,19267584,4,"cuda:0"],[20,21,0,9408,4,"cuda:0"],[0],[2,2],[3,3],[1,1],false,[0,0],1,[false,true,false]], "input_shapes": [[128,64,112,112],[128,3,224,224],[64,3,7,7],[[]],[[],[]],[[],[]],[[],[]],[],[[],[]],[],[[],[],[]]], "input_types": ["Tensor(float)","Tensor(float)","Tensor(float)","GenericList[Int]","GenericList[Int,Int]","GenericList[Int,Int]","GenericList[Int,Int]","Bool","GenericList[Int,Int]","Int","GenericList[Bool,Bool,Bool]"],
+      "outputs": [[23,0,0,0,0,""],[77,1480,0,9408,4,"cuda:0"],[23,0,0,0,0,""]], "output_shapes": [[],[64,3,7,7],[]], "output_types": ["Tensor(nullptr (uninitialized))","Tensor(float)","Tensor(nullptr (uninitialized))"]
+    },
+    {
+      "name": "ConvolutionBackward0", "id": 1477, "rf_id": 975, "parent": 1476, "fw_parent": 2, "seq_id": 730, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[389,47,0,102760448,4,"cuda:0"]], "input_shapes": [[128,64,112,112]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: ConvolutionBackward0", "id": 1476, "rf_id": 974, "parent": 847, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "detach", "id": 1484, "rf_id": 981, "parent": 1483, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [[77,1480,0,9408,4,"cuda:0"]], "input_shapes": [[64,3,7,7]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::detach", "id": 1483, "rf_id": 980, "parent": 1482, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "aten::detach(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[77,1480,0,9408,4,"cuda:0"]], "input_shapes": [[64,3,7,7]], "input_types": ["Tensor(float)"],
+      "outputs": [[116,1480,0,9408,4,"cuda:0"]], "output_shapes": [[64,3,7,7]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "torch::autograd::AccumulateGrad", "id": 1482, "rf_id": 979, "parent": 1481, "fw_parent": 2, "seq_id": -1, "scope": 1, "tid": 2, "fw_tid": 1, "op_schema": "",
+      "inputs": [[77,1480,0,9408,4,"cuda:0"]], "input_shapes": [[64,3,7,7]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "autograd::engine::evaluate_function: torch::autograd::AccumulateGrad", "id": 1481, "rf_id": 978, "parent": 847, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 2, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::result_type", "id": 1487, "rf_id": 984, "parent": 1486, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[116,1480,0,9408,4,"cuda:0"],0.000100], "input_shapes": [[64,3,7,7],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1488, "rf_id": 985, "parent": 1486, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[27,97,0,64,4,"cuda:0"],0.000100], "input_shapes": [[64],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1489, "rf_id": 986, "parent": 1486, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[49,100,0,64,4,"cuda:0"],0.000100], "input_shapes": [[64],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1490, "rf_id": 987, "parent": 1486, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[156,832,0,36864,4,"cuda:0"],0.000100], "input_shapes": [[64,64,3,3],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1491, "rf_id": 988, "parent": 1486, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[73,136,0,64,4,"cuda:0"],0.000100], "input_shapes": [[64],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1492, "rf_id": 989, "parent": 1486, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[95,139,0,64,4,"cuda:0"],0.000100], "input_shapes": [[64],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1493, "rf_id": 990, "parent": 1486, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[195,1419,0,36864,4,"cuda:0"],0.000100], "input_shapes": [[64,64,3,3],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1494, "rf_id": 991, "parent": 1486, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[134,176,0,64,4,"cuda:0"],0.000100], "input_shapes": [[64],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1495, "rf_id": 992, "parent": 1486, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[138,179,0,64,4,"cuda:0"],0.000100], "input_shapes": [[64],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1496, "rf_id": 993, "parent": 1486, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[235,1388,0,36864,4,"cuda:0"],0.000100], "input_shapes": [[64,64,3,3],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1497, "rf_id": 994, "parent": 1486, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[141,215,0,64,4,"cuda:0"],0.000100], "input_shapes": [[64],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1498, "rf_id": 995, "parent": 1486, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[174,218,0,64,4,"cuda:0"],0.000100], "input_shapes": [[64],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1499, "rf_id": 996, "parent": 1486, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[350,808,0,36864,4,"cuda:0"],0.000100], "input_shapes": [[64,64,3,3],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1500, "rf_id": 997, "parent": 1486, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[213,255,0,64,4,"cuda:0"],0.000100], "input_shapes": [[64],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1501, "rf_id": 998, "parent": 1486, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[217,258,0,64,4,"cuda:0"],0.000100], "input_shapes": [[64],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1502, "rf_id": 999, "parent": 1486, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[468,865,0,73728,4,"cuda:0"],0.000100], "input_shapes": [[128,64,3,3],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1503, "rf_id": 1000, "parent": 1486, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[220,294,0,128,4,"cuda:0"],0.000100], "input_shapes": [[128],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1504, "rf_id": 1001, "parent": 1486, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[253,297,0,128,4,"cuda:0"],0.000100], "input_shapes": [[128],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1505, "rf_id": 1002, "parent": 1486, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[582,1303,0,147456,4,"cuda:0"],0.000100], "input_shapes": [[128,128,3,3],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1506, "rf_id": 1003, "parent": 1486, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[292,331,0,128,4,"cuda:0"],0.000100], "input_shapes": [[128],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1507, "rf_id": 1004, "parent": 1486, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[296,334,0,128,4,"cuda:0"],0.000100], "input_shapes": [[128],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1508, "rf_id": 1005, "parent": 1486, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[308,1278,0,8192,4,"cuda:0"],0.000100], "input_shapes": [[128,64,1,1],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1509, "rf_id": 1006, "parent": 1486, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[329,370,0,128,4,"cuda:0"],0.000100], "input_shapes": [[128],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1510, "rf_id": 1007, "parent": 1486, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[333,373,0,128,4,"cuda:0"],0.000100], "input_shapes": [[128],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1511, "rf_id": 1008, "parent": 1486, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[429,1247,0,147456,4,"cuda:0"],0.000100], "input_shapes": [[128,128,3,3],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1512, "rf_id": 1009, "parent": 1486, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[299,409,0,128,4,"cuda:0"],0.000100], "input_shapes": [[128],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1513, "rf_id": 1010, "parent": 1486, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[368,412,0,128,4,"cuda:0"],0.000100], "input_shapes": [[128],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1514, "rf_id": 1011, "parent": 1486, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[530,1219,0,147456,4,"cuda:0"],0.000100], "input_shapes": [[128,128,3,3],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1515, "rf_id": 1012, "parent": 1486, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[407,449,0,128,4,"cuda:0"],0.000100], "input_shapes": [[128],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1516, "rf_id": 1013, "parent": 1486, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[411,1204,0,128,4,"cuda:0"],0.000100], "input_shapes": [[128],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1517, "rf_id": 1014, "parent": 1486, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[661,1187,0,294912,4,"cuda:0"],0.000100], "input_shapes": [[256,128,3,3],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1518, "rf_id": 1015, "parent": 1486, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[414,488,0,256,4,"cuda:0"],0.000100], "input_shapes": [[256],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1519, "rf_id": 1016, "parent": 1486, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[447,491,0,256,4,"cuda:0"],0.000100], "input_shapes": [[256],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1520, "rf_id": 1017, "parent": 1486, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[831,1159,0,589824,4,"cuda:0"],0.000100], "input_shapes": [[256,256,3,3],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1521, "rf_id": 1018, "parent": 1486, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[486,525,0,256,4,"cuda:0"],0.000100], "input_shapes": [[256],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1522, "rf_id": 1019, "parent": 1486, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[490,528,0,256,4,"cuda:0"],0.000100], "input_shapes": [[256],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1523, "rf_id": 1020, "parent": 1486, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[502,1134,0,32768,4,"cuda:0"],0.000100], "input_shapes": [[256,128,1,1],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1524, "rf_id": 1021, "parent": 1486, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[523,563,0,256,4,"cuda:0"],0.000100], "input_shapes": [[256],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1525, "rf_id": 1022, "parent": 1486, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[527,566,0,256,4,"cuda:0"],0.000100], "input_shapes": [[256],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1526, "rf_id": 1023, "parent": 1486, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[622,1103,0,589824,4,"cuda:0"],0.000100], "input_shapes": [[256,256,3,3],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1527, "rf_id": 1024, "parent": 1486, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[493,602,0,256,4,"cuda:0"],0.000100], "input_shapes": [[256],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1528, "rf_id": 1025, "parent": 1486, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[561,605,0,256,4,"cuda:0"],0.000100], "input_shapes": [[256],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1529, "rf_id": 1026, "parent": 1486, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[723,1075,0,589824,4,"cuda:0"],0.000100], "input_shapes": [[256,256,3,3],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1530, "rf_id": 1027, "parent": 1486, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[600,642,0,256,4,"cuda:0"],0.000100], "input_shapes": [[256],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1531, "rf_id": 1028, "parent": 1486, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[604,1060,0,256,4,"cuda:0"],0.000100], "input_shapes": [[256],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1532, "rf_id": 1029, "parent": 1486, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[811,1043,0,1179648,4,"cuda:0"],0.000100], "input_shapes": [[512,256,3,3],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1533, "rf_id": 1030, "parent": 1486, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[607,681,0,512,4,"cuda:0"],0.000100], "input_shapes": [[512],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1534, "rf_id": 1031, "parent": 1486, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[640,684,0,512,4,"cuda:0"],0.000100], "input_shapes": [[512],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1535, "rf_id": 1032, "parent": 1486, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[870,1015,0,2359296,4,"cuda:0"],0.000100], "input_shapes": [[512,512,3,3],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1536, "rf_id": 1033, "parent": 1486, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[679,718,0,512,4,"cuda:0"],0.000100], "input_shapes": [[512],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1537, "rf_id": 1034, "parent": 1486, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[683,721,0,512,4,"cuda:0"],0.000100], "input_shapes": [[512],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1538, "rf_id": 1035, "parent": 1486, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[695,824,0,131072,4,"cuda:0"],0.000100], "input_shapes": [[512,256,1,1],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1539, "rf_id": 1036, "parent": 1486, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[716,756,0,512,4,"cuda:0"],0.000100], "input_shapes": [[512],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1540, "rf_id": 1037, "parent": 1486, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[720,759,0,512,4,"cuda:0"],0.000100], "input_shapes": [[512],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1541, "rf_id": 1038, "parent": 1486, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[875,960,0,2359296,4,"cuda:0"],0.000100], "input_shapes": [[512,512,3,3],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1542, "rf_id": 1039, "parent": 1486, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[686,795,0,512,4,"cuda:0"],0.000100], "input_shapes": [[512],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1543, "rf_id": 1040, "parent": 1486, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[754,798,0,512,4,"cuda:0"],0.000100], "input_shapes": [[512],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1544, "rf_id": 1041, "parent": 1486, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[820,932,0,2359296,4,"cuda:0"],0.000100], "input_shapes": [[512,512,3,3],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1545, "rf_id": 1042, "parent": 1486, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[793,915,0,512,4,"cuda:0"],0.000100], "input_shapes": [[512],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1546, "rf_id": 1043, "parent": 1486, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[797,917,0,512,4,"cuda:0"],0.000100], "input_shapes": [[512],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1547, "rf_id": 1044, "parent": 1486, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[851,871,0,512000,4,"cuda:0"],0.000100], "input_shapes": [[1000,512],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1548, "rf_id": 1045, "parent": 1486, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[800,837,0,1000,4,"cuda:0"],0.000100], "input_shapes": [[1000],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::empty_strided", "id": 1549, "rf_id": 1046, "parent": 1486, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty_strided(SymInt[] size, SymInt[] stride, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor",
+      "inputs": [[64,3,7,7],[147,49,7,1],6,0,"cuda:0","<None>"], "input_shapes": [[[],[],[],[]],[[],[],[],[]],[],[],[],[]], "input_types": ["GenericList[Int,Int,Int,Int]","GenericList[Int,Int,Int,Int]","Int","Int","Device","None"],
+      "outputs": [[844,1550,0,9408,4,"cuda:0"]], "output_shapes": [[64,3,7,7]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty_strided", "id": 1551, "rf_id": 1047, "parent": 1486, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty_strided(SymInt[] size, SymInt[] stride, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor",
+      "inputs": [[64],[1],6,0,"cuda:0","<None>"], "input_shapes": [[[]],[[]],[],[],[],[]], "input_types": ["GenericList[Int]","GenericList[Int]","Int","Int","Device","None"],
+      "outputs": [[1552,452,0,64,4,"cuda:0"]], "output_shapes": [[64]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty_strided", "id": 1553, "rf_id": 1048, "parent": 1486, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty_strided(SymInt[] size, SymInt[] stride, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor",
+      "inputs": [[64],[1],6,0,"cuda:0","<None>"], "input_shapes": [[[]],[[]],[],[],[],[]], "input_types": ["GenericList[Int]","GenericList[Int]","Int","Int","Device","None"],
+      "outputs": [[1554,1555,0,64,4,"cuda:0"]], "output_shapes": [[64]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty_strided", "id": 1556, "rf_id": 1049, "parent": 1486, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty_strided(SymInt[] size, SymInt[] stride, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor",
+      "inputs": [[64,64,3,3],[576,9,3,1],6,0,"cuda:0","<None>"], "input_shapes": [[[],[],[],[]],[[],[],[],[]],[],[],[],[]], "input_types": ["GenericList[Int,Int,Int,Int]","GenericList[Int,Int,Int,Int]","Int","Int","Device","None"],
+      "outputs": [[823,1557,0,36864,4,"cuda:0"]], "output_shapes": [[64,64,3,3]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty_strided", "id": 1558, "rf_id": 1050, "parent": 1486, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty_strided(SymInt[] size, SymInt[] stride, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor",
+      "inputs": [[64],[1],6,0,"cuda:0","<None>"], "input_shapes": [[[]],[[]],[],[],[],[]], "input_types": ["GenericList[Int]","GenericList[Int]","Int","Int","Device","None"],
+      "outputs": [[725,1559,0,64,4,"cuda:0"]], "output_shapes": [[64]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty_strided", "id": 1560, "rf_id": 1051, "parent": 1486, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty_strided(SymInt[] size, SymInt[] stride, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor",
+      "inputs": [[64],[1],6,0,"cuda:0","<None>"], "input_shapes": [[[]],[[]],[],[],[],[]], "input_types": ["GenericList[Int]","GenericList[Int]","Int","Int","Device","None"],
+      "outputs": [[1561,1562,0,64,4,"cuda:0"]], "output_shapes": [[64]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty_strided", "id": 1563, "rf_id": 1052, "parent": 1486, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty_strided(SymInt[] size, SymInt[] stride, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor",
+      "inputs": [[64,64,3,3],[576,9,3,1],6,0,"cuda:0","<None>"], "input_shapes": [[[],[],[],[]],[[],[],[],[]],[],[],[],[]], "input_types": ["GenericList[Int,Int,Int,Int]","GenericList[Int,Int,Int,Int]","Int","Int","Device","None"],
+      "outputs": [[761,1564,0,36864,4,"cuda:0"]], "output_shapes": [[64,64,3,3]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty_strided", "id": 1565, "rf_id": 1053, "parent": 1486, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty_strided(SymInt[] size, SymInt[] stride, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor",
+      "inputs": [[64],[1],6,0,"cuda:0","<None>"], "input_shapes": [[[]],[[]],[],[],[],[]], "input_types": ["GenericList[Int]","GenericList[Int]","Int","Int","Device","None"],
+      "outputs": [[758,1566,0,64,4,"cuda:0"]], "output_shapes": [[64]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty_strided", "id": 1567, "rf_id": 1054, "parent": 1486, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty_strided(SymInt[] size, SymInt[] stride, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor",
+      "inputs": [[64],[1],6,0,"cuda:0","<None>"], "input_shapes": [[[]],[[]],[],[],[],[]], "input_types": ["GenericList[Int]","GenericList[Int]","Int","Int","Device","None"],
+      "outputs": [[1568,645,0,64,4,"cuda:0"]], "output_shapes": [[64]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty_strided", "id": 1569, "rf_id": 1055, "parent": 1486, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty_strided(SymInt[] size, SymInt[] stride, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor",
+      "inputs": [[64,64,3,3],[576,9,3,1],6,0,"cuda:0","<None>"], "input_shapes": [[[],[],[],[]],[[],[],[],[]],[],[],[],[]], "input_types": ["GenericList[Int,Int,Int,Int]","GenericList[Int,Int,Int,Int]","Int","Int","Device","None"],
+      "outputs": [[1570,1571,0,36864,4,"cuda:0"]], "output_shapes": [[64,64,3,3]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty_strided", "id": 1572, "rf_id": 1056, "parent": 1486, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty_strided(SymInt[] size, SymInt[] stride, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor",
+      "inputs": [[64],[1],6,0,"cuda:0","<None>"], "input_shapes": [[[]],[[]],[],[],[],[]], "input_types": ["GenericList[Int]","GenericList[Int]","Int","Int","Device","None"],
+      "outputs": [[878,1573,0,64,4,"cuda:0"]], "output_shapes": [[64]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty_strided", "id": 1574, "rf_id": 1057, "parent": 1486, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty_strided(SymInt[] size, SymInt[] stride, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor",
+      "inputs": [[64],[1],6,0,"cuda:0","<None>"], "input_shapes": [[[]],[[]],[],[],[],[]], "input_types": ["GenericList[Int]","GenericList[Int]","Int","Int","Device","None"],
+      "outputs": [[644,1575,0,64,4,"cuda:0"]], "output_shapes": [[64]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty_strided", "id": 1576, "rf_id": 1058, "parent": 1486, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty_strided(SymInt[] size, SymInt[] stride, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor",
+      "inputs": [[64,64,3,3],[576,9,3,1],6,0,"cuda:0","<None>"], "input_shapes": [[[],[],[],[]],[[],[],[],[]],[],[],[],[]], "input_types": ["GenericList[Int,Int,Int,Int]","GenericList[Int,Int,Int,Int]","Int","Int","Device","None"],
+      "outputs": [[570,1577,0,36864,4,"cuda:0"]], "output_shapes": [[64,64,3,3]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty_strided", "id": 1578, "rf_id": 1059, "parent": 1486, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty_strided(SymInt[] size, SymInt[] stride, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor",
+      "inputs": [[64],[1],6,0,"cuda:0","<None>"], "input_shapes": [[[]],[[]],[],[],[],[]], "input_types": ["GenericList[Int]","GenericList[Int]","Int","Int","Device","None"],
+      "outputs": [[565,1579,0,64,4,"cuda:0"]], "output_shapes": [[64]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty_strided", "id": 1580, "rf_id": 1060, "parent": 1486, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty_strided(SymInt[] size, SymInt[] stride, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor",
+      "inputs": [[64],[1],6,0,"cuda:0","<None>"], "input_shapes": [[[]],[[]],[],[],[],[]], "input_types": ["GenericList[Int]","GenericList[Int]","Int","Int","Device","None"],
+      "outputs": [[1581,1582,0,64,4,"cuda:0"]], "output_shapes": [[64]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty_strided", "id": 1583, "rf_id": 1061, "parent": 1486, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty_strided(SymInt[] size, SymInt[] stride, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor",
+      "inputs": [[128,64,3,3],[576,9,3,1],6,0,"cuda:0","<None>"], "input_shapes": [[[],[],[],[]],[[],[],[],[]],[],[],[],[]], "input_types": ["GenericList[Int,Int,Int,Int]","GenericList[Int,Int,Int,Int]","Int","Int","Device","None"],
+      "outputs": [[609,1584,0,73728,4,"cuda:0"]], "output_shapes": [[128,64,3,3]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty_strided", "id": 1585, "rf_id": 1062, "parent": 1486, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty_strided(SymInt[] size, SymInt[] stride, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor",
+      "inputs": [[128],[1],6,0,"cuda:0","<None>"], "input_shapes": [[[]],[[]],[],[],[],[]], "input_types": ["GenericList[Int]","GenericList[Int]","Int","Int","Device","None"],
+      "outputs": [[1586,1587,0,128,4,"cuda:0"]], "output_shapes": [[128]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty_strided", "id": 1588, "rf_id": 1063, "parent": 1486, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty_strided(SymInt[] size, SymInt[] stride, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor",
+      "inputs": [[128],[1],6,0,"cuda:0","<None>"], "input_shapes": [[[]],[[]],[],[],[],[]], "input_types": ["GenericList[Int]","GenericList[Int]","Int","Int","Device","None"],
+      "outputs": [[647,1589,0,128,4,"cuda:0"]], "output_shapes": [[128]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty_strided", "id": 1590, "rf_id": 1064, "parent": 1486, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty_strided(SymInt[] size, SymInt[] stride, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor",
+      "inputs": [[128,128,3,3],[1152,9,3,1],6,0,"cuda:0","<None>"], "input_shapes": [[[],[],[],[]],[[],[],[],[]],[],[],[],[]], "input_types": ["GenericList[Int,Int,Int,Int]","GenericList[Int,Int,Int,Int]","Int","Int","Device","None"],
+      "outputs": [[649,1591,0,147456,4,"cuda:0"]], "output_shapes": [[128,128,3,3]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty_strided", "id": 1592, "rf_id": 1065, "parent": 1486, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty_strided(SymInt[] size, SymInt[] stride, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor",
+      "inputs": [[128],[1],6,0,"cuda:0","<None>"], "input_shapes": [[[]],[[]],[],[],[],[]], "input_types": ["GenericList[Int]","GenericList[Int]","Int","Int","Device","None"],
+      "outputs": [[568,1593,0,128,4,"cuda:0"]], "output_shapes": [[128]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty_strided", "id": 1594, "rf_id": 1066, "parent": 1486, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty_strided(SymInt[] size, SymInt[] stride, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor",
+      "inputs": [[128],[1],6,0,"cuda:0","<None>"], "input_shapes": [[[]],[[]],[],[],[],[]], "input_types": ["GenericList[Int]","GenericList[Int]","Int","Int","Device","None"],
+      "outputs": [[416,1595,0,128,4,"cuda:0"]], "output_shapes": [[128]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty_strided", "id": 1596, "rf_id": 1067, "parent": 1486, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty_strided(SymInt[] size, SymInt[] stride, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor",
+      "inputs": [[128,64,1,1],[64,1,1,1],6,0,"cuda:0","<None>"], "input_shapes": [[[],[],[],[]],[[],[],[],[]],[],[],[],[]], "input_types": ["GenericList[Int,Int,Int,Int]","GenericList[Int,Int,Int,Int]","Int","Int","Device","None"],
+      "outputs": [[1597,1598,0,8192,4,"cuda:0"]], "output_shapes": [[128,64,1,1]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty_strided", "id": 1599, "rf_id": 1068, "parent": 1486, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty_strided(SymInt[] size, SymInt[] stride, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor",
+      "inputs": [[128],[1],6,0,"cuda:0","<None>"], "input_shapes": [[[]],[[]],[],[],[],[]], "input_types": ["GenericList[Int]","GenericList[Int]","Int","Int","Device","None"],
+      "outputs": [[454,1600,0,128,4,"cuda:0"]], "output_shapes": [[128]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty_strided", "id": 1601, "rf_id": 1069, "parent": 1486, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty_strided(SymInt[] size, SymInt[] stride, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor",
+      "inputs": [[128],[1],6,0,"cuda:0","<None>"], "input_shapes": [[[]],[[]],[],[],[],[]], "input_types": ["GenericList[Int]","GenericList[Int]","Int","Int","Device","None"],
+      "outputs": [[456,1602,0,128,4,"cuda:0"]], "output_shapes": [[128]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty_strided", "id": 1603, "rf_id": 1070, "parent": 1486, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty_strided(SymInt[] size, SymInt[] stride, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor",
+      "inputs": [[128,128,3,3],[1152,9,3,1],6,0,"cuda:0","<None>"], "input_shapes": [[[],[],[],[]],[[],[],[],[]],[],[],[],[]], "input_types": ["GenericList[Int,Int,Int,Int]","GenericList[Int,Int,Int,Int]","Int","Int","Device","None"],
+      "outputs": [[451,1604,0,147456,4,"cuda:0"]], "output_shapes": [[128,128,3,3]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty_strided", "id": 1605, "rf_id": 1071, "parent": 1486, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty_strided(SymInt[] size, SymInt[] stride, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor",
+      "inputs": [[128],[1],6,0,"cuda:0","<None>"], "input_shapes": [[[]],[[]],[],[],[],[]], "input_types": ["GenericList[Int]","GenericList[Int]","Int","Int","Device","None"],
+      "outputs": [[532,1606,0,128,4,"cuda:0"]], "output_shapes": [[128]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty_strided", "id": 1607, "rf_id": 1072, "parent": 1486, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty_strided(SymInt[] size, SymInt[] stride, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor",
+      "inputs": [[128],[1],6,0,"cuda:0","<None>"], "input_shapes": [[[]],[[]],[],[],[],[]], "input_types": ["GenericList[Int]","GenericList[Int]","Int","Int","Device","None"],
+      "outputs": [[1608,1609,0,128,4,"cuda:0"]], "output_shapes": [[128]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty_strided", "id": 1610, "rf_id": 1073, "parent": 1486, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty_strided(SymInt[] size, SymInt[] stride, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor",
+      "inputs": [[128,128,3,3],[1152,9,3,1],6,0,"cuda:0","<None>"], "input_shapes": [[[],[],[],[]],[[],[],[],[]],[],[],[],[]], "input_types": ["GenericList[Int,Int,Int,Int]","GenericList[Int,Int,Int,Int]","Int","Int","Device","None"],
+      "outputs": [[104,1611,0,147456,4,"cuda:0"]], "output_shapes": [[128,128,3,3]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty_strided", "id": 1612, "rf_id": 1074, "parent": 1486, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty_strided(SymInt[] size, SymInt[] stride, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor",
+      "inputs": [[128],[1],6,0,"cuda:0","<None>"], "input_shapes": [[[]],[[]],[],[],[],[]], "input_types": ["GenericList[Int]","GenericList[Int]","Int","Int","Device","None"],
+      "outputs": [[1613,1614,0,128,4,"cuda:0"]], "output_shapes": [[128]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty_strided", "id": 1615, "rf_id": 1075, "parent": 1486, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty_strided(SymInt[] size, SymInt[] stride, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor",
+      "inputs": [[128],[1],6,0,"cuda:0","<None>"], "input_shapes": [[[]],[[]],[],[],[],[]], "input_types": ["GenericList[Int]","GenericList[Int]","Int","Int","Device","None"],
+      "outputs": [[1616,1617,0,128,4,"cuda:0"]], "output_shapes": [[128]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty_strided", "id": 1618, "rf_id": 1076, "parent": 1486, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty_strided(SymInt[] size, SymInt[] stride, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor",
+      "inputs": [[256,128,3,3],[1152,9,3,1],6,0,"cuda:0","<None>"], "input_shapes": [[[],[],[],[]],[[],[],[],[]],[],[],[],[]], "input_types": ["GenericList[Int,Int,Int,Int]","GenericList[Int,Int,Int,Int]","Int","Int","Device","None"],
+      "outputs": [[1619,1620,0,294912,4,"cuda:0"]], "output_shapes": [[256,128,3,3]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty_strided", "id": 1621, "rf_id": 1077, "parent": 1486, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty_strided(SymInt[] size, SymInt[] stride, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor",
+      "inputs": [[256],[1],6,0,"cuda:0","<None>"], "input_shapes": [[[]],[[]],[],[],[],[]], "input_types": ["GenericList[Int]","GenericList[Int]","Int","Int","Device","None"],
+      "outputs": [[1622,1623,0,256,4,"cuda:0"]], "output_shapes": [[256]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty_strided", "id": 1624, "rf_id": 1078, "parent": 1486, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty_strided(SymInt[] size, SymInt[] stride, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor",
+      "inputs": [[256],[1],6,0,"cuda:0","<None>"], "input_shapes": [[[]],[[]],[],[],[],[]], "input_types": ["GenericList[Int]","GenericList[Int]","Int","Int","Device","None"],
+      "outputs": [[65,1625,0,256,4,"cuda:0"]], "output_shapes": [[256]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty_strided", "id": 1626, "rf_id": 1079, "parent": 1486, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty_strided(SymInt[] size, SymInt[] stride, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor",
+      "inputs": [[256,256,3,3],[2304,9,3,1],6,0,"cuda:0","<None>"], "input_shapes": [[[],[],[],[]],[[],[],[],[]],[],[],[],[]], "input_types": ["GenericList[Int,Int,Int,Int]","GenericList[Int,Int,Int,Int]","Int","Int","Device","None"],
+      "outputs": [[31,1627,0,589824,4,"cuda:0"]], "output_shapes": [[256,256,3,3]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty_strided", "id": 1628, "rf_id": 1080, "parent": 1486, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty_strided(SymInt[] size, SymInt[] stride, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor",
+      "inputs": [[256],[1],6,0,"cuda:0","<None>"], "input_shapes": [[[]],[[]],[],[],[],[]], "input_types": ["GenericList[Int]","GenericList[Int]","Int","Int","Device","None"],
+      "outputs": [[102,1629,0,256,4,"cuda:0"]], "output_shapes": [[256]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty_strided", "id": 1630, "rf_id": 1081, "parent": 1486, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty_strided(SymInt[] size, SymInt[] stride, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor",
+      "inputs": [[256],[1],6,0,"cuda:0","<None>"], "input_shapes": [[[]],[[]],[],[],[],[]], "input_types": ["GenericList[Int]","GenericList[Int]","Int","Int","Device","None"],
+      "outputs": [[802,1631,0,256,4,"cuda:0"]], "output_shapes": [[256]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty_strided", "id": 1632, "rf_id": 1082, "parent": 1486, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty_strided(SymInt[] size, SymInt[] stride, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor",
+      "inputs": [[256,128,1,1],[128,1,1,1],6,0,"cuda:0","<None>"], "input_shapes": [[[],[],[],[]],[[],[],[],[]],[],[],[],[]], "input_types": ["GenericList[Int,Int,Int,Int]","GenericList[Int,Int,Int,Int]","Int","Int","Device","None"],
+      "outputs": [[1633,1634,0,32768,4,"cuda:0"]], "output_shapes": [[256,128,1,1]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty_strided", "id": 1635, "rf_id": 1083, "parent": 1486, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty_strided(SymInt[] size, SymInt[] stride, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor",
+      "inputs": [[256],[1],6,0,"cuda:0","<None>"], "input_shapes": [[[]],[[]],[],[],[],[]], "input_types": ["GenericList[Int]","GenericList[Int]","Int","Int","Device","None"],
+      "outputs": [[1636,1637,0,256,4,"cuda:0"]], "output_shapes": [[256]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty_strided", "id": 1638, "rf_id": 1084, "parent": 1486, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty_strided(SymInt[] size, SymInt[] stride, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor",
+      "inputs": [[256],[1],6,0,"cuda:0","<None>"], "input_shapes": [[[]],[[]],[],[],[],[]], "input_types": ["GenericList[Int]","GenericList[Int]","Int","Int","Device","None"],
+      "outputs": [[1639,1640,0,256,4,"cuda:0"]], "output_shapes": [[256]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty_strided", "id": 1641, "rf_id": 1085, "parent": 1486, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty_strided(SymInt[] size, SymInt[] stride, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor",
+      "inputs": [[256,256,3,3],[2304,9,3,1],6,0,"cuda:0","<None>"], "input_shapes": [[[],[],[],[]],[[],[],[],[]],[],[],[],[]], "input_types": ["GenericList[Int,Int,Int,Int]","GenericList[Int,Int,Int,Int]","Int","Int","Device","None"],
+      "outputs": [[1642,1643,0,589824,4,"cuda:0"]], "output_shapes": [[256,256,3,3]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty_strided", "id": 1644, "rf_id": 1086, "parent": 1486, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty_strided(SymInt[] size, SymInt[] stride, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor",
+      "inputs": [[256],[1],6,0,"cuda:0","<None>"], "input_shapes": [[[]],[[]],[],[],[],[]], "input_types": ["GenericList[Int]","GenericList[Int]","Int","Int","Device","None"],
+      "outputs": [[1645,1646,0,256,4,"cuda:0"]], "output_shapes": [[256]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty_strided", "id": 1647, "rf_id": 1087, "parent": 1486, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty_strided(SymInt[] size, SymInt[] stride, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor",
+      "inputs": [[256],[1],6,0,"cuda:0","<None>"], "input_shapes": [[[]],[[]],[],[],[],[]], "input_types": ["GenericList[Int]","GenericList[Int]","Int","Int","Device","None"],
+      "outputs": [[1648,1649,0,256,4,"cuda:0"]], "output_shapes": [[256]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty_strided", "id": 1650, "rf_id": 1088, "parent": 1486, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty_strided(SymInt[] size, SymInt[] stride, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor",
+      "inputs": [[256,256,3,3],[2304,9,3,1],6,0,"cuda:0","<None>"], "input_shapes": [[[],[],[],[]],[[],[],[],[]],[],[],[],[]], "input_types": ["GenericList[Int,Int,Int,Int]","GenericList[Int,Int,Int,Int]","Int","Int","Device","None"],
+      "outputs": [[1651,1652,0,589824,4,"cuda:0"]], "output_shapes": [[256,256,3,3]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty_strided", "id": 1653, "rf_id": 1089, "parent": 1486, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty_strided(SymInt[] size, SymInt[] stride, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor",
+      "inputs": [[256],[1],6,0,"cuda:0","<None>"], "input_shapes": [[[]],[[]],[],[],[],[]], "input_types": ["GenericList[Int]","GenericList[Int]","Int","Int","Device","None"],
+      "outputs": [[1654,1655,0,256,4,"cuda:0"]], "output_shapes": [[256]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty_strided", "id": 1656, "rf_id": 1090, "parent": 1486, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty_strided(SymInt[] size, SymInt[] stride, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor",
+      "inputs": [[256],[1],6,0,"cuda:0","<None>"], "input_shapes": [[[]],[[]],[],[],[],[]], "input_types": ["GenericList[Int]","GenericList[Int]","Int","Int","Device","None"],
+      "outputs": [[1657,1658,0,256,4,"cuda:0"]], "output_shapes": [[256]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty_strided", "id": 1659, "rf_id": 1091, "parent": 1486, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty_strided(SymInt[] size, SymInt[] stride, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor",
+      "inputs": [[512,256,3,3],[2304,9,3,1],6,0,"cuda:0","<None>"], "input_shapes": [[[],[],[],[]],[[],[],[],[]],[],[],[],[]], "input_types": ["GenericList[Int,Int,Int,Int]","GenericList[Int,Int,Int,Int]","Int","Int","Device","None"],
+      "outputs": [[1660,426,0,1179648,4,"cuda:0"]], "output_shapes": [[512,256,3,3]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty_strided", "id": 1661, "rf_id": 1092, "parent": 1486, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty_strided(SymInt[] size, SymInt[] stride, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor",
+      "inputs": [[512],[1],6,0,"cuda:0","<None>"], "input_shapes": [[[]],[[]],[],[],[],[]], "input_types": ["GenericList[Int]","GenericList[Int]","Int","Int","Device","None"],
+      "outputs": [[1662,1663,0,512,4,"cuda:0"]], "output_shapes": [[512]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty_strided", "id": 1664, "rf_id": 1093, "parent": 1486, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty_strided(SymInt[] size, SymInt[] stride, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor",
+      "inputs": [[512],[1],6,0,"cuda:0","<None>"], "input_shapes": [[[]],[[]],[],[],[],[]], "input_types": ["GenericList[Int]","GenericList[Int]","Int","Int","Device","None"],
+      "outputs": [[1665,1666,0,512,4,"cuda:0"]], "output_shapes": [[512]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty_strided", "id": 1667, "rf_id": 1094, "parent": 1486, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty_strided(SymInt[] size, SymInt[] stride, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor",
+      "inputs": [[512,512,3,3],[4608,9,3,1],6,0,"cuda:0","<None>"], "input_shapes": [[[],[],[],[]],[[],[],[],[]],[],[],[],[]], "input_types": ["GenericList[Int,Int,Int,Int]","GenericList[Int,Int,Int,Int]","Int","Int","Device","None"],
+      "outputs": [[1668,1669,0,2359296,4,"cuda:0"]], "output_shapes": [[512,512,3,3]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty_strided", "id": 1670, "rf_id": 1095, "parent": 1486, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty_strided(SymInt[] size, SymInt[] stride, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor",
+      "inputs": [[512],[1],6,0,"cuda:0","<None>"], "input_shapes": [[[]],[[]],[],[],[],[]], "input_types": ["GenericList[Int]","GenericList[Int]","Int","Int","Device","None"],
+      "outputs": [[1671,1672,0,512,4,"cuda:0"]], "output_shapes": [[512]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty_strided", "id": 1673, "rf_id": 1096, "parent": 1486, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty_strided(SymInt[] size, SymInt[] stride, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor",
+      "inputs": [[512],[1],6,0,"cuda:0","<None>"], "input_shapes": [[[]],[[]],[],[],[],[]], "input_types": ["GenericList[Int]","GenericList[Int]","Int","Int","Device","None"],
+      "outputs": [[1674,1675,0,512,4,"cuda:0"]], "output_shapes": [[512]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty_strided", "id": 1676, "rf_id": 1097, "parent": 1486, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty_strided(SymInt[] size, SymInt[] stride, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor",
+      "inputs": [[512,256,1,1],[256,1,1,1],6,0,"cuda:0","<None>"], "input_shapes": [[[],[],[],[]],[[],[],[],[]],[],[],[],[]], "input_types": ["GenericList[Int,Int,Int,Int]","GenericList[Int,Int,Int,Int]","Int","Int","Device","None"],
+      "outputs": [[1677,1678,0,131072,4,"cuda:0"]], "output_shapes": [[512,256,1,1]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty_strided", "id": 1679, "rf_id": 1098, "parent": 1486, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty_strided(SymInt[] size, SymInt[] stride, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor",
+      "inputs": [[512],[1],6,0,"cuda:0","<None>"], "input_shapes": [[[]],[[]],[],[],[],[]], "input_types": ["GenericList[Int]","GenericList[Int]","Int","Int","Device","None"],
+      "outputs": [[1680,1681,0,512,4,"cuda:0"]], "output_shapes": [[512]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty_strided", "id": 1682, "rf_id": 1099, "parent": 1486, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty_strided(SymInt[] size, SymInt[] stride, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor",
+      "inputs": [[512],[1],6,0,"cuda:0","<None>"], "input_shapes": [[[]],[[]],[],[],[],[]], "input_types": ["GenericList[Int]","GenericList[Int]","Int","Int","Device","None"],
+      "outputs": [[1683,1684,0,512,4,"cuda:0"]], "output_shapes": [[512]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty_strided", "id": 1685, "rf_id": 1100, "parent": 1486, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty_strided(SymInt[] size, SymInt[] stride, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor",
+      "inputs": [[512,512,3,3],[4608,9,3,1],6,0,"cuda:0","<None>"], "input_shapes": [[[],[],[],[]],[[],[],[],[]],[],[],[],[]], "input_types": ["GenericList[Int,Int,Int,Int]","GenericList[Int,Int,Int,Int]","Int","Int","Device","None"],
+      "outputs": [[1686,1687,0,2359296,4,"cuda:0"]], "output_shapes": [[512,512,3,3]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty_strided", "id": 1688, "rf_id": 1101, "parent": 1486, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty_strided(SymInt[] size, SymInt[] stride, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor",
+      "inputs": [[512],[1],6,0,"cuda:0","<None>"], "input_shapes": [[[]],[[]],[],[],[],[]], "input_types": ["GenericList[Int]","GenericList[Int]","Int","Int","Device","None"],
+      "outputs": [[1689,1690,0,512,4,"cuda:0"]], "output_shapes": [[512]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty_strided", "id": 1691, "rf_id": 1102, "parent": 1486, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty_strided(SymInt[] size, SymInt[] stride, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor",
+      "inputs": [[512],[1],6,0,"cuda:0","<None>"], "input_shapes": [[[]],[[]],[],[],[],[]], "input_types": ["GenericList[Int]","GenericList[Int]","Int","Int","Device","None"],
+      "outputs": [[1692,1693,0,512,4,"cuda:0"]], "output_shapes": [[512]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty_strided", "id": 1694, "rf_id": 1103, "parent": 1486, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty_strided(SymInt[] size, SymInt[] stride, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor",
+      "inputs": [[512,512,3,3],[4608,9,3,1],6,0,"cuda:0","<None>"], "input_shapes": [[[],[],[],[]],[[],[],[],[]],[],[],[],[]], "input_types": ["GenericList[Int,Int,Int,Int]","GenericList[Int,Int,Int,Int]","Int","Int","Device","None"],
+      "outputs": [[1695,1696,0,2359296,4,"cuda:0"]], "output_shapes": [[512,512,3,3]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty_strided", "id": 1697, "rf_id": 1104, "parent": 1486, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty_strided(SymInt[] size, SymInt[] stride, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor",
+      "inputs": [[512],[1],6,0,"cuda:0","<None>"], "input_shapes": [[[]],[[]],[],[],[],[]], "input_types": ["GenericList[Int]","GenericList[Int]","Int","Int","Device","None"],
+      "outputs": [[1698,1699,0,512,4,"cuda:0"]], "output_shapes": [[512]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty_strided", "id": 1700, "rf_id": 1105, "parent": 1486, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty_strided(SymInt[] size, SymInt[] stride, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor",
+      "inputs": [[512],[1],6,0,"cuda:0","<None>"], "input_shapes": [[[]],[[]],[],[],[],[]], "input_types": ["GenericList[Int]","GenericList[Int]","Int","Int","Device","None"],
+      "outputs": [[1701,1702,0,512,4,"cuda:0"]], "output_shapes": [[512]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty_strided", "id": 1703, "rf_id": 1106, "parent": 1486, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty_strided(SymInt[] size, SymInt[] stride, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor",
+      "inputs": [[1000,512],[512,1],6,0,"cuda:0","<None>"], "input_shapes": [[[],[]],[[],[]],[],[],[],[]], "input_types": ["GenericList[Int,Int]","GenericList[Int,Int]","Int","Int","Device","None"],
+      "outputs": [[1704,1705,0,512000,4,"cuda:0"]], "output_shapes": [[1000,512]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty_strided", "id": 1706, "rf_id": 1107, "parent": 1486, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty_strided(SymInt[] size, SymInt[] stride, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor",
+      "inputs": [[1000],[1],6,0,"cuda:0","<None>"], "input_shapes": [[[]],[[]],[],[],[],[]], "input_types": ["GenericList[Int]","GenericList[Int]","Int","Int","Device","None"],
+      "outputs": [[1707,1708,0,1000,4,"cuda:0"]], "output_shapes": [[1000]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::_foreach_add", "id": 1486, "rf_id": 983, "parent": 1485, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::_foreach_add.List(Tensor[] self, Tensor[] other, *, Scalar alpha=1) -> Tensor[]",
+      "inputs": [[[116,1480,0,9408,4,"cuda:0"],[27,97,0,64,4,"cuda:0"],[49,100,0,64,4,"cuda:0"],[156,832,0,36864,4,"cuda:0"],[73,136,0,64,4,"cuda:0"],[95,139,0,64,4,"cuda:0"],[195,1419,0,36864,4,"cuda:0"],[134,176,0,64,4,"cuda:0"],[138,179,0,64,4,"cuda:0"],[235,1388,0,36864,4,"cuda:0"],[141,215,0,64,4,"cuda:0"],[174,218,0,64,4,"cuda:0"],[350,808,0,36864,4,"cuda:0"],[213,255,0,64,4,"cuda:0"],[217,258,0,64,4,"cuda:0"],[468,865,0,73728,4,"cuda:0"],[220,294,0,128,4,"cuda:0"],[253,297,0,128,4,"cuda:0"],[582,1303,0,147456,4,"cuda:0"],[292,331,0,128,4,"cuda:0"],[296,334,0,128,4,"cuda:0"],[308,1278,0,8192,4,"cuda:0"],[329,370,0,128,4,"cuda:0"],[333,373,0,128,4,"cuda:0"],[429,1247,0,147456,4,"cuda:0"],[299,409,0,128,4,"cuda:0"],[368,412,0,128,4,"cuda:0"],[530,1219,0,147456,4,"cuda:0"],[407,449,0,128,4,"cuda:0"],[411,1204,0,128,4,"cuda:0"],[661,1187,0,294912,4,"cuda:0"],[414,488,0,256,4,"cuda:0"],[447,491,0,256,4,"cuda:0"],[831,1159,0,589824,4,"cuda:0"],[486,525,0,256,4,"cuda:0"],[490,528,0,256,4,"cuda:0"],[502,1134,0,32768,4,"cuda:0"],[523,563,0,256,4,"cuda:0"],[527,566,0,256,4,"cuda:0"],[622,1103,0,589824,4,"cuda:0"],[493,602,0,256,4,"cuda:0"],[561,605,0,256,4,"cuda:0"],[723,1075,0,589824,4,"cuda:0"],[600,642,0,256,4,"cuda:0"],[604,1060,0,256,4,"cuda:0"],[811,1043,0,1179648,4,"cuda:0"],[607,681,0,512,4,"cuda:0"],[640,684,0,512,4,"cuda:0"],[870,1015,0,2359296,4,"cuda:0"],[679,718,0,512,4,"cuda:0"],[683,721,0,512,4,"cuda:0"],[695,824,0,131072,4,"cuda:0"],[716,756,0,512,4,"cuda:0"],[720,759,0,512,4,"cuda:0"],[875,960,0,2359296,4,"cuda:0"],[686,795,0,512,4,"cuda:0"],[754,798,0,512,4,"cuda:0"],[820,932,0,2359296,4,"cuda:0"],[793,915,0,512,4,"cuda:0"],[797,917,0,512,4,"cuda:0"],[851,871,0,512000,4,"cuda:0"],[800,837,0,1000,4,"cuda:0"]],[[20,21,0,9408,4,"cuda:0"],[34,35,0,64,4,"cuda:0"],[36,37,0,64,4,"cuda:0"],[67,68,0,36864,4,"cuda:0"],[80,81,0,64,4,"cuda:0"],[82,83,0,64,4,"cuda:0"],[107,108,0,36864,4,"cuda:0"],[119,120,0,64,4,"cuda:0"],[121,122,0,64,4,"cuda:0"],[147,148,0,36864,4,"cuda:0"],[159,160,0,64,4,"cuda:0"],[161,162,0,64,4,"cuda:0"],[186,187,0,36864,4,"cuda:0"],[198,199,0,64,4,"cuda:0"],[200,201,0,64,4,"cuda:0"],[226,227,0,73728,4,"cuda:0"],[238,239,0,128,4,"cuda:0"],[240,241,0,128,4,"cuda:0"],[265,266,0,147456,4,"cuda:0"],[277,278,0,128,4,"cuda:0"],[279,280,0,128,4,"cuda:0"],[302,303,0,8192,4,"cuda:0"],[314,315,0,128,4,"cuda:0"],[316,317,0,128,4,"cuda:0"],[342,343,0,147456,4,"cuda:0"],[353,354,0,128,4,"cuda:0"],[355,356,0,128,4,"cuda:0"],[380,381,0,147456,4,"cuda:0"],[392,393,0,128,4,"cuda:0"],[394,395,0,128,4,"cuda:0"],[420,421,0,294912,4,"cuda:0"],[432,433,0,256,4,"cuda:0"],[434,435,0,256,4,"cuda:0"],[459,460,0,589824,4,"cuda:0"],[471,472,0,256,4,"cuda:0"],[473,474,0,256,4,"cuda:0"],[496,497,0,32768,4,"cuda:0"],[508,509,0,256,4,"cuda:0"],[510,511,0,256,4,"cuda:0"],[536,537,0,589824,4,"cuda:0"],[546,547,0,256,4,"cuda:0"],[548,549,0,256,4,"cuda:0"],[573,574,0,589824,4,"cuda:0"],[585,586,0,256,4,"cuda:0"],[587,588,0,256,4,"cuda:0"],[613,614,0,1179648,4,"cuda:0"],[625,626,0,512,4,"cuda:0"],[627,628,0,512,4,"cuda:0"],[652,653,0,2359296,4,"cuda:0"],[664,665,0,512,4,"cuda:0"],[666,667,0,512,4,"cuda:0"],[689,690,0,131072,4,"cuda:0"],[701,702,0,512,4,"cuda:0"],[703,704,0,512,4,"cuda:0"],[729,730,0,2359296,4,"cuda:0"],[739,740,0,512,4,"cuda:0"],[741,742,0,512,4,"cuda:0"],[766,767,0,2359296,4,"cuda:0"],[778,779,0,512,4,"cuda:0"],[780,781,0,512,4,"cuda:0"],[812,813,0,512000,4,"cuda:0"],[814,815,0,1000,4,"cuda:0"]],0.000100], "input_shapes": [[[64,3,7,7],[64],[64],[64,64,3,3],[64],[64],[64,64,3,3],[64],[64],[64,64,3,3],[64],[64],[64,64,3,3],[64],[64],[128,64,3,3],[128],[128],[128,128,3,3],[128],[128],[128,64,1,1],[128],[128],[128,128,3,3],[128],[128],[128,128,3,3],[128],[128],[256,128,3,3],[256],[256],[256,256,3,3],[256],[256],[256,128,1,1],[256],[256],[256,256,3,3],[256],[256],[256,256,3,3],[256],[256],[512,256,3,3],[512],[512],[512,512,3,3],[512],[512],[512,256,1,1],[512],[512],[512,512,3,3],[512],[512],[512,512,3,3],[512],[512],[1000,512],[1000]],[[64,3,7,7],[64],[64],[64,64,3,3],[64],[64],[64,64,3,3],[64],[64],[64,64,3,3],[64],[64],[64,64,3,3],[64],[64],[128,64,3,3],[128],[128],[128,128,3,3],[128],[128],[128,64,1,1],[128],[128],[128,128,3,3],[128],[128],[128,128,3,3],[128],[128],[256,128,3,3],[256],[256],[256,256,3,3],[256],[256],[256,128,1,1],[256],[256],[256,256,3,3],[256],[256],[256,256,3,3],[256],[256],[512,256,3,3],[512],[512],[512,512,3,3],[512],[512],[512,256,1,1],[512],[512],[512,512,3,3],[512],[512],[512,512,3,3],[512],[512],[1000,512],[1000]],[]], "input_types": ["GenericList[Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float)]","GenericList[Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float)]","Double"],
+      "outputs": [[[844,1550,0,9408,4,"cuda:0"],[1552,452,0,64,4,"cuda:0"],[1554,1555,0,64,4,"cuda:0"],[823,1557,0,36864,4,"cuda:0"],[725,1559,0,64,4,"cuda:0"],[1561,1562,0,64,4,"cuda:0"],[761,1564,0,36864,4,"cuda:0"],[758,1566,0,64,4,"cuda:0"],[1568,645,0,64,4,"cuda:0"],[1570,1571,0,36864,4,"cuda:0"],[878,1573,0,64,4,"cuda:0"],[644,1575,0,64,4,"cuda:0"],[570,1577,0,36864,4,"cuda:0"],[565,1579,0,64,4,"cuda:0"],[1581,1582,0,64,4,"cuda:0"],[609,1584,0,73728,4,"cuda:0"],[1586,1587,0,128,4,"cuda:0"],[647,1589,0,128,4,"cuda:0"],[649,1591,0,147456,4,"cuda:0"],[568,1593,0,128,4,"cuda:0"],[416,1595,0,128,4,"cuda:0"],[1597,1598,0,8192,4,"cuda:0"],[454,1600,0,128,4,"cuda:0"],[456,1602,0,128,4,"cuda:0"],[451,1604,0,147456,4,"cuda:0"],[532,1606,0,128,4,"cuda:0"],[1608,1609,0,128,4,"cuda:0"],[104,1611,0,147456,4,"cuda:0"],[1613,1614,0,128,4,"cuda:0"],[1616,1617,0,128,4,"cuda:0"],[1619,1620,0,294912,4,"cuda:0"],[1622,1623,0,256,4,"cuda:0"],[65,1625,0,256,4,"cuda:0"],[31,1627,0,589824,4,"cuda:0"],[102,1629,0,256,4,"cuda:0"],[802,1631,0,256,4,"cuda:0"],[1633,1634,0,32768,4,"cuda:0"],[1636,1637,0,256,4,"cuda:0"],[1639,1640,0,256,4,"cuda:0"],[1642,1643,0,589824,4,"cuda:0"],[1645,1646,0,256,4,"cuda:0"],[1648,1649,0,256,4,"cuda:0"],[1651,1652,0,589824,4,"cuda:0"],[1654,1655,0,256,4,"cuda:0"],[1657,1658,0,256,4,"cuda:0"],[1660,426,0,1179648,4,"cuda:0"],[1662,1663,0,512,4,"cuda:0"],[1665,1666,0,512,4,"cuda:0"],[1668,1669,0,2359296,4,"cuda:0"],[1671,1672,0,512,4,"cuda:0"],[1674,1675,0,512,4,"cuda:0"],[1677,1678,0,131072,4,"cuda:0"],[1680,1681,0,512,4,"cuda:0"],[1683,1684,0,512,4,"cuda:0"],[1686,1687,0,2359296,4,"cuda:0"],[1689,1690,0,512,4,"cuda:0"],[1692,1693,0,512,4,"cuda:0"],[1695,1696,0,2359296,4,"cuda:0"],[1698,1699,0,512,4,"cuda:0"],[1701,1702,0,512,4,"cuda:0"],[1704,1705,0,512000,4,"cuda:0"],[1707,1708,0,1000,4,"cuda:0"]]], "output_shapes": [[[64,3,7,7],[64],[64],[64,64,3,3],[64],[64],[64,64,3,3],[64],[64],[64,64,3,3],[64],[64],[64,64,3,3],[64],[64],[128,64,3,3],[128],[128],[128,128,3,3],[128],[128],[128,64,1,1],[128],[128],[128,128,3,3],[128],[128],[128,128,3,3],[128],[128],[256,128,3,3],[256],[256],[256,256,3,3],[256],[256],[256,128,1,1],[256],[256],[256,256,3,3],[256],[256],[256,256,3,3],[256],[256],[512,256,3,3],[512],[512],[512,512,3,3],[512],[512],[512,256,1,1],[512],[512],[512,512,3,3],[512],[512],[512,512,3,3],[512],[512],[1000,512],[1000]]], "output_types": ["GenericList[Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float)]"]
+    },
+    {
+      "name": "aten::result_type", "id": 1834, "rf_id": 1109, "parent": 1833, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[1709,1710,0,9408,4,"cuda:0"],0.900000], "input_shapes": [[64,3,7,7],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1835, "rf_id": 1110, "parent": 1833, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[1711,1712,0,64,4,"cuda:0"],0.900000], "input_shapes": [[64],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1836, "rf_id": 1111, "parent": 1833, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[1713,1714,0,64,4,"cuda:0"],0.900000], "input_shapes": [[64],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1837, "rf_id": 1112, "parent": 1833, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[1715,1716,0,36864,4,"cuda:0"],0.900000], "input_shapes": [[64,64,3,3],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1838, "rf_id": 1113, "parent": 1833, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[1717,1718,0,64,4,"cuda:0"],0.900000], "input_shapes": [[64],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1839, "rf_id": 1114, "parent": 1833, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[1719,1720,0,64,4,"cuda:0"],0.900000], "input_shapes": [[64],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1840, "rf_id": 1115, "parent": 1833, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[1721,1722,0,36864,4,"cuda:0"],0.900000], "input_shapes": [[64,64,3,3],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1841, "rf_id": 1116, "parent": 1833, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[1723,1724,0,64,4,"cuda:0"],0.900000], "input_shapes": [[64],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1842, "rf_id": 1117, "parent": 1833, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[1725,1726,0,64,4,"cuda:0"],0.900000], "input_shapes": [[64],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1843, "rf_id": 1118, "parent": 1833, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[1727,1728,0,36864,4,"cuda:0"],0.900000], "input_shapes": [[64,64,3,3],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1844, "rf_id": 1119, "parent": 1833, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[1729,1730,0,64,4,"cuda:0"],0.900000], "input_shapes": [[64],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1845, "rf_id": 1120, "parent": 1833, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[1731,1732,0,64,4,"cuda:0"],0.900000], "input_shapes": [[64],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1846, "rf_id": 1121, "parent": 1833, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[1733,1734,0,36864,4,"cuda:0"],0.900000], "input_shapes": [[64,64,3,3],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1847, "rf_id": 1122, "parent": 1833, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[1735,1736,0,64,4,"cuda:0"],0.900000], "input_shapes": [[64],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1848, "rf_id": 1123, "parent": 1833, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[1737,1738,0,64,4,"cuda:0"],0.900000], "input_shapes": [[64],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1849, "rf_id": 1124, "parent": 1833, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[1739,1740,0,73728,4,"cuda:0"],0.900000], "input_shapes": [[128,64,3,3],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1850, "rf_id": 1125, "parent": 1833, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[1741,1742,0,128,4,"cuda:0"],0.900000], "input_shapes": [[128],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1851, "rf_id": 1126, "parent": 1833, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[1743,1744,0,128,4,"cuda:0"],0.900000], "input_shapes": [[128],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1852, "rf_id": 1127, "parent": 1833, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[1745,1746,0,147456,4,"cuda:0"],0.900000], "input_shapes": [[128,128,3,3],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1853, "rf_id": 1128, "parent": 1833, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[1747,1748,0,128,4,"cuda:0"],0.900000], "input_shapes": [[128],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1854, "rf_id": 1129, "parent": 1833, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[1749,1750,0,128,4,"cuda:0"],0.900000], "input_shapes": [[128],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1855, "rf_id": 1130, "parent": 1833, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[1751,1752,0,8192,4,"cuda:0"],0.900000], "input_shapes": [[128,64,1,1],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1856, "rf_id": 1131, "parent": 1833, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[1753,1754,0,128,4,"cuda:0"],0.900000], "input_shapes": [[128],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1857, "rf_id": 1132, "parent": 1833, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[1755,1756,0,128,4,"cuda:0"],0.900000], "input_shapes": [[128],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1858, "rf_id": 1133, "parent": 1833, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[1757,1758,0,147456,4,"cuda:0"],0.900000], "input_shapes": [[128,128,3,3],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1859, "rf_id": 1134, "parent": 1833, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[1759,1760,0,128,4,"cuda:0"],0.900000], "input_shapes": [[128],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1860, "rf_id": 1135, "parent": 1833, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[1761,1762,0,128,4,"cuda:0"],0.900000], "input_shapes": [[128],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1861, "rf_id": 1136, "parent": 1833, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[1763,1764,0,147456,4,"cuda:0"],0.900000], "input_shapes": [[128,128,3,3],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1862, "rf_id": 1137, "parent": 1833, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[1765,1766,0,128,4,"cuda:0"],0.900000], "input_shapes": [[128],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1863, "rf_id": 1138, "parent": 1833, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[1767,1768,0,128,4,"cuda:0"],0.900000], "input_shapes": [[128],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1864, "rf_id": 1139, "parent": 1833, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[1769,1770,0,294912,4,"cuda:0"],0.900000], "input_shapes": [[256,128,3,3],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1865, "rf_id": 1140, "parent": 1833, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[1771,1772,0,256,4,"cuda:0"],0.900000], "input_shapes": [[256],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1866, "rf_id": 1141, "parent": 1833, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[1773,1774,0,256,4,"cuda:0"],0.900000], "input_shapes": [[256],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1867, "rf_id": 1142, "parent": 1833, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[1775,1776,0,589824,4,"cuda:0"],0.900000], "input_shapes": [[256,256,3,3],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1868, "rf_id": 1143, "parent": 1833, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[1777,1778,0,256,4,"cuda:0"],0.900000], "input_shapes": [[256],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1869, "rf_id": 1144, "parent": 1833, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[1779,1780,0,256,4,"cuda:0"],0.900000], "input_shapes": [[256],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1870, "rf_id": 1145, "parent": 1833, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[1781,1782,0,32768,4,"cuda:0"],0.900000], "input_shapes": [[256,128,1,1],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1871, "rf_id": 1146, "parent": 1833, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[1783,1784,0,256,4,"cuda:0"],0.900000], "input_shapes": [[256],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1872, "rf_id": 1147, "parent": 1833, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[1785,1786,0,256,4,"cuda:0"],0.900000], "input_shapes": [[256],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1873, "rf_id": 1148, "parent": 1833, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[1787,1788,0,589824,4,"cuda:0"],0.900000], "input_shapes": [[256,256,3,3],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1874, "rf_id": 1149, "parent": 1833, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[1789,1790,0,256,4,"cuda:0"],0.900000], "input_shapes": [[256],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1875, "rf_id": 1150, "parent": 1833, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[1791,1792,0,256,4,"cuda:0"],0.900000], "input_shapes": [[256],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1876, "rf_id": 1151, "parent": 1833, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[1793,1794,0,589824,4,"cuda:0"],0.900000], "input_shapes": [[256,256,3,3],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1877, "rf_id": 1152, "parent": 1833, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[1795,1796,0,256,4,"cuda:0"],0.900000], "input_shapes": [[256],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1878, "rf_id": 1153, "parent": 1833, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[1797,1798,0,256,4,"cuda:0"],0.900000], "input_shapes": [[256],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1879, "rf_id": 1154, "parent": 1833, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[1799,1800,0,1179648,4,"cuda:0"],0.900000], "input_shapes": [[512,256,3,3],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1880, "rf_id": 1155, "parent": 1833, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[1801,1802,0,512,4,"cuda:0"],0.900000], "input_shapes": [[512],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1881, "rf_id": 1156, "parent": 1833, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[1803,1804,0,512,4,"cuda:0"],0.900000], "input_shapes": [[512],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1882, "rf_id": 1157, "parent": 1833, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[1805,1806,0,2359296,4,"cuda:0"],0.900000], "input_shapes": [[512,512,3,3],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1883, "rf_id": 1158, "parent": 1833, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[1807,1808,0,512,4,"cuda:0"],0.900000], "input_shapes": [[512],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1884, "rf_id": 1159, "parent": 1833, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[1809,1810,0,512,4,"cuda:0"],0.900000], "input_shapes": [[512],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1885, "rf_id": 1160, "parent": 1833, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[1811,1812,0,131072,4,"cuda:0"],0.900000], "input_shapes": [[512,256,1,1],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1886, "rf_id": 1161, "parent": 1833, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[1813,1814,0,512,4,"cuda:0"],0.900000], "input_shapes": [[512],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1887, "rf_id": 1162, "parent": 1833, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[1815,1816,0,512,4,"cuda:0"],0.900000], "input_shapes": [[512],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1888, "rf_id": 1163, "parent": 1833, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[1817,1818,0,2359296,4,"cuda:0"],0.900000], "input_shapes": [[512,512,3,3],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1889, "rf_id": 1164, "parent": 1833, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[1819,1820,0,512,4,"cuda:0"],0.900000], "input_shapes": [[512],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1890, "rf_id": 1165, "parent": 1833, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[1821,1822,0,512,4,"cuda:0"],0.900000], "input_shapes": [[512],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1891, "rf_id": 1166, "parent": 1833, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[1823,1824,0,2359296,4,"cuda:0"],0.900000], "input_shapes": [[512,512,3,3],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1892, "rf_id": 1167, "parent": 1833, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[1825,1826,0,512,4,"cuda:0"],0.900000], "input_shapes": [[512],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1893, "rf_id": 1168, "parent": 1833, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[1827,1828,0,512,4,"cuda:0"],0.900000], "input_shapes": [[512],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1894, "rf_id": 1169, "parent": 1833, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[1829,1830,0,512000,4,"cuda:0"],0.900000], "input_shapes": [[1000,512],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1895, "rf_id": 1170, "parent": 1833, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[1831,1832,0,1000,4,"cuda:0"],0.900000], "input_shapes": [[1000],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::_foreach_mul_", "id": 1833, "rf_id": 1108, "parent": 1485, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::_foreach_mul_.Scalar(Tensor(a!)[] self, Scalar scalar) -> ()",
+      "inputs": [[[1709,1710,0,9408,4,"cuda:0"],[1711,1712,0,64,4,"cuda:0"],[1713,1714,0,64,4,"cuda:0"],[1715,1716,0,36864,4,"cuda:0"],[1717,1718,0,64,4,"cuda:0"],[1719,1720,0,64,4,"cuda:0"],[1721,1722,0,36864,4,"cuda:0"],[1723,1724,0,64,4,"cuda:0"],[1725,1726,0,64,4,"cuda:0"],[1727,1728,0,36864,4,"cuda:0"],[1729,1730,0,64,4,"cuda:0"],[1731,1732,0,64,4,"cuda:0"],[1733,1734,0,36864,4,"cuda:0"],[1735,1736,0,64,4,"cuda:0"],[1737,1738,0,64,4,"cuda:0"],[1739,1740,0,73728,4,"cuda:0"],[1741,1742,0,128,4,"cuda:0"],[1743,1744,0,128,4,"cuda:0"],[1745,1746,0,147456,4,"cuda:0"],[1747,1748,0,128,4,"cuda:0"],[1749,1750,0,128,4,"cuda:0"],[1751,1752,0,8192,4,"cuda:0"],[1753,1754,0,128,4,"cuda:0"],[1755,1756,0,128,4,"cuda:0"],[1757,1758,0,147456,4,"cuda:0"],[1759,1760,0,128,4,"cuda:0"],[1761,1762,0,128,4,"cuda:0"],[1763,1764,0,147456,4,"cuda:0"],[1765,1766,0,128,4,"cuda:0"],[1767,1768,0,128,4,"cuda:0"],[1769,1770,0,294912,4,"cuda:0"],[1771,1772,0,256,4,"cuda:0"],[1773,1774,0,256,4,"cuda:0"],[1775,1776,0,589824,4,"cuda:0"],[1777,1778,0,256,4,"cuda:0"],[1779,1780,0,256,4,"cuda:0"],[1781,1782,0,32768,4,"cuda:0"],[1783,1784,0,256,4,"cuda:0"],[1785,1786,0,256,4,"cuda:0"],[1787,1788,0,589824,4,"cuda:0"],[1789,1790,0,256,4,"cuda:0"],[1791,1792,0,256,4,"cuda:0"],[1793,1794,0,589824,4,"cuda:0"],[1795,1796,0,256,4,"cuda:0"],[1797,1798,0,256,4,"cuda:0"],[1799,1800,0,1179648,4,"cuda:0"],[1801,1802,0,512,4,"cuda:0"],[1803,1804,0,512,4,"cuda:0"],[1805,1806,0,2359296,4,"cuda:0"],[1807,1808,0,512,4,"cuda:0"],[1809,1810,0,512,4,"cuda:0"],[1811,1812,0,131072,4,"cuda:0"],[1813,1814,0,512,4,"cuda:0"],[1815,1816,0,512,4,"cuda:0"],[1817,1818,0,2359296,4,"cuda:0"],[1819,1820,0,512,4,"cuda:0"],[1821,1822,0,512,4,"cuda:0"],[1823,1824,0,2359296,4,"cuda:0"],[1825,1826,0,512,4,"cuda:0"],[1827,1828,0,512,4,"cuda:0"],[1829,1830,0,512000,4,"cuda:0"],[1831,1832,0,1000,4,"cuda:0"]],0.900000], "input_shapes": [[[64,3,7,7],[64],[64],[64,64,3,3],[64],[64],[64,64,3,3],[64],[64],[64,64,3,3],[64],[64],[64,64,3,3],[64],[64],[128,64,3,3],[128],[128],[128,128,3,3],[128],[128],[128,64,1,1],[128],[128],[128,128,3,3],[128],[128],[128,128,3,3],[128],[128],[256,128,3,3],[256],[256],[256,256,3,3],[256],[256],[256,128,1,1],[256],[256],[256,256,3,3],[256],[256],[256,256,3,3],[256],[256],[512,256,3,3],[512],[512],[512,512,3,3],[512],[512],[512,256,1,1],[512],[512],[512,512,3,3],[512],[512],[512,512,3,3],[512],[512],[1000,512],[1000]],[]], "input_types": ["GenericList[Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float)]","Double"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::result_type", "id": 1897, "rf_id": 1172, "parent": 1896, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[1709,1710,0,9408,4,"cuda:0"],1], "input_shapes": [[64,3,7,7],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1898, "rf_id": 1173, "parent": 1896, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[1711,1712,0,64,4,"cuda:0"],1], "input_shapes": [[64],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1899, "rf_id": 1174, "parent": 1896, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[1713,1714,0,64,4,"cuda:0"],1], "input_shapes": [[64],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1900, "rf_id": 1175, "parent": 1896, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[1715,1716,0,36864,4,"cuda:0"],1], "input_shapes": [[64,64,3,3],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1901, "rf_id": 1176, "parent": 1896, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[1717,1718,0,64,4,"cuda:0"],1], "input_shapes": [[64],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1902, "rf_id": 1177, "parent": 1896, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[1719,1720,0,64,4,"cuda:0"],1], "input_shapes": [[64],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1903, "rf_id": 1178, "parent": 1896, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[1721,1722,0,36864,4,"cuda:0"],1], "input_shapes": [[64,64,3,3],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1904, "rf_id": 1179, "parent": 1896, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[1723,1724,0,64,4,"cuda:0"],1], "input_shapes": [[64],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1905, "rf_id": 1180, "parent": 1896, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[1725,1726,0,64,4,"cuda:0"],1], "input_shapes": [[64],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1906, "rf_id": 1181, "parent": 1896, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[1727,1728,0,36864,4,"cuda:0"],1], "input_shapes": [[64,64,3,3],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1907, "rf_id": 1182, "parent": 1896, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[1729,1730,0,64,4,"cuda:0"],1], "input_shapes": [[64],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1908, "rf_id": 1183, "parent": 1896, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[1731,1732,0,64,4,"cuda:0"],1], "input_shapes": [[64],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1909, "rf_id": 1184, "parent": 1896, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[1733,1734,0,36864,4,"cuda:0"],1], "input_shapes": [[64,64,3,3],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1910, "rf_id": 1185, "parent": 1896, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[1735,1736,0,64,4,"cuda:0"],1], "input_shapes": [[64],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1911, "rf_id": 1186, "parent": 1896, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[1737,1738,0,64,4,"cuda:0"],1], "input_shapes": [[64],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1912, "rf_id": 1187, "parent": 1896, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[1739,1740,0,73728,4,"cuda:0"],1], "input_shapes": [[128,64,3,3],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1913, "rf_id": 1188, "parent": 1896, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[1741,1742,0,128,4,"cuda:0"],1], "input_shapes": [[128],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1914, "rf_id": 1189, "parent": 1896, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[1743,1744,0,128,4,"cuda:0"],1], "input_shapes": [[128],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1915, "rf_id": 1190, "parent": 1896, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[1745,1746,0,147456,4,"cuda:0"],1], "input_shapes": [[128,128,3,3],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1916, "rf_id": 1191, "parent": 1896, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[1747,1748,0,128,4,"cuda:0"],1], "input_shapes": [[128],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1917, "rf_id": 1192, "parent": 1896, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[1749,1750,0,128,4,"cuda:0"],1], "input_shapes": [[128],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1918, "rf_id": 1193, "parent": 1896, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[1751,1752,0,8192,4,"cuda:0"],1], "input_shapes": [[128,64,1,1],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1919, "rf_id": 1194, "parent": 1896, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[1753,1754,0,128,4,"cuda:0"],1], "input_shapes": [[128],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1920, "rf_id": 1195, "parent": 1896, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[1755,1756,0,128,4,"cuda:0"],1], "input_shapes": [[128],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1921, "rf_id": 1196, "parent": 1896, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[1757,1758,0,147456,4,"cuda:0"],1], "input_shapes": [[128,128,3,3],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1922, "rf_id": 1197, "parent": 1896, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[1759,1760,0,128,4,"cuda:0"],1], "input_shapes": [[128],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1923, "rf_id": 1198, "parent": 1896, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[1761,1762,0,128,4,"cuda:0"],1], "input_shapes": [[128],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1924, "rf_id": 1199, "parent": 1896, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[1763,1764,0,147456,4,"cuda:0"],1], "input_shapes": [[128,128,3,3],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1925, "rf_id": 1200, "parent": 1896, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[1765,1766,0,128,4,"cuda:0"],1], "input_shapes": [[128],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1926, "rf_id": 1201, "parent": 1896, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[1767,1768,0,128,4,"cuda:0"],1], "input_shapes": [[128],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1927, "rf_id": 1202, "parent": 1896, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[1769,1770,0,294912,4,"cuda:0"],1], "input_shapes": [[256,128,3,3],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1928, "rf_id": 1203, "parent": 1896, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[1771,1772,0,256,4,"cuda:0"],1], "input_shapes": [[256],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1929, "rf_id": 1204, "parent": 1896, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[1773,1774,0,256,4,"cuda:0"],1], "input_shapes": [[256],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1930, "rf_id": 1205, "parent": 1896, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[1775,1776,0,589824,4,"cuda:0"],1], "input_shapes": [[256,256,3,3],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1931, "rf_id": 1206, "parent": 1896, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[1777,1778,0,256,4,"cuda:0"],1], "input_shapes": [[256],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1932, "rf_id": 1207, "parent": 1896, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[1779,1780,0,256,4,"cuda:0"],1], "input_shapes": [[256],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1933, "rf_id": 1208, "parent": 1896, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[1781,1782,0,32768,4,"cuda:0"],1], "input_shapes": [[256,128,1,1],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1934, "rf_id": 1209, "parent": 1896, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[1783,1784,0,256,4,"cuda:0"],1], "input_shapes": [[256],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1935, "rf_id": 1210, "parent": 1896, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[1785,1786,0,256,4,"cuda:0"],1], "input_shapes": [[256],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1936, "rf_id": 1211, "parent": 1896, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[1787,1788,0,589824,4,"cuda:0"],1], "input_shapes": [[256,256,3,3],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1937, "rf_id": 1212, "parent": 1896, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[1789,1790,0,256,4,"cuda:0"],1], "input_shapes": [[256],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1938, "rf_id": 1213, "parent": 1896, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[1791,1792,0,256,4,"cuda:0"],1], "input_shapes": [[256],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1939, "rf_id": 1214, "parent": 1896, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[1793,1794,0,589824,4,"cuda:0"],1], "input_shapes": [[256,256,3,3],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1940, "rf_id": 1215, "parent": 1896, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[1795,1796,0,256,4,"cuda:0"],1], "input_shapes": [[256],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1941, "rf_id": 1216, "parent": 1896, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[1797,1798,0,256,4,"cuda:0"],1], "input_shapes": [[256],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1942, "rf_id": 1217, "parent": 1896, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[1799,1800,0,1179648,4,"cuda:0"],1], "input_shapes": [[512,256,3,3],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1943, "rf_id": 1218, "parent": 1896, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[1801,1802,0,512,4,"cuda:0"],1], "input_shapes": [[512],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1944, "rf_id": 1219, "parent": 1896, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[1803,1804,0,512,4,"cuda:0"],1], "input_shapes": [[512],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1945, "rf_id": 1220, "parent": 1896, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[1805,1806,0,2359296,4,"cuda:0"],1], "input_shapes": [[512,512,3,3],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1946, "rf_id": 1221, "parent": 1896, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[1807,1808,0,512,4,"cuda:0"],1], "input_shapes": [[512],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1947, "rf_id": 1222, "parent": 1896, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[1809,1810,0,512,4,"cuda:0"],1], "input_shapes": [[512],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1948, "rf_id": 1223, "parent": 1896, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[1811,1812,0,131072,4,"cuda:0"],1], "input_shapes": [[512,256,1,1],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1949, "rf_id": 1224, "parent": 1896, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[1813,1814,0,512,4,"cuda:0"],1], "input_shapes": [[512],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1950, "rf_id": 1225, "parent": 1896, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[1815,1816,0,512,4,"cuda:0"],1], "input_shapes": [[512],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1951, "rf_id": 1226, "parent": 1896, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[1817,1818,0,2359296,4,"cuda:0"],1], "input_shapes": [[512,512,3,3],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1952, "rf_id": 1227, "parent": 1896, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[1819,1820,0,512,4,"cuda:0"],1], "input_shapes": [[512],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1953, "rf_id": 1228, "parent": 1896, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[1821,1822,0,512,4,"cuda:0"],1], "input_shapes": [[512],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1954, "rf_id": 1229, "parent": 1896, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[1823,1824,0,2359296,4,"cuda:0"],1], "input_shapes": [[512,512,3,3],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1955, "rf_id": 1230, "parent": 1896, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[1825,1826,0,512,4,"cuda:0"],1], "input_shapes": [[512],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1956, "rf_id": 1231, "parent": 1896, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[1827,1828,0,512,4,"cuda:0"],1], "input_shapes": [[512],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1957, "rf_id": 1232, "parent": 1896, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[1829,1830,0,512000,4,"cuda:0"],1], "input_shapes": [[1000,512],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1958, "rf_id": 1233, "parent": 1896, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[1831,1832,0,1000,4,"cuda:0"],1], "input_shapes": [[1000],[]], "input_types": ["Tensor(float)","Int"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::_foreach_add_", "id": 1896, "rf_id": 1171, "parent": 1485, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::_foreach_add_.List(Tensor(a!)[] self, Tensor[] other, *, Scalar alpha=1) -> ()",
+      "inputs": [[[1709,1710,0,9408,4,"cuda:0"],[1711,1712,0,64,4,"cuda:0"],[1713,1714,0,64,4,"cuda:0"],[1715,1716,0,36864,4,"cuda:0"],[1717,1718,0,64,4,"cuda:0"],[1719,1720,0,64,4,"cuda:0"],[1721,1722,0,36864,4,"cuda:0"],[1723,1724,0,64,4,"cuda:0"],[1725,1726,0,64,4,"cuda:0"],[1727,1728,0,36864,4,"cuda:0"],[1729,1730,0,64,4,"cuda:0"],[1731,1732,0,64,4,"cuda:0"],[1733,1734,0,36864,4,"cuda:0"],[1735,1736,0,64,4,"cuda:0"],[1737,1738,0,64,4,"cuda:0"],[1739,1740,0,73728,4,"cuda:0"],[1741,1742,0,128,4,"cuda:0"],[1743,1744,0,128,4,"cuda:0"],[1745,1746,0,147456,4,"cuda:0"],[1747,1748,0,128,4,"cuda:0"],[1749,1750,0,128,4,"cuda:0"],[1751,1752,0,8192,4,"cuda:0"],[1753,1754,0,128,4,"cuda:0"],[1755,1756,0,128,4,"cuda:0"],[1757,1758,0,147456,4,"cuda:0"],[1759,1760,0,128,4,"cuda:0"],[1761,1762,0,128,4,"cuda:0"],[1763,1764,0,147456,4,"cuda:0"],[1765,1766,0,128,4,"cuda:0"],[1767,1768,0,128,4,"cuda:0"],[1769,1770,0,294912,4,"cuda:0"],[1771,1772,0,256,4,"cuda:0"],[1773,1774,0,256,4,"cuda:0"],[1775,1776,0,589824,4,"cuda:0"],[1777,1778,0,256,4,"cuda:0"],[1779,1780,0,256,4,"cuda:0"],[1781,1782,0,32768,4,"cuda:0"],[1783,1784,0,256,4,"cuda:0"],[1785,1786,0,256,4,"cuda:0"],[1787,1788,0,589824,4,"cuda:0"],[1789,1790,0,256,4,"cuda:0"],[1791,1792,0,256,4,"cuda:0"],[1793,1794,0,589824,4,"cuda:0"],[1795,1796,0,256,4,"cuda:0"],[1797,1798,0,256,4,"cuda:0"],[1799,1800,0,1179648,4,"cuda:0"],[1801,1802,0,512,4,"cuda:0"],[1803,1804,0,512,4,"cuda:0"],[1805,1806,0,2359296,4,"cuda:0"],[1807,1808,0,512,4,"cuda:0"],[1809,1810,0,512,4,"cuda:0"],[1811,1812,0,131072,4,"cuda:0"],[1813,1814,0,512,4,"cuda:0"],[1815,1816,0,512,4,"cuda:0"],[1817,1818,0,2359296,4,"cuda:0"],[1819,1820,0,512,4,"cuda:0"],[1821,1822,0,512,4,"cuda:0"],[1823,1824,0,2359296,4,"cuda:0"],[1825,1826,0,512,4,"cuda:0"],[1827,1828,0,512,4,"cuda:0"],[1829,1830,0,512000,4,"cuda:0"],[1831,1832,0,1000,4,"cuda:0"]],[[844,1550,0,9408,4,"cuda:0"],[1552,452,0,64,4,"cuda:0"],[1554,1555,0,64,4,"cuda:0"],[823,1557,0,36864,4,"cuda:0"],[725,1559,0,64,4,"cuda:0"],[1561,1562,0,64,4,"cuda:0"],[761,1564,0,36864,4,"cuda:0"],[758,1566,0,64,4,"cuda:0"],[1568,645,0,64,4,"cuda:0"],[1570,1571,0,36864,4,"cuda:0"],[878,1573,0,64,4,"cuda:0"],[644,1575,0,64,4,"cuda:0"],[570,1577,0,36864,4,"cuda:0"],[565,1579,0,64,4,"cuda:0"],[1581,1582,0,64,4,"cuda:0"],[609,1584,0,73728,4,"cuda:0"],[1586,1587,0,128,4,"cuda:0"],[647,1589,0,128,4,"cuda:0"],[649,1591,0,147456,4,"cuda:0"],[568,1593,0,128,4,"cuda:0"],[416,1595,0,128,4,"cuda:0"],[1597,1598,0,8192,4,"cuda:0"],[454,1600,0,128,4,"cuda:0"],[456,1602,0,128,4,"cuda:0"],[451,1604,0,147456,4,"cuda:0"],[532,1606,0,128,4,"cuda:0"],[1608,1609,0,128,4,"cuda:0"],[104,1611,0,147456,4,"cuda:0"],[1613,1614,0,128,4,"cuda:0"],[1616,1617,0,128,4,"cuda:0"],[1619,1620,0,294912,4,"cuda:0"],[1622,1623,0,256,4,"cuda:0"],[65,1625,0,256,4,"cuda:0"],[31,1627,0,589824,4,"cuda:0"],[102,1629,0,256,4,"cuda:0"],[802,1631,0,256,4,"cuda:0"],[1633,1634,0,32768,4,"cuda:0"],[1636,1637,0,256,4,"cuda:0"],[1639,1640,0,256,4,"cuda:0"],[1642,1643,0,589824,4,"cuda:0"],[1645,1646,0,256,4,"cuda:0"],[1648,1649,0,256,4,"cuda:0"],[1651,1652,0,589824,4,"cuda:0"],[1654,1655,0,256,4,"cuda:0"],[1657,1658,0,256,4,"cuda:0"],[1660,426,0,1179648,4,"cuda:0"],[1662,1663,0,512,4,"cuda:0"],[1665,1666,0,512,4,"cuda:0"],[1668,1669,0,2359296,4,"cuda:0"],[1671,1672,0,512,4,"cuda:0"],[1674,1675,0,512,4,"cuda:0"],[1677,1678,0,131072,4,"cuda:0"],[1680,1681,0,512,4,"cuda:0"],[1683,1684,0,512,4,"cuda:0"],[1686,1687,0,2359296,4,"cuda:0"],[1689,1690,0,512,4,"cuda:0"],[1692,1693,0,512,4,"cuda:0"],[1695,1696,0,2359296,4,"cuda:0"],[1698,1699,0,512,4,"cuda:0"],[1701,1702,0,512,4,"cuda:0"],[1704,1705,0,512000,4,"cuda:0"],[1707,1708,0,1000,4,"cuda:0"]],1], "input_shapes": [[[64,3,7,7],[64],[64],[64,64,3,3],[64],[64],[64,64,3,3],[64],[64],[64,64,3,3],[64],[64],[64,64,3,3],[64],[64],[128,64,3,3],[128],[128],[128,128,3,3],[128],[128],[128,64,1,1],[128],[128],[128,128,3,3],[128],[128],[128,128,3,3],[128],[128],[256,128,3,3],[256],[256],[256,256,3,3],[256],[256],[256,128,1,1],[256],[256],[256,256,3,3],[256],[256],[256,256,3,3],[256],[256],[512,256,3,3],[512],[512],[512,512,3,3],[512],[512],[512,256,1,1],[512],[512],[512,512,3,3],[512],[512],[512,512,3,3],[512],[512],[1000,512],[1000]],[[64,3,7,7],[64],[64],[64,64,3,3],[64],[64],[64,64,3,3],[64],[64],[64,64,3,3],[64],[64],[64,64,3,3],[64],[64],[128,64,3,3],[128],[128],[128,128,3,3],[128],[128],[128,64,1,1],[128],[128],[128,128,3,3],[128],[128],[128,128,3,3],[128],[128],[256,128,3,3],[256],[256],[256,256,3,3],[256],[256],[256,128,1,1],[256],[256],[256,256,3,3],[256],[256],[256,256,3,3],[256],[256],[512,256,3,3],[512],[512],[512,512,3,3],[512],[512],[512,256,1,1],[512],[512],[512,512,3,3],[512],[512],[512,512,3,3],[512],[512],[1000,512],[1000]],[]], "input_types": ["GenericList[Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float)]","GenericList[Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float)]","Int"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::result_type", "id": 1960, "rf_id": 1235, "parent": 1959, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[20,21,0,9408,4,"cuda:0"],-0.100000], "input_shapes": [[64,3,7,7],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1961, "rf_id": 1236, "parent": 1959, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[34,35,0,64,4,"cuda:0"],-0.100000], "input_shapes": [[64],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1962, "rf_id": 1237, "parent": 1959, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[36,37,0,64,4,"cuda:0"],-0.100000], "input_shapes": [[64],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1963, "rf_id": 1238, "parent": 1959, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[67,68,0,36864,4,"cuda:0"],-0.100000], "input_shapes": [[64,64,3,3],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1964, "rf_id": 1239, "parent": 1959, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[80,81,0,64,4,"cuda:0"],-0.100000], "input_shapes": [[64],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1965, "rf_id": 1240, "parent": 1959, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[82,83,0,64,4,"cuda:0"],-0.100000], "input_shapes": [[64],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1966, "rf_id": 1241, "parent": 1959, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[107,108,0,36864,4,"cuda:0"],-0.100000], "input_shapes": [[64,64,3,3],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1967, "rf_id": 1242, "parent": 1959, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[119,120,0,64,4,"cuda:0"],-0.100000], "input_shapes": [[64],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1968, "rf_id": 1243, "parent": 1959, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[121,122,0,64,4,"cuda:0"],-0.100000], "input_shapes": [[64],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1969, "rf_id": 1244, "parent": 1959, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[147,148,0,36864,4,"cuda:0"],-0.100000], "input_shapes": [[64,64,3,3],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1970, "rf_id": 1245, "parent": 1959, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[159,160,0,64,4,"cuda:0"],-0.100000], "input_shapes": [[64],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1971, "rf_id": 1246, "parent": 1959, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[161,162,0,64,4,"cuda:0"],-0.100000], "input_shapes": [[64],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1972, "rf_id": 1247, "parent": 1959, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[186,187,0,36864,4,"cuda:0"],-0.100000], "input_shapes": [[64,64,3,3],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1973, "rf_id": 1248, "parent": 1959, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[198,199,0,64,4,"cuda:0"],-0.100000], "input_shapes": [[64],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1974, "rf_id": 1249, "parent": 1959, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[200,201,0,64,4,"cuda:0"],-0.100000], "input_shapes": [[64],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1975, "rf_id": 1250, "parent": 1959, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[226,227,0,73728,4,"cuda:0"],-0.100000], "input_shapes": [[128,64,3,3],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1976, "rf_id": 1251, "parent": 1959, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[238,239,0,128,4,"cuda:0"],-0.100000], "input_shapes": [[128],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1977, "rf_id": 1252, "parent": 1959, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[240,241,0,128,4,"cuda:0"],-0.100000], "input_shapes": [[128],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1978, "rf_id": 1253, "parent": 1959, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[265,266,0,147456,4,"cuda:0"],-0.100000], "input_shapes": [[128,128,3,3],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1979, "rf_id": 1254, "parent": 1959, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[277,278,0,128,4,"cuda:0"],-0.100000], "input_shapes": [[128],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1980, "rf_id": 1255, "parent": 1959, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[279,280,0,128,4,"cuda:0"],-0.100000], "input_shapes": [[128],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1981, "rf_id": 1256, "parent": 1959, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[302,303,0,8192,4,"cuda:0"],-0.100000], "input_shapes": [[128,64,1,1],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1982, "rf_id": 1257, "parent": 1959, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[314,315,0,128,4,"cuda:0"],-0.100000], "input_shapes": [[128],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1983, "rf_id": 1258, "parent": 1959, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[316,317,0,128,4,"cuda:0"],-0.100000], "input_shapes": [[128],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1984, "rf_id": 1259, "parent": 1959, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[342,343,0,147456,4,"cuda:0"],-0.100000], "input_shapes": [[128,128,3,3],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1985, "rf_id": 1260, "parent": 1959, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[353,354,0,128,4,"cuda:0"],-0.100000], "input_shapes": [[128],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1986, "rf_id": 1261, "parent": 1959, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[355,356,0,128,4,"cuda:0"],-0.100000], "input_shapes": [[128],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1987, "rf_id": 1262, "parent": 1959, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[380,381,0,147456,4,"cuda:0"],-0.100000], "input_shapes": [[128,128,3,3],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1988, "rf_id": 1263, "parent": 1959, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[392,393,0,128,4,"cuda:0"],-0.100000], "input_shapes": [[128],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1989, "rf_id": 1264, "parent": 1959, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[394,395,0,128,4,"cuda:0"],-0.100000], "input_shapes": [[128],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1990, "rf_id": 1265, "parent": 1959, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[420,421,0,294912,4,"cuda:0"],-0.100000], "input_shapes": [[256,128,3,3],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1991, "rf_id": 1266, "parent": 1959, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[432,433,0,256,4,"cuda:0"],-0.100000], "input_shapes": [[256],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1992, "rf_id": 1267, "parent": 1959, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[434,435,0,256,4,"cuda:0"],-0.100000], "input_shapes": [[256],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1993, "rf_id": 1268, "parent": 1959, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[459,460,0,589824,4,"cuda:0"],-0.100000], "input_shapes": [[256,256,3,3],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1994, "rf_id": 1269, "parent": 1959, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[471,472,0,256,4,"cuda:0"],-0.100000], "input_shapes": [[256],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1995, "rf_id": 1270, "parent": 1959, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[473,474,0,256,4,"cuda:0"],-0.100000], "input_shapes": [[256],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1996, "rf_id": 1271, "parent": 1959, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[496,497,0,32768,4,"cuda:0"],-0.100000], "input_shapes": [[256,128,1,1],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1997, "rf_id": 1272, "parent": 1959, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[508,509,0,256,4,"cuda:0"],-0.100000], "input_shapes": [[256],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1998, "rf_id": 1273, "parent": 1959, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[510,511,0,256,4,"cuda:0"],-0.100000], "input_shapes": [[256],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 1999, "rf_id": 1274, "parent": 1959, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[536,537,0,589824,4,"cuda:0"],-0.100000], "input_shapes": [[256,256,3,3],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 2000, "rf_id": 1275, "parent": 1959, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[546,547,0,256,4,"cuda:0"],-0.100000], "input_shapes": [[256],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 2001, "rf_id": 1276, "parent": 1959, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[548,549,0,256,4,"cuda:0"],-0.100000], "input_shapes": [[256],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 2002, "rf_id": 1277, "parent": 1959, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[573,574,0,589824,4,"cuda:0"],-0.100000], "input_shapes": [[256,256,3,3],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 2003, "rf_id": 1278, "parent": 1959, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[585,586,0,256,4,"cuda:0"],-0.100000], "input_shapes": [[256],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 2004, "rf_id": 1279, "parent": 1959, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[587,588,0,256,4,"cuda:0"],-0.100000], "input_shapes": [[256],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 2005, "rf_id": 1280, "parent": 1959, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[613,614,0,1179648,4,"cuda:0"],-0.100000], "input_shapes": [[512,256,3,3],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 2006, "rf_id": 1281, "parent": 1959, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[625,626,0,512,4,"cuda:0"],-0.100000], "input_shapes": [[512],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 2007, "rf_id": 1282, "parent": 1959, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[627,628,0,512,4,"cuda:0"],-0.100000], "input_shapes": [[512],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 2008, "rf_id": 1283, "parent": 1959, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[652,653,0,2359296,4,"cuda:0"],-0.100000], "input_shapes": [[512,512,3,3],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 2009, "rf_id": 1284, "parent": 1959, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[664,665,0,512,4,"cuda:0"],-0.100000], "input_shapes": [[512],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 2010, "rf_id": 1285, "parent": 1959, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[666,667,0,512,4,"cuda:0"],-0.100000], "input_shapes": [[512],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 2011, "rf_id": 1286, "parent": 1959, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[689,690,0,131072,4,"cuda:0"],-0.100000], "input_shapes": [[512,256,1,1],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 2012, "rf_id": 1287, "parent": 1959, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[701,702,0,512,4,"cuda:0"],-0.100000], "input_shapes": [[512],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 2013, "rf_id": 1288, "parent": 1959, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[703,704,0,512,4,"cuda:0"],-0.100000], "input_shapes": [[512],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 2014, "rf_id": 1289, "parent": 1959, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[729,730,0,2359296,4,"cuda:0"],-0.100000], "input_shapes": [[512,512,3,3],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 2015, "rf_id": 1290, "parent": 1959, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[739,740,0,512,4,"cuda:0"],-0.100000], "input_shapes": [[512],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 2016, "rf_id": 1291, "parent": 1959, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[741,742,0,512,4,"cuda:0"],-0.100000], "input_shapes": [[512],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 2017, "rf_id": 1292, "parent": 1959, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[766,767,0,2359296,4,"cuda:0"],-0.100000], "input_shapes": [[512,512,3,3],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 2018, "rf_id": 1293, "parent": 1959, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[778,779,0,512,4,"cuda:0"],-0.100000], "input_shapes": [[512],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 2019, "rf_id": 1294, "parent": 1959, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[780,781,0,512,4,"cuda:0"],-0.100000], "input_shapes": [[512],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 2020, "rf_id": 1295, "parent": 1959, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[812,813,0,512000,4,"cuda:0"],-0.100000], "input_shapes": [[1000,512],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::result_type", "id": 2021, "rf_id": 1296, "parent": 1959, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::result_type.Scalar(Tensor tensor, Scalar other) -> ScalarType",
+      "inputs": [[814,815,0,1000,4,"cuda:0"],-0.100000], "input_shapes": [[1000],[]], "input_types": ["Tensor(float)","Double"],
+      "outputs": [6], "output_shapes": [[]], "output_types": ["Int"]
+    },
+    {
+      "name": "aten::_foreach_add_", "id": 1959, "rf_id": 1234, "parent": 1485, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::_foreach_add_.List(Tensor(a!)[] self, Tensor[] other, *, Scalar alpha=1) -> ()",
+      "inputs": [[[20,21,0,9408,4,"cuda:0"],[34,35,0,64,4,"cuda:0"],[36,37,0,64,4,"cuda:0"],[67,68,0,36864,4,"cuda:0"],[80,81,0,64,4,"cuda:0"],[82,83,0,64,4,"cuda:0"],[107,108,0,36864,4,"cuda:0"],[119,120,0,64,4,"cuda:0"],[121,122,0,64,4,"cuda:0"],[147,148,0,36864,4,"cuda:0"],[159,160,0,64,4,"cuda:0"],[161,162,0,64,4,"cuda:0"],[186,187,0,36864,4,"cuda:0"],[198,199,0,64,4,"cuda:0"],[200,201,0,64,4,"cuda:0"],[226,227,0,73728,4,"cuda:0"],[238,239,0,128,4,"cuda:0"],[240,241,0,128,4,"cuda:0"],[265,266,0,147456,4,"cuda:0"],[277,278,0,128,4,"cuda:0"],[279,280,0,128,4,"cuda:0"],[302,303,0,8192,4,"cuda:0"],[314,315,0,128,4,"cuda:0"],[316,317,0,128,4,"cuda:0"],[342,343,0,147456,4,"cuda:0"],[353,354,0,128,4,"cuda:0"],[355,356,0,128,4,"cuda:0"],[380,381,0,147456,4,"cuda:0"],[392,393,0,128,4,"cuda:0"],[394,395,0,128,4,"cuda:0"],[420,421,0,294912,4,"cuda:0"],[432,433,0,256,4,"cuda:0"],[434,435,0,256,4,"cuda:0"],[459,460,0,589824,4,"cuda:0"],[471,472,0,256,4,"cuda:0"],[473,474,0,256,4,"cuda:0"],[496,497,0,32768,4,"cuda:0"],[508,509,0,256,4,"cuda:0"],[510,511,0,256,4,"cuda:0"],[536,537,0,589824,4,"cuda:0"],[546,547,0,256,4,"cuda:0"],[548,549,0,256,4,"cuda:0"],[573,574,0,589824,4,"cuda:0"],[585,586,0,256,4,"cuda:0"],[587,588,0,256,4,"cuda:0"],[613,614,0,1179648,4,"cuda:0"],[625,626,0,512,4,"cuda:0"],[627,628,0,512,4,"cuda:0"],[652,653,0,2359296,4,"cuda:0"],[664,665,0,512,4,"cuda:0"],[666,667,0,512,4,"cuda:0"],[689,690,0,131072,4,"cuda:0"],[701,702,0,512,4,"cuda:0"],[703,704,0,512,4,"cuda:0"],[729,730,0,2359296,4,"cuda:0"],[739,740,0,512,4,"cuda:0"],[741,742,0,512,4,"cuda:0"],[766,767,0,2359296,4,"cuda:0"],[778,779,0,512,4,"cuda:0"],[780,781,0,512,4,"cuda:0"],[812,813,0,512000,4,"cuda:0"],[814,815,0,1000,4,"cuda:0"]],[[1709,1710,0,9408,4,"cuda:0"],[1711,1712,0,64,4,"cuda:0"],[1713,1714,0,64,4,"cuda:0"],[1715,1716,0,36864,4,"cuda:0"],[1717,1718,0,64,4,"cuda:0"],[1719,1720,0,64,4,"cuda:0"],[1721,1722,0,36864,4,"cuda:0"],[1723,1724,0,64,4,"cuda:0"],[1725,1726,0,64,4,"cuda:0"],[1727,1728,0,36864,4,"cuda:0"],[1729,1730,0,64,4,"cuda:0"],[1731,1732,0,64,4,"cuda:0"],[1733,1734,0,36864,4,"cuda:0"],[1735,1736,0,64,4,"cuda:0"],[1737,1738,0,64,4,"cuda:0"],[1739,1740,0,73728,4,"cuda:0"],[1741,1742,0,128,4,"cuda:0"],[1743,1744,0,128,4,"cuda:0"],[1745,1746,0,147456,4,"cuda:0"],[1747,1748,0,128,4,"cuda:0"],[1749,1750,0,128,4,"cuda:0"],[1751,1752,0,8192,4,"cuda:0"],[1753,1754,0,128,4,"cuda:0"],[1755,1756,0,128,4,"cuda:0"],[1757,1758,0,147456,4,"cuda:0"],[1759,1760,0,128,4,"cuda:0"],[1761,1762,0,128,4,"cuda:0"],[1763,1764,0,147456,4,"cuda:0"],[1765,1766,0,128,4,"cuda:0"],[1767,1768,0,128,4,"cuda:0"],[1769,1770,0,294912,4,"cuda:0"],[1771,1772,0,256,4,"cuda:0"],[1773,1774,0,256,4,"cuda:0"],[1775,1776,0,589824,4,"cuda:0"],[1777,1778,0,256,4,"cuda:0"],[1779,1780,0,256,4,"cuda:0"],[1781,1782,0,32768,4,"cuda:0"],[1783,1784,0,256,4,"cuda:0"],[1785,1786,0,256,4,"cuda:0"],[1787,1788,0,589824,4,"cuda:0"],[1789,1790,0,256,4,"cuda:0"],[1791,1792,0,256,4,"cuda:0"],[1793,1794,0,589824,4,"cuda:0"],[1795,1796,0,256,4,"cuda:0"],[1797,1798,0,256,4,"cuda:0"],[1799,1800,0,1179648,4,"cuda:0"],[1801,1802,0,512,4,"cuda:0"],[1803,1804,0,512,4,"cuda:0"],[1805,1806,0,2359296,4,"cuda:0"],[1807,1808,0,512,4,"cuda:0"],[1809,1810,0,512,4,"cuda:0"],[1811,1812,0,131072,4,"cuda:0"],[1813,1814,0,512,4,"cuda:0"],[1815,1816,0,512,4,"cuda:0"],[1817,1818,0,2359296,4,"cuda:0"],[1819,1820,0,512,4,"cuda:0"],[1821,1822,0,512,4,"cuda:0"],[1823,1824,0,2359296,4,"cuda:0"],[1825,1826,0,512,4,"cuda:0"],[1827,1828,0,512,4,"cuda:0"],[1829,1830,0,512000,4,"cuda:0"],[1831,1832,0,1000,4,"cuda:0"]],-0.100000], "input_shapes": [[[64,3,7,7],[64],[64],[64,64,3,3],[64],[64],[64,64,3,3],[64],[64],[64,64,3,3],[64],[64],[64,64,3,3],[64],[64],[128,64,3,3],[128],[128],[128,128,3,3],[128],[128],[128,64,1,1],[128],[128],[128,128,3,3],[128],[128],[128,128,3,3],[128],[128],[256,128,3,3],[256],[256],[256,256,3,3],[256],[256],[256,128,1,1],[256],[256],[256,256,3,3],[256],[256],[256,256,3,3],[256],[256],[512,256,3,3],[512],[512],[512,512,3,3],[512],[512],[512,256,1,1],[512],[512],[512,512,3,3],[512],[512],[512,512,3,3],[512],[512],[1000,512],[1000]],[[64,3,7,7],[64],[64],[64,64,3,3],[64],[64],[64,64,3,3],[64],[64],[64,64,3,3],[64],[64],[64,64,3,3],[64],[64],[128,64,3,3],[128],[128],[128,128,3,3],[128],[128],[128,64,1,1],[128],[128],[128,128,3,3],[128],[128],[128,128,3,3],[128],[128],[256,128,3,3],[256],[256],[256,256,3,3],[256],[256],[256,128,1,1],[256],[256],[256,256,3,3],[256],[256],[256,256,3,3],[256],[256],[512,256,3,3],[512],[512],[512,512,3,3],[512],[512],[512,256,1,1],[512],[512],[512,512,3,3],[512],[512],[512,512,3,3],[512],[512],[1000,512],[1000]],[]], "input_types": ["GenericList[Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float)]","GenericList[Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float),Tensor(float)]","Double"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "Optimizer.step#SGD.step", "id": 1485, "rf_id": 982, "parent": 2, "fw_parent": 0, "seq_id": -1, "scope": 7, "tid": 1, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::add_", "id": 2024, "rf_id": 1297, "parent": 2, "fw_parent": 0, "seq_id": 802, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::add_.Tensor(Tensor(a!) self, Tensor other, *, Scalar alpha=1) -> Tensor(a!)",
+      "inputs": [[2022,2023,0,1,4,"cuda:0"],[839,840,0,1,4,"cuda:0"],1], "input_shapes": [[1],[],[]], "input_types": ["Tensor(float)","Tensor(float)","Int"],
+      "outputs": [[2022,2023,0,1,4,"cuda:0"]], "output_shapes": [[1]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty", "id": 2026, "rf_id": 1299, "parent": 2025, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[0],6,0,"cpu",false,"<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","Int","Device","Bool","None"],
+      "outputs": [[1689,57,0,0,4,"cpu"]], "output_shapes": [[0]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::to", "id": 2027, "rf_id": 1300, "parent": 2025, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::to.device(Tensor(a) self, Device device, ScalarType dtype, bool non_blocking=False, bool copy=False, MemoryFormat? memory_format=None) -> Tensor(a)",
+      "inputs": [[1689,57,0,0,4,"cpu"],"cpu",6,false,false,"<None>"], "input_shapes": [[0],[],[],[],[],[]], "input_types": ["Tensor(float)","Device","Int","Bool","Bool","None"],
+      "outputs": [[1689,57,0,0,4,"cpu"]], "output_shapes": [[0]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::lift_fresh", "id": 2028, "rf_id": 1301, "parent": 2025, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::lift_fresh(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[1689,57,0,0,4,"cpu"]], "input_shapes": [[0]], "input_types": ["Tensor(float)"],
+      "outputs": [[1689,57,0,0,4,"cpu"]], "output_shapes": [[0]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "detach_", "id": 2030, "rf_id": 1303, "parent": 2029, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "",
+      "inputs": [[1689,57,0,0,4,"cpu"]], "input_shapes": [[0]], "input_types": ["Tensor(float)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::detach_", "id": 2029, "rf_id": 1302, "parent": 2025, "fw_parent": 0, "seq_id": 803, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::detach_(Tensor(a!) self) -> Tensor(a!)",
+      "inputs": [[1689,57,0,0,4,"cpu"]], "input_shapes": [[0]], "input_types": ["Tensor(float)"],
+      "outputs": [[1689,57,0,0,4,"cpu"]], "output_shapes": [[0]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::set_", "id": 2031, "rf_id": 1304, "parent": 2025, "fw_parent": 0, "seq_id": 803, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::set_.source_Storage_storage_offset(Tensor(a!) self, Storage source, SymInt storage_offset, SymInt[] size, SymInt[] stride=[]) -> Tensor(a!)",
+      "inputs": [[1689,57,0,0,4,"cpu"],"<Storage>",0,[128,3,224,224],[150528,50176,224,1]], "input_shapes": [[0],[],[],[[],[],[],[]],[[],[],[],[]]], "input_types": ["Tensor(float)","Storage","Int","GenericList[Int,Int,Int,Int]","GenericList[Int,Int,Int,Int]"],
+      "outputs": [[1689,2032,0,19267584,4,"cpu"]], "output_shapes": [[128,3,224,224]], "output_types": ["Tensor(float)"]
+    },
+    {
+      "name": "aten::empty", "id": 2033, "rf_id": 1305, "parent": 2025, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::empty.memory_format(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor",
+      "inputs": [[0],4,0,"cpu",false,"<None>"], "input_shapes": [[[]],[],[],[],[],[]], "input_types": ["GenericList[Int]","Int","Int","Device","Bool","None"],
+      "outputs": [[1692,57,0,0,8,"cpu"]], "output_shapes": [[0]], "output_types": ["Tensor(long int)"]
+    },
+    {
+      "name": "aten::to", "id": 2034, "rf_id": 1306, "parent": 2025, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::to.device(Tensor(a) self, Device device, ScalarType dtype, bool non_blocking=False, bool copy=False, MemoryFormat? memory_format=None) -> Tensor(a)",
+      "inputs": [[1692,57,0,0,8,"cpu"],"cpu",4,false,false,"<None>"], "input_shapes": [[0],[],[],[],[],[]], "input_types": ["Tensor(long int)","Device","Int","Bool","Bool","None"],
+      "outputs": [[1692,57,0,0,8,"cpu"]], "output_shapes": [[0]], "output_types": ["Tensor(long int)"]
+    },
+    {
+      "name": "aten::lift_fresh", "id": 2035, "rf_id": 1307, "parent": 2025, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::lift_fresh(Tensor(a) self) -> Tensor(a)",
+      "inputs": [[1692,57,0,0,8,"cpu"]], "input_shapes": [[0]], "input_types": ["Tensor(long int)"],
+      "outputs": [[1692,57,0,0,8,"cpu"]], "output_shapes": [[0]], "output_types": ["Tensor(long int)"]
+    },
+    {
+      "name": "detach_", "id": 2037, "rf_id": 1309, "parent": 2036, "fw_parent": 0, "seq_id": -1, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "",
+      "inputs": [[1692,57,0,0,8,"cpu"]], "input_shapes": [[0]], "input_types": ["Tensor(long int)"],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "aten::detach_", "id": 2036, "rf_id": 1308, "parent": 2025, "fw_parent": 0, "seq_id": 803, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::detach_(Tensor(a!) self) -> Tensor(a!)",
+      "inputs": [[1692,57,0,0,8,"cpu"]], "input_shapes": [[0]], "input_types": ["Tensor(long int)"],
+      "outputs": [[1692,57,0,0,8,"cpu"]], "output_shapes": [[0]], "output_types": ["Tensor(long int)"]
+    },
+    {
+      "name": "aten::set_", "id": 2038, "rf_id": 1310, "parent": 2025, "fw_parent": 0, "seq_id": 803, "scope": 0, "tid": 1, "fw_tid": 0, "op_schema": "aten::set_.source_Storage_storage_offset(Tensor(a!) self, Storage source, SymInt storage_offset, SymInt[] size, SymInt[] stride=[]) -> Tensor(a!)",
+      "inputs": [[1692,57,0,0,8,"cpu"],"<Storage>",0,[128],[1]], "input_shapes": [[0],[],[],[[]],[[]]], "input_types": ["Tensor(long int)","Storage","Int","GenericList[Int]","GenericList[Int]"],
+      "outputs": [[1692,2039,0,128,8,"cpu"]], "output_shapes": [[128]], "output_types": ["Tensor(long int)"]
+    },
+    {
+      "name": "enumerate(DataLoader)#_MultiProcessingDataLoaderIter.__next__", "id": 2025, "rf_id": 1298, "parent": 2, "fw_parent": 0, "seq_id": -1, "scope": 7, "tid": 1, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    },
+    {
+      "name": "[pytorch|profiler|execution_graph|process]", "id": 1, "rf_id": 0, "parent": 1, "fw_parent": 0, "seq_id": -1, "scope": 7, "tid": 0, "fw_tid": 0, "op_schema": "",
+      "inputs": [], "input_shapes": [], "input_types": [],
+      "outputs": [], "output_shapes": [], "output_types": []
+    }
+  ],
+  "finish_ts": 68995724
+}

--- a/train/compute/python/test/test_trace_link.py
+++ b/train/compute/python/test/test_trace_link.py
@@ -1,0 +1,28 @@
+import unittest
+from param_bench.train.compute.python.tools.trace_link import trace_analysis, exact_match, approximate_match
+
+
+class TestTraceLink(unittest.TestCase):
+    def test_exact_match(self):
+        et_file = './data/linear_et.json'
+        kineto_file = './data/linear_kineto.json'
+        # Annotation to slice multiple iterations in kineto trace
+        annotation = 'Optimizer.step#SGD.step'
+
+        et_nodes, kineto_et_events = trace_analysis(et_file, kineto_file, annotation)
+        et_enhanced = exact_match(kineto_et_events, et_nodes)
+        self.assertTrue(et_enhanced)
+
+    def test_approximate_match(self):
+        et_file = './data/resnet_et.json'
+        kineto_file = './data/resnet_kineto.json'
+        # Annotation to slice multiple iterations in kineto trace
+        annotation = 'enumerate(DataLoader)#_MultiProcessingDataLoaderIter.__next__'
+
+        et_nodes, kineto_et_events = trace_analysis(et_file, kineto_file, annotation)
+        et_enhanced = approximate_match(kineto_et_events, et_nodes)
+        self.assertTrue(et_enhanced)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/train/compute/python/tools/trace_link.py
+++ b/train/compute/python/tools/trace_link.py
@@ -1,0 +1,137 @@
+import json
+from param_bench.train.compute.python.tools.execution_graph import ExecutionGraph
+
+def read_dictionary_from_json(file_path):
+    with open(file_path, 'r') as file:
+        data = json.load(file)
+        return data
+
+
+def find_node(nodes, target_name):
+    target_node = None
+    found = False  # Flag variable to track search status
+
+    def traverse(root, target_name):
+        nonlocal target_node, found
+
+        if found:  # If target node is already found, exit immediately
+            return
+
+        for node in root.children:
+            if node.name == target_name:
+                target_node = node
+                found = True  # Set the flag to indicate target node is found
+                return  # Immediately return when target node is found
+
+            traverse(node, target_name)
+
+    root = nodes[1]
+    traverse(root, target_name)
+    return target_node
+
+
+def find_node_with_children(nodes, target_node_name, child_name):
+    target_node = None
+    found = False  # Flag variable to track search status
+
+    def traverse(root, target_node_name, child_name):
+        nonlocal target_node, found
+
+        if found:  # If target node is already found, exit immediately
+            return
+
+        if root.name == target_node_name:
+            for child in root.children:
+                if child_name in child.name.lower():
+                    target_node = root
+                    found = True
+                    return
+
+        for child in root.children:
+            traverse(child, target_node_name, child_name)
+
+    root = nodes[1]
+    traverse(root, target_node_name, child_name)
+    return target_node
+
+
+def collect_nodes(node):
+    def traverse(node):
+        nonlocal nodes
+        nodes.append(node)
+        for child in node.children:
+            traverse(child)
+
+    nodes = []
+    traverse(node)
+    nodes = nodes[1:]
+    sorted_nodes = sorted(nodes, key=lambda x: x.id)
+    return sorted_nodes
+
+
+if __name__ == "__main__":
+    import argparse
+    
+    parser = argparse.ArgumentParser(description="Link kineto trace with execution trace")
+    parser.add_argument("--et_file", type=str, required=True, help="Path to the execution trace file")
+    parser.add_argument("--kineto_file", type=str, required=True, help="Path to the kineto trace file")
+    parser.add_argument("--annotation", type=str, required=True, help="User annotation of the iteration step of execution trace")
+
+    args = parser.parse_args()
+
+    # Analysis of kineto trace
+    kineto_trace_events = read_dictionary_from_json(args.kineto_file)['traceEvents']
+
+    annotation_event = [event for event in kineto_trace_events if 'name' in event and event['name'] == args.annotation]
+    assert(len(annotation_event) == 1)
+    sorted_kineto_trace_events = sorted(kineto_trace_events, key=lambda kv: kv['ts'])
+
+    kineto_trace_events_under_annotation = [event for event in sorted_kineto_trace_events if event['ts'] > annotation_event[0]['ts'] and event['ts'] < annotation_event[0]['ts'] + annotation_event[0]['dur']]
+    kineto_et_events = [event for event in kineto_trace_events_under_annotation if event['cat'] == 'cpu_op' or event['cat'] == 'user_annotation']
+
+    print('Number of captured ops in kineto trace: ', len(kineto_et_events))
+
+    # Analysis of execution trace
+    with open(args.et_file, 'r') as f:
+        et = ExecutionGraph(json.load(f))
+
+    nodes = et.get_nodes(clean=True)
+    annotation_node = find_node(nodes, args.annotation)
+
+    # Backward ops in ET are not under the user annotation node (e.g., iteration#xxx), so we need to find their root node first
+    backward_thread_node = find_node_with_children(nodes, '[pytorch|profiler|execution_graph|thread]', 'backward')
+
+    # Redirect the parent of the backward nodes to the user annotation node
+    for child in backward_thread_node.children:
+        child.parent = annotation_node
+        annotation_node.children.append(child)
+
+    et_nodes = collect_nodes(annotation_node)
+
+    print('Number of captured ops in execution trace: ', len(et_nodes))
+    
+    # Duration of et nodes
+    et_node_dur = {}
+
+    # Link kineto trace and execution trace
+    for i in range(len(et_nodes)):
+        et_node = et_nodes[i]
+        kineto_et_event = kineto_et_events[i]
+        if et_node.name != kineto_et_event['name']:
+            print('Ops mismatch between kineto and execution trace:')
+            print(f'Op index: {i}, kineto op name: {kineto_et_event["name"]}, kineto op timestamp: {kineto_et_event["ts"]}, \
+                    execution trace op name: {et_node.name}, execution trace op id: {et_node.id}')
+            exit(0)
+        else:
+            et_node_dur[et_node.id] = kineto_et_event['dur']
+
+    # Add duration time to each et node and dump as et_plus
+    with open(args.et_file, 'r') as f:
+        et = json.load(f)
+        for node in et['nodes']:
+            if node['id'] in et_node_dur:
+                node['dur'] = et_node_dur[node['id']]
+    
+    et_plus_file = args.et_file.replace('.json', '_plus.json')
+    with open(et_plus_file, 'w') as f:
+        json.dump(et, f, indent=4)

--- a/train/compute/python/tools/trace_link.py
+++ b/train/compute/python/tools/trace_link.py
@@ -1,5 +1,13 @@
+import networkx as nx
+from networkx.algorithms import isomorphism
 import json
 from param_bench.train.compute.python.tools.execution_graph import ExecutionGraph
+import sys
+
+
+# Increase recursion limit
+sys.setrecursionlimit(10**6)
+
 
 def read_dictionary_from_json(file_path):
     with open(file_path, 'r') as file:
@@ -7,54 +15,7 @@ def read_dictionary_from_json(file_path):
         return data
 
 
-def find_node(nodes, target_name):
-    target_node = None
-    found = False  # Flag variable to track search status
-
-    def traverse(root, target_name):
-        nonlocal target_node, found
-
-        if found:  # If target node is already found, exit immediately
-            return
-
-        for node in root.children:
-            if node.name == target_name:
-                target_node = node
-                found = True  # Set the flag to indicate target node is found
-                return  # Immediately return when target node is found
-
-            traverse(node, target_name)
-
-    root = nodes[1]
-    traverse(root, target_name)
-    return target_node
-
-
-def find_node_with_children(nodes, target_node_name, child_name):
-    target_node = None
-    found = False  # Flag variable to track search status
-
-    def traverse(root, target_node_name, child_name):
-        nonlocal target_node, found
-
-        if found:  # If target node is already found, exit immediately
-            return
-
-        if root.name == target_node_name:
-            for child in root.children:
-                if child_name in child.name.lower():
-                    target_node = root
-                    found = True
-                    return
-
-        for child in root.children:
-            traverse(child, target_node_name, child_name)
-
-    root = nodes[1]
-    traverse(root, target_node_name, child_name)
-    return target_node
-
-
+# Add and sort ET nodes from the execution graph  
 def collect_nodes(node):
     def traverse(node):
         nonlocal nodes
@@ -64,9 +25,203 @@ def collect_nodes(node):
 
     nodes = []
     traverse(node)
-    nodes = nodes[1:]
     sorted_nodes = sorted(nodes, key=lambda x: x.id)
     return sorted_nodes
+
+
+class Kineto_node:
+    def __init__(self, name, start, end, id):
+        self.name = name
+        self.start = start
+        self.end = end
+        self.id = id
+        self.children = []
+
+
+# Function to transform your self-defined tree to a directed graph with max depth
+def transform_to_graph_depth(node, max_depth=100):
+    graph = nx.DiGraph()
+    add_node_to_graph_depth(node, graph, max_depth, 1)
+    return graph
+
+
+# Helper function to recursively add nodes and edges to the graph with max depth
+def add_node_to_graph_depth(node, graph, max_depth, cur_depth):
+    graph.add_node(node.id, label=node.name)
+    if cur_depth == max_depth:
+        return
+    for child in node.children:
+        graph.add_node(node.id, label=node.name)
+        add_node_to_graph_depth(child, graph, max_depth, cur_depth + 1)
+
+
+# Custom node comparison function for edit distance
+def node_compare(n1, n2):
+    return n1 == n2
+
+
+# Find the segment that has a length closest to the target
+def find_closest_segment(segs, target_length):
+    closest_length = float('inf')
+    closest_seg = None
+
+    for seg in segs:
+        length_difference = abs(len(seg) - target_length)
+        if length_difference < closest_length:
+            closest_length = length_difference
+            closest_seg = seg
+
+    return closest_seg
+
+
+def exact_match(kineto_et_events, et_nodes):
+    # Since kineto trace is missing the annotations for processes/threads, we add them back to match with ET
+    kineto_event_per_thread = {}
+
+    process_end_time = -1
+    for i in range(len(kineto_et_events)):
+        event = kineto_et_events[i]
+        if event['tid'] not in kineto_event_per_thread:
+            kineto_event_per_thread[event['tid']] = {}
+            kineto_event_per_thread[event['tid']]['ts'] = event['ts']
+            kineto_event_per_thread[event['tid']]['dur'] = event['ts'] + event['dur']
+            kineto_event_per_thread[event['tid']]['index'] = i
+        else:
+            kineto_event_per_thread[event['tid']]['dur'] = max(kineto_event_per_thread[event['tid']]['dur'], event['ts'] + event['dur'])
+        process_end_time = max(process_end_time, event['ts'] + event['dur'])
+
+    process_event = {'name': '[pytorch|profiler|execution_graph|process]', 'ts': kineto_et_events[0]['ts'], 
+                     'dur': process_end_time - kineto_et_events[0]['ts']}
+
+    kineto_et_events.insert(0, process_event)
+    
+    sorted_threads = dict(sorted(kineto_event_per_thread.items(), key=lambda x: x[1]['index']))
+
+    for index, (tid, thread_info) in enumerate(sorted_threads.items()):
+        thread_event = {'name': '[pytorch|profiler|execution_graph|thread]', 'ts': thread_info['ts'], 'dur': thread_info['dur']}
+        # Be careful of the insertion position, note that we already inserted process event
+        kineto_et_events.insert(index + 1 + thread_info['index'], thread_event)
+
+    # Duration of ET nodes
+    et_enhanced = {}
+
+    # Link kineto trace and execution trace
+    if len(kineto_et_events) == len(et_nodes):
+        for i in range(len(et_nodes)):
+            et_node = et_nodes[i]
+            kineto_et_event = kineto_et_events[i]
+            if et_node.name == kineto_et_event['name'] or ('iteration#' in et_node.name and 'iteration#' in kineto_et_event['name']):
+                et_enhanced[et_node.id] = kineto_et_event['dur']
+            else:
+                print('Op mismatch between kineto and execution trace:')
+                print(f'Op index: {i}, kineto op name: {kineto_et_event["name"]}, kineto op timestamp: {kineto_et_event["ts"]}, ' 
+                    f'execution trace op name: {et_node.name}, execution trace op id: {et_node.id}')
+                exit(0)
+    else:
+        print('Ops count mismatch between kineto and execution trace')
+
+    return et_enhanced
+
+
+def approximate_match(kineto_et_events, et_nodes):
+    # Since kineto trace is missing the annotations for processes/threads, we add them back to match with ET
+    kineto_event_per_thread = {}
+
+    # Mapping node id to the corresponding node
+    kineto_nodes_mapping = {}
+
+    for event in kineto_et_events:
+        if event['tid'] not in kineto_event_per_thread:
+            kineto_event_per_thread[event['tid']] = []
+        kineto_event_per_thread[event['tid']].append(event)
+    
+    start_time = kineto_et_events[0]['ts']
+    end_time = -1
+    for event in kineto_et_events:
+        end_time = max(end_time, event['ts'] + event['dur'])
+    process_node = Kineto_node('[pytorch|profiler|execution_graph|process]', start_time, end_time, 0)
+    kineto_nodes_mapping[0] = process_node
+
+    cnt = 1
+    for thread in kineto_event_per_thread:
+        start_time = kineto_event_per_thread[thread][0]['ts']
+        end_time = -1
+        for event in kineto_event_per_thread[thread]:
+            end_time = max(end_time, event['ts'] + event['dur'])
+
+        thread_node = Kineto_node('[pytorch|profiler|execution_graph|thread]', start_time, end_time, cnt)
+        kineto_nodes_mapping[cnt] = thread_node
+        cnt += 1
+
+        process_node.children.append(thread_node)
+
+        kineto_nodes = [thread_node]
+        for event in kineto_event_per_thread[thread]:
+            if event['ts'] < kineto_nodes[-1].end:
+                tmp = Kineto_node(event['name'], event['ts'], event['ts'] + event['dur'], cnt)
+                kineto_nodes_mapping[cnt] = tmp
+                cnt += 1
+                kineto_nodes[-1].children.append(tmp)
+                kineto_nodes.append(tmp)
+            else:
+                while kineto_nodes[-1].end <= event['ts']:
+                    kineto_nodes.pop()
+                tmp = Kineto_node(event['name'], event['ts'], event['ts'] + event['dur'], cnt)
+                kineto_nodes_mapping[cnt] = tmp
+                cnt += 1
+                kineto_nodes[-1].children.append(tmp)
+                kineto_nodes.append(tmp)
+
+    # Max call stack depth when building the tree, the deeper the more accurate but takes longer time
+    depth = 10
+
+    # Build a tree from the kineto trace
+    kineto_graph = transform_to_graph_depth(process_node, depth)
+    print("Kineto tree nodes number: ", len(kineto_graph.nodes))
+
+    # Build a tree from the execution trace
+    et_graph = transform_to_graph_depth(et_nodes[0], depth)
+    print("ET tree nodes number: ", len(et_graph.nodes))
+
+    # print("Kineto nodes info: ", list(kineto_graph.nodes(data=True)))
+    # print("ET nodes info: ", list(et_graph.nodes(data=True)))
+
+    # Create the GraphMatcher
+    GM = isomorphism.GraphMatcher(kineto_graph, et_graph)
+
+    # Duration of ET nodes
+    et_enhanced = {}
+
+    if GM.is_isomorphic():
+        mapping = GM.mapping
+        print("Graphs are isomorphic")
+        for kineto_id, et_id in mapping.items():
+            et_enhanced[et_id] = kineto_nodes_mapping[kineto_id].end - kineto_nodes_mapping[kineto_id].start
+    else:
+        print("Graphs are not isomorphic")
+
+        # # Compute the edit distance using the graph_edit_distance function with node comparison
+        # paths, cost = nx.graph_edit_distance(kineto_graph, et_graph, node_compare)
+        # print("Tree edit distance:", cost)
+
+        # The problem of finding the exact Graph Edit Distance (GED) is NP-hard so it is often slow
+        # and below is a sub-optimal approach
+
+        edit_distance_generator = nx.optimize_graph_edit_distance(kineto_graph, et_graph, node_compare)
+        cost = next(edit_distance_generator)
+
+        paths_generator = nx.optimize_edit_paths(kineto_graph, et_graph, node_compare)
+        node_edits, edge_edits, cost = next(paths_generator)
+
+        print("Sub-optimal tree edit distance:", cost)
+
+        # print("node_edits: ", node_edits)
+
+        for kineto_id, et_id in node_edits:
+            if kineto_id is not None and et_id is not None:
+                et_enhanced[et_id] = kineto_nodes_mapping[kineto_id].end - kineto_nodes_mapping[kineto_id].start
+
+    return et_enhanced
 
 
 if __name__ == "__main__":
@@ -75,63 +230,80 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Link kineto trace with execution trace")
     parser.add_argument("--et_file", type=str, required=True, help="Path to the execution trace file")
     parser.add_argument("--kineto_file", type=str, required=True, help="Path to the kineto trace file")
-    parser.add_argument("--annotation", type=str, required=True, help="User annotation of the iteration step of execution trace")
+    parser.add_argument("--annotation", default='DataLoader', type=str, help="User annotation of the iteration step of execution trace")
+    parser.add_argument("--exact_match", default=False, action='store_true', help="Whether to match the traces exactly")
 
     args = parser.parse_args()
-
-    # Analysis of kineto trace
-    kineto_trace_events = read_dictionary_from_json(args.kineto_file)['traceEvents']
-
-    annotation_event = [event for event in kineto_trace_events if 'name' in event and event['name'] == args.annotation]
-    assert(len(annotation_event) == 1)
-    sorted_kineto_trace_events = sorted(kineto_trace_events, key=lambda kv: kv['ts'])
-
-    kineto_trace_events_under_annotation = [event for event in sorted_kineto_trace_events if event['ts'] > annotation_event[0]['ts'] and event['ts'] < annotation_event[0]['ts'] + annotation_event[0]['dur']]
-    kineto_et_events = [event for event in kineto_trace_events_under_annotation if event['cat'] == 'cpu_op' or event['cat'] == 'user_annotation']
-
-    print('Number of captured ops in kineto trace: ', len(kineto_et_events))
 
     # Analysis of execution trace
     with open(args.et_file, 'r') as f:
         et = ExecutionGraph(json.load(f))
 
     nodes = et.get_nodes(clean=True)
-    annotation_node = find_node(nodes, args.annotation)
 
-    # Backward ops in ET are not under the user annotation node (e.g., iteration#xxx), so we need to find their root node first
-    backward_thread_node = find_node_with_children(nodes, '[pytorch|profiler|execution_graph|thread]', 'backward')
-
-    # Redirect the parent of the backward nodes to the user annotation node
-    for child in backward_thread_node.children:
-        child.parent = annotation_node
-        annotation_node.children.append(child)
-
-    et_nodes = collect_nodes(annotation_node)
+    # Root node of execution trace is 1-based
+    et_nodes = collect_nodes(nodes[1])
 
     print('Number of captured ops in execution trace: ', len(et_nodes))
-    
-    # Duration of et nodes
-    et_node_dur = {}
 
-    # Link kineto trace and execution trace
-    for i in range(len(et_nodes)):
-        et_node = et_nodes[i]
-        kineto_et_event = kineto_et_events[i]
-        if et_node.name != kineto_et_event['name']:
-            print('Ops mismatch between kineto and execution trace:')
-            print(f'Op index: {i}, kineto op name: {kineto_et_event["name"]}, kineto op timestamp: {kineto_et_event["ts"]}, \
-                    execution trace op name: {et_node.name}, execution trace op id: {et_node.id}')
-            exit(0)
+    # Analysis of kineto trace
+    kineto_trace_events = read_dictionary_from_json(args.kineto_file)['traceEvents']
+
+    sorted_kineto_trace_events = sorted(kineto_trace_events, key=lambda kv: kv['ts'])
+
+    kineto_et_events = [event for event in sorted_kineto_trace_events if 'cat' in event and (event['cat'] == 'cpu_op' or event['cat'] == 'user_annotation')]
+
+    kineto_et_segs = []
+    kineto_et_seg = []
+
+    # The choice below normally does not matter for approximate match since we rely on the isomorphism of
+    # the graphs, but for exact match we will use the execution order and then we should be careful
+
+    # Assume that an iteration ends with the specified annotation
+    end_time = -1
+    for event in kineto_et_events:
+        if end_time > 0 and event['ts'] >= end_time:
+            kineto_et_segs.append(kineto_et_seg)
+            kineto_et_seg = []
+            end_time = -1
+
+        if args.annotation in event['name']:
+            kineto_et_seg.append(event)
+            end_time = event['ts'] + event['dur']
         else:
-            et_node_dur[et_node.id] = kineto_et_event['dur']
+            kineto_et_seg.append(event)
 
-    # Add duration time to each et node and dump as et_plus
-    with open(args.et_file, 'r') as f:
-        et = json.load(f)
-        for node in et['nodes']:
-            if node['id'] in et_node_dur:
-                node['dur'] = et_node_dur[node['id']]
-    
-    et_plus_file = args.et_file.replace('.json', '_plus.json')
-    with open(et_plus_file, 'w') as f:
-        json.dump(et, f, indent=4)
+    # # Assume that an iteration starts with the specified annotation
+    # for event in kineto_et_events:
+    #     if args.annotation in event['name']:
+    #         kineto_et_segs.append(kineto_et_seg)
+    #         kineto_et_seg = [event]
+    #     else:
+    #         kineto_et_seg.append(event)
+
+    # Find the segment in kineto trace (assuming it contains multiple) with the closest ops to ET 
+    # (usually ET has 3 additional annotation ops for processes/threads)
+    kineto_et_events = find_closest_segment(kineto_et_segs, len(et_nodes) - 3)
+
+    # # Just a test to randomly choose a segment
+    # kineto_et_events = kineto_et_segs[3]
+
+    print('Number of captured ops in kineto trace (should be #ops_in_ET - 3): ', len(kineto_et_events))
+
+    if args.exact_match:
+        et_hanced = exact_match(kineto_et_events, et_nodes)
+    else:
+        et_hanced = approximate_match(kineto_et_events, et_nodes)
+
+    # If linking works, add duration time to each ET node and dump as ET_plus
+    if et_hanced:
+        with open(args.et_file, 'r') as f:
+            et = json.load(f)
+            for node in et['nodes']:
+                if node['id'] in et_hanced:
+                    node['dur'] = et_hanced[node['id']]
+        
+        et_plus_file = args.et_file.replace('.json', '_plus.json')
+        print(f'Enhanced execution trace dumped to {et_plus_file}.')
+        with open(et_plus_file, 'w') as f:
+            json.dump(et, f, indent=4)


### PR DESCRIPTION
This implementation supports two match modes: exact match and approximate match. For exact match, two traces must contain the same iteration and the one-on-one operator linking will be based on the execution order. For approximate match, we will first transform the traces to graphs and perform the best-effort match using the tree edit distance. Both will create an enhanced version of execution trace with execution duration of each operator.

Example use:

python trace_link.py --et-file PATH_TO_ET --kineto-file PATH_TO_KINETO_TRACE --annotation OPERATOR_NAME_TO_SLICE_THE_KINETO_TRACE

Currently we assume ET only contains one iteration and kineto trace may contain multiple iterations,  and in case of multiple, the user needs to specify an operator that occurs once per iteration to help slice these iterations. By default, the DataLoader is used.