### PR TITLE
Set up black for GitHub CI pipeline

### DIFF
--- a/.github/workflows/python_lint.yml
+++ b/.github/workflows/python_lint.yml
@@ -1,0 +1,21 @@
+name: Python Linting
+
+on: [push, pull_request]
+
+jobs:
+  lint-and-format:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.8'
+
+    - name: Install dependencies
+      run: |
+        pip install black
+    - name: Run Black
+      run: black . --check


### PR DESCRIPTION
## Summary
This PR introduces a linter, black, for linting purposes.

## Test Plan
Please refer to the actions tab of the forked repository ([link](https://github.com/TaekyungHeo/param/actions)). At present, PARAM does not pass the linter checks. Additional refactoring is necessary.