### PR TITLE
Bug fix in pyproject.toml of et_replay

### DIFF
--- a/et_replay/pyproject.toml
+++ b/et_replay/pyproject.toml
@@ -10,7 +10,7 @@ version = "0.5.0"
 "et_replay.lib" = "lib"
 "et_replay.lib.comm" = "lib/comm"
 "et_replay.tools" = "tools"
-"param_bench" = "../../param"
+"param_bench" = ".."
 
 [project.scripts]
 comm_replay = "et_replay.tools.comm_replay:main"


### PR DESCRIPTION
## Summary
Bug fix in pyproject.toml of et_replay. The current pyproject.toml does not work when the cloned directory name is not param.
```
$ cd et_replay
$ pwd
/Users/theo/param-test/et_replay
$ pip install .
Processing /Users/theo/param-test/et_replay
  Installing build dependencies ... done
  Getting requirements to build wheel ... error
  error: subprocess-exited-with-error
  
  × Getting requirements to build wheel did not run successfully.
  │ exit code: 1
  ╰─> [6 lines of output]
      running egg_info
      writing et_replay.egg-info/PKG-INFO
      writing dependency_links to et_replay.egg-info/dependency_links.txt
      writing entry points to et_replay.egg-info/entry_points.txt
      writing top-level names to et_replay.egg-info/top_level.txt
      error: package directory '../../param' does not exist
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: subprocess-exited-with-error

× Getting requirements to build wheel did not run successfully.
│ exit code: 1
╰─> See above for output.

note: This error originates from a subprocess, and is likely not a problem with pip.
```

## Test Plan
```
$ pip install .
Processing /Users/theo/param-test/et_replay
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Preparing metadata (pyproject.toml) ... done
Building wheels for collected packages: et_replay
  Building wheel for et_replay (pyproject.toml) ... done
  Created wheel for et_replay: filename=et_replay-0.5.0-py3-none-any.whl size=997368 sha256=c56963b35fca98e8450a47a6252a772839d27dfa09d396a8dbf861f7b83cf252
  Stored in directory: /private/var/folders/z0/c9mq5j4s6n14n0_gs7nlt6mc0000gp/T/pip-ephem-wheel-cache-8h1d4nfy/wheels/0d/e9/00/7607890ab4cb86d84e223f8a52c1c39c41b37d4b31a87a0481
Successfully built et_replay
Installing collected packages: et_replay
  Attempting uninstall: et_replay
    Found existing installation: et_replay 0.5.0
    Uninstalling et_replay-0.5.0:
      Successfully uninstalled et_replay-0.5.0
Successfully installed et_replay-0.5.0
```