### PR TITLE
Refactor TBE generate requests return type

### DIFF
--- a/train/comms/pt/comms_utils.py
+++ b/train/comms/pt/comms_utils.py
@@ -1781,7 +1781,7 @@ def init_emb_lookup(collectiveArgs, commsParams, backendFuncs):
     # If we are doing backward pass, then we need to initialize Lookup tensor using forward pass and grad output
     if collectiveArgs.direction == "backward":
         for i in range(len(collectiveArgs.embRequests)):
-            (indices, offsets, weights) = collectiveArgs.embRequests[i]
+            (indices, offsets, weights) = collectiveArgs.embRequests[i].unpack_3()
             collectiveArgs.LookupOut = collectiveArgs.emb[i].forward(
                 indices,
                 offsets,


### PR DESCRIPTION
Summary:
X-link: https://github.com/pytorch/FBGEMM/pull/2411

This diff refactors the return type of `generate_requests` (TBE random
input generator).  Prior to this diff, `generate_requests` returns
a list of indices, offsets and per sample weights (optional) tuple
(`List[Tuple(Tensor, Tensor, Optional[Tensor])]`).  If we add another
return value to the tuple, we need to update every request tuple
unpacking site and update typing to satisfy Pyre requirements.  Thus,
this diff adds `TBERequest` which is a wrapper of return values of
`generate_requests`.  It allows the user to access each return value
individually or as an arbitrary length tuple.

Differential Revision: D54710610


