### PR TITLE
Modified pyproject.toml to support OSS et-replay

### DIFF
--- a/et_replay/pyproject.toml
+++ b/et_replay/pyproject.toml
@@ -7,8 +7,10 @@ name = "et_replay"
 version = "0.5.0"
 
 [tool.setuptools.package-dir]
+"et_replay.lib" = "lib"
 "et_replay.lib.comm" = "lib/comm"
 "et_replay.tools" = "tools"
+"param_bench" = "../../param"
 
 [project.scripts]
 comm_replay = "et_replay.tools.comm_replay:main"


### PR DESCRIPTION
Summary: pyproject.toml misses two componentd in tool.setuptools.package-dir. This DIFF is to add these two components.

Reviewed By: briancoutinho

Differential Revision: D58738954
