### PR TITLE
Refactor backend classes and remove deprecated methods in PyTorch backends

### DIFF
--- a/et_replay/comm/backend/base_backend.py
+++ b/et_replay/comm/backend/base_backend.py
@@ -151,51 +151,6 @@ class BaseBackend(ABC):
 
         self.computeFunc = {"gemm": self.gemm}
 
-    def getBusBW(
-        self, collective: str, algBW: float, collectiveArgs: collectiveArgsHolder
-    ) -> float:
-        """
-        Calculate bus bandwidth for collective.
-
-        Args:
-            collective: Name of collective.
-            algBW: Algorithmic bandwidth for the collective.
-            collectiveArgs: Contains information about world size.
-        Returns:
-            busBW: Bus bandwidth in GBps
-        """
-        busBW = algBW
-        mulFactor = 1.0
-        if collective == "all_reduce":
-            if collectiveArgs.world_size != 0:
-                mulFactor = (
-                    2 * (collectiveArgs.world_size - 1) / (collectiveArgs.world_size)
-                )
-            busBW = algBW * mulFactor
-        elif collective in (
-            "all_to_all_single",
-            "all_to_all",
-            "all_to_allv",
-            "gather",
-            "all_gather",
-            "reduce_scatter",
-            "reduce_scatter_base",
-            "scatter",
-            "all_gather_base",
-        ):
-            if collectiveArgs.world_size != 0:
-                mulFactor = (collectiveArgs.world_size - 1) / (
-                    collectiveArgs.world_size
-                )
-            busBW = algBW * mulFactor
-        elif collective in ("reduce", "broadcast", "incast", "multicast"):
-            busBW = algBW
-        else:
-            logger.error(
-                f"collective: {collective} is not supported in computing bus BW! "
-            )
-        return busBW
-
     def alloc_ones(
         self,
         sizeArr: int,

--- a/et_replay/comm/backend/base_backend.py
+++ b/et_replay/comm/backend/base_backend.py
@@ -125,7 +125,7 @@ class collectiveArgsHolder:
         self.use_ext_dist = False
 
 
-class backendFunctions(ABC):
+class BaseBackend(ABC):
     """Abstract base class, provides common abstraction for all the backends."""
 
     def __init__(self) -> None:
@@ -357,12 +357,12 @@ class backendFunctions(ABC):
         pass
 
 
-customized_backend: Dict[str, backendFunctions] = {}
+customized_backend: Dict[str, BaseBackend] = {}
 
 
 def register_customized_backend(
     name: str,
-    func: backendFunctions,
+    func: BaseBackend,
     device: Optional[str] = None,
 ) -> None:
     global customized_backend

--- a/et_replay/comm/backend/pytorch_dist_backend.py
+++ b/et_replay/comm/backend/pytorch_dist_backend.py
@@ -15,8 +15,10 @@ import torch.distributed as dist
 import torch.nn as nn
 
 from et_replay.comm.param_profile import paramProfile
-from et_replay.comm.pytorch_backend_utils import backendFunctions, collectiveArgsHolder
-
+from et_replay.comm.backend.base_backend import (
+    BaseBackend,
+    collectiveArgsHolder,
+)
 
 try:
     from param_bench.train.comms.pt.fb.internals import (
@@ -68,7 +70,7 @@ def _dequantize(obj):
             return resultTensor
 
 
-class PyTorchDistBackend(backendFunctions):
+class PyTorchDistBackend(BaseBackend):
     def get_collective_group(self, collectiveArgs):
         if self.use_ext_dist:
             return collectiveArgs.group.my_pg

--- a/et_replay/comm/backend/pytorch_dist_backend.py
+++ b/et_replay/comm/backend/pytorch_dist_backend.py
@@ -1018,17 +1018,6 @@ class PyTorchDistBackend(BaseBackend):
             tensorList = [t.cpu().detach().numpy() for t in tensorList]
         return np.array(tensorList)
 
-    def initialize_tcpstore(self, master_ip, master_port):
-        global_rank = self.bootstrap_info.global_rank
-        world_size = self.bootstrap_info.world_size
-        self.tcp_store = dist.TCPStore(
-            master_ip,
-            int(master_port),
-            world_size,
-            is_master=(global_rank == 0),
-            use_libuv=True,
-        )
-
     def initialize_backend(
         self, master_ip, master_port, backend="gloo", eager_mode=False
     ):
@@ -1052,7 +1041,13 @@ class PyTorchDistBackend(BaseBackend):
 
         if self.tcp_store is None:
             # TCP store initializaiton for generic CPU data
-            self.initialize_tcpstore(master_ip, master_port)
+            self.tcp_store = dist.TCPStore(
+                master_ip,
+                int(master_port),
+                world_size,
+                is_master=(global_rank == 0),
+                use_libuv=True,
+            )
 
         if not dist.is_initialized():
             # init default process group if not yet initialized or extend_distributed failed or is disabled

--- a/et_replay/comm/backend/pytorch_dist_backend.py
+++ b/et_replay/comm/backend/pytorch_dist_backend.py
@@ -998,18 +998,12 @@ class PyTorchDistBackend(BaseBackend):
             if isinstance(self.commsParams, dict)
             else self.commsParams.backend
         )
-        # Import ucc plugin
-        if backend == "ucc":
-            # try OSS/setup.py
+        # Import Fairring
+        if backend == "fairring":
             try:
-                import torch_ucc  # noqa
+                import fairring  # noqa
             except ImportError:
-                try:
-                    from ucc_plugin import initialize_ucc_plugin
-                except ImportError:
-                    raise RuntimeError("Unable to import initialize_ucc_plugin")
-                else:
-                    initialize_ucc_plugin(backend)
+                raise RuntimeError("Unable to import Fairring")
 
     def get_new_pg(self, group_ranks, backend):
         if self.use_ext_dist:

--- a/et_replay/comm/backend/pytorch_tpu_backend.py
+++ b/et_replay/comm/backend/pytorch_tpu_backend.py
@@ -7,10 +7,10 @@ import torch.nn as nn
 import torch_xla.core.xla_model as xm  # @manual
 import torch_xla.distributed.xla_multiprocessing as xmp  # @manual
 
-from et_replay.comm.comms_utils import backendFunctions
+from et_replay.comm.backend.base_backend import BaseBackend
 
 
-class PyTorchTPUBackend(backendFunctions):
+class PyTorchTPUBackend(BaseBackend):
     def sayHello(self):
         myhost = os.uname()[1]
         device = self.get_device()

--- a/et_replay/comm/commsTraceParser.py
+++ b/et_replay/comm/commsTraceParser.py
@@ -7,7 +7,7 @@ from typing import List, Tuple
 from et_replay import ExecutionTrace
 from et_replay.comm import comms_utils
 from et_replay.comm.comms_utils import commsArgs
-from et_replay.comm.pytorch_backend_utils import supportedP2pOps
+from et_replay.comm.backend.base_backend import supportedP2pOps
 
 tensorDtypeMap = {
     "Tensor(int)": "int",

--- a/et_replay/comm/comms_utils.py
+++ b/et_replay/comm/comms_utils.py
@@ -40,8 +40,8 @@ import numpy as np
 import torch
 
 from et_replay.comm.param_profile import paramTimer
-from et_replay.comm.pytorch_backend_utils import (
-    backendFunctions,
+from et_replay.comm.backend.base_backend import (
+    BaseBackend,
     collectiveArgsHolder,
     customized_backend,
     supportedC10dBackends,
@@ -233,7 +233,7 @@ def fixBeginSize(commsParams: commsParamsHolder, world_size: int) -> None:
 
 
 def get_rank_details(
-    backendFuncs: backendFunctions,
+    backendFuncs: BaseBackend,
 ) -> Tuple[int, int, int, ProcessGroup, str, str]:
     """
     Returns the details of the rank for the current backendFunction.
@@ -699,7 +699,7 @@ class paramStreamGuard(ContextDecorator):
         self,
         stream: Optional[torch.cuda.Stream],
         curDevice: torch.device,
-        backendFuncs: backendFunctions,
+        backendFuncs: BaseBackend,
         is_blocking: bool = True,
         timer: Optional[paramDeviceTimer] = None,
     ) -> None:
@@ -729,7 +729,7 @@ class paramDeviceTimer(paramTimer):
     Device timer.
     """
 
-    def __init__(self, name: str, backendFuncs: backendFunctions) -> None:
+    def __init__(self, name: str, backendFuncs: BaseBackend) -> None:
         """
         Initialize start and end device events
         """
@@ -918,7 +918,7 @@ class paramCommsBench(ABC):
             "char": torch.int8,
         }
         self.supportedDtype = list(self.dtypeMap.keys())
-        self.backendFuncs: backendFunctions
+        self.backendFuncs: BaseBackend
 
         self.collectiveArgs = collectiveArgsHolder()
         self.comm_size = 1

--- a/et_replay/tools/comm_replay.py
+++ b/et_replay/tools/comm_replay.py
@@ -28,7 +28,7 @@ from et_replay.comm.comms_utils import (
     paramToCommName,
 )
 from et_replay.comm.param_profile import paramProfile, paramTimer
-from et_replay.comm.pytorch_backend_utils import supportedP2pOps
+from et_replay.comm.backend.base_backend import supportedP2pOps
 
 try:
     from trainer_iteration_wrapper import setTrainingIteration  # @manual
@@ -1382,11 +1382,11 @@ class commsTraceReplayBench(paramCommsBench):
         """
         # init backend and corresponding function pointers
         if commsParams.nw_stack == "pytorch-dist":
-            from et_replay.comm.pytorch_dist_backend import PyTorchDistBackend
+            from et_replay.comm.backend.pytorch_dist_backend import PyTorchDistBackend
 
             self.backendFuncs = PyTorchDistBackend(bootstrap_info, commsParams)
         elif commsParams.nw_stack == "pytorch-xla-tpu":
-            from et_replay.comm.pytorch_tpu_backend import PyTorchTPUBackend
+            from et_replay.comm.backend.pytorch_tpu_backend import PyTorchTPUBackend
 
             self.backendFuncs = PyTorchTPUBackend(bootstrap_info, commsParams)
         else:


### PR DESCRIPTION
## Summary
- Renamed backendFunctions to BaseBackend and refactored associated modules for improved abstraction.
- Removed getBusBW from BaseBackend.
- Removed initialize_tcpstore and UCC plugin support from PyTorchDistBackend.
- Reorganized module structure by relocating files to a backend directory.

## Test Plan
* Note: The following command was executed using https://github.com/facebookresearch/param/pull/148.
```
$ comm_replay --trace-type et --trace-path /home/sanshang/021_debug/000_code/param/trace/traces_megatronlm_gpt_43B_32ranks_pytnightly0703/execution_trace
```
![image](https://github.com/user-attachments/assets/6c9c2c47-1053-4358-b492-0823b1c55909)