### PR TITLE
Sync GPU device for discrete benchmark

### DIFF
--- a/train/compute/python/lib/pytorch/timer.py
+++ b/train/compute/python/lib/pytorch/timer.py
@@ -7,17 +7,21 @@ import torch
 class Timer:
     def __init__(self, device: str):
         self.device: str = device
+        if self.device is None:
+            self.torch_device = None
+        else:
+            self.torch_device = torch.device(self.device)
         self.start_time: float = 0
         self.end_time: float = 0
 
     def start(self):
         if self.device.startswith("cuda"):
-            torch.cuda.synchronize()
+            torch.cuda.synchronize(self.torch_device)
         self.start_time = time.perf_counter()
 
     def stop(self):
         if self.device.startswith("cuda"):
-            torch.cuda.synchronize()
+            torch.cuda.synchronize(self.torch_device)
         self.end_time = time.perf_counter()
 
     # Return result in milliseconds.


### PR DESCRIPTION
Summary:
This diff aims to synchronize the GPU device for discrete benchmark. In discrete benchmark, the op run time is measure after the op runs. However, on device except cuda:0, the run is a-synchronized, the measured time is only the host runtime. 

Added torch.cuda.synchronize call to wait until the op run finishes on GPU.

Differential Revision: D54907227


