### PR TITLE
Add warning for trace_link script when annotation is not present, fix write for gzip files

### DIFF
--- a/train/compute/python/tools/utility.py
+++ b/train/compute/python/tools/utility.py
@@ -42,3 +42,13 @@ def read_dictionary_from_json_file(file_path: str) -> Dict[Any, Any]:
         file_path, "r"
     ) as f:
         return json.load(f)
+
+
+def write_dictionary_to_json_file(file_path: str, data: Dict[Any, Any]) -> None:
+    """Write input dictionary to a json file."""
+    if file_path.endswith("gz"):
+        with gzip.open(file_path, "w") as f:
+            f.write(json.dumps(data, indent=4).encode("utf-8"))
+    else:
+        with open(file_path, "w") as f:
+            json.dump(data, f, indent=4)


### PR DESCRIPTION
Summary:
1. Add a warning when annotation is not found
2. Support writing json to gzip files

Differential Revision: D48038506

