### PR TITLE
Configure Project Structure and Refactor Imports for et_replay

### DIFF
--- a/et_replay/.gitignore
+++ b/et_replay/.gitignore
@@ -1,0 +1,2 @@
+build/
+et_replay.egg-info/

--- a/et_replay/pyproject.toml
+++ b/et_replay/pyproject.toml
@@ -1,0 +1,15 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "et_replay"
+version = "0.5.0"
+
+[tool.setuptools.package-dir]
+"et_replay.lib" = "lib"
+"et_replay.tools" = "tools"
+
+[project.scripts]
+et_replay = "et_replay.tools.et_replay:main"
+validate_traces = "et_replay.tools.validate_traces:main"

--- a/et_replay/tools/et_replay.py
+++ b/et_replay/tools/et_replay.py
@@ -12,7 +12,7 @@ from functools import reduce
 
 import numpy as np
 import torch
-from param_bench.et_replay.lib.et_replay_utils import (
+from ..lib.et_replay_utils import (
     build_fbgemm_func,
     build_torchscript_func,
     build_triton_func,
@@ -36,7 +36,7 @@ from param_bench.et_replay.lib.et_replay_utils import (
     TORCH_DTYPES_RNG_str,
 )
 
-from param_bench.et_replay.lib.execution_trace import ExecutionTrace, NodeType
+from et_replay.lib.execution_trace import ExecutionTrace, NodeType
 
 from param_bench.et_replay.lib.utils import trace_handler
 from param_bench.train.comms.pt import comms_utils, commsTraceReplay

--- a/et_replay/tools/validate_trace.py
+++ b/et_replay/tools/validate_trace.py
@@ -9,7 +9,7 @@ from __future__ import (
 import gzip
 import json
 
-from param_bench.et_replay.lib.execution_trace import ExecutionTrace
+from et_replay.lib.execution_trace import ExecutionTrace
 
 
 class TraceValidator:


### PR DESCRIPTION
## Summary
- Created `pyproject.toml` for package setup and script entry points.
- Refactored import paths in `et_replay.py` and `validate_trace.py` to align with new package structure.
- Added `.gitignore` to exclude `build/` and `et_replay.egg-info/`.

## Test Plan
```
$ cd et_replay

$ pip install .
Processing /Users/theo/param/et_replay
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Installing backend dependencies ... done
  Preparing metadata (pyproject.toml) ... done
Building wheels for collected packages: et_replay
  Building wheel for et_replay (pyproject.toml) ... done
  Created wheel for et_replay: filename=et_replay-1.0.0-py3-none-any.whl size=59701 sha256=8bf68250c2b168b1e67ab75ea3d2059d018e2738ec9437bc712c2e3f00da6511
  Stored in directory: /private/var/folders/z0/c9mq5j4s6n14n0_gs7nlt6mc0000gp/T/pip-ephem-wheel-cache-_rrl79h0/wheels/3b/3f/aa/d3fc853f83c22c6f3eeb09763570c2cc8031a1a414cb3c18b6
Successfully built et_replay
Installing collected packages: et_replay
  Attempting uninstall: et_replay
    Found existing installation: et_replay 1.0.0
    Uninstalling et_replay-1.0.0:
      Successfully uninstalled et_replay-1.0.0
Successfully installed et_replay-1.0.0

$ validate_trace ~/Downloads/llama_pytorch24.05/megatron_et_0.json 
num ops = 51343, num comms = 32, num triton ops = 0
Trace validation result =  False

$ et_replay                                                       
Traceback (most recent call last):
  File "/Users/theo/venv/bin/et_replay", line 5, in <module>
    from et_replay.tools.et_replay import main
  File "/Users/theo/venv/lib/python3.10/site-packages/et_replay/tools/et_replay.py", line 15, in <module>
    from ..lib.et_replay_utils import (
  File "/Users/theo/venv/lib/python3.10/site-packages/et_replay/lib/et_replay_utils.py", line 5, in <module>
    from fbgemm_gpu.split_table_batched_embeddings_ops import PoolingMode, WeightDecayMode
ModuleNotFoundError: No module named 'fbgemm_gpu'
```