### PR TITLE
Refactor comms trace parser and deprecate support for basic and Kineto traces

### DIFF
--- a/et_replay/comm/commsTraceParser.py
+++ b/et_replay/comm/commsTraceParser.py
@@ -9,6 +9,9 @@ from et_replay.comm import comms_utils
 from et_replay.comm.backend.base_backend import supportedP2pOps
 from et_replay.comm.comms_utils import commsArgs
 
+import logging
+logger = logging.getLogger(__name__)
+
 tensorDtypeMap = {
     "Tensor(int)": "int",
     "Tensor(float)": "float",
@@ -112,7 +115,8 @@ def _parse_proc_group_info(in_trace: ExecutionTrace):
         for pg in pg_objs:
             if not pg["pg_name"].isdecimal():
                 # TODO support local synchronization pg
-                raise ValueError(f"Process group name is {pg['pg_name']} in node {node['id']}, which is not supported.")
+                logger.warning(f"Process group name is {pg['pg_name']} in node {node.id}, which is not supported. Skip.")
+                continue
             (pg_id, ranks, group_size, group_count) = [pg[k] for k in ["pg_name", "ranks", "group_size", "group_count"]]
             pg_id = int(pg_id)
             pg_ranks_map[node.id][pg_id] = (

--- a/et_replay/comm/commsTraceParser.py
+++ b/et_replay/comm/commsTraceParser.py
@@ -160,14 +160,16 @@ def _parse_comms_op_node(in_trace: ExecutionTrace, pg_ranks_map: dict, target_ra
                 (comm_args.outMsgSize, _) = _getTensorInfoFromPyTorchETEntry(node.outputs, node.output_types[0])
                 comm_args.dtype = tensorDtypeMap[in_msg_type]  # 1st value of input_types is the data type for the tensors
 
+            # the recorded rank id in execution trace is local rank id in the process group
+            # we need to convert it to global rank for replay, check the function broadcast() of pytorch below:
+            # https://github.com/pytorch/pytorch/blob/6c4efd4e959017fc758fcc5dc32d8cc6a4b9164d/torch/distributed/distributed_c10d.py#L2404
             if comm_args.comms in supportedP2pOps:
                 if "send" in comm_args.comms:
-                    (comm_args.src_rank, comm_args.dst_rank) = (target_rank, recorded_rank)
+                    (comm_args.src_rank, comm_args.dst_rank) = (target_rank, comm_args.groupRanks[recorded_rank])
                 elif "recv" in comm_args.comms:
-                    (comm_args.src_rank, comm_args.dst_rank) = (recorded_rank, target_rank)
-
-            if comm_args.comms in ["reduce", "broadcast", "gather", "scatter"]:
-                comm_args.root = recorded_rank
+                    (comm_args.src_rank, comm_args.dst_rank) = (comm_args.groupRanks[recorded_rank], target_rank)
+            elif comm_args.comms in ["reduce", "broadcast", "gather", "scatter"]:
+                comm_args.root = comm_args.groupRanks[recorded_rank]
                 comm_args.groupRanks = comm_args.groupRanks
 
             if comm_args.comms == "all_to_allv":

--- a/et_replay/comm/commsTraceParser.py
+++ b/et_replay/comm/commsTraceParser.py
@@ -10,6 +10,7 @@ from et_replay.comm.backend.base_backend import supportedP2pOps
 from et_replay.comm.comms_utils import commsArgs
 
 import logging
+
 logger = logging.getLogger(__name__)
 
 tensorDtypeMap = {
@@ -29,7 +30,11 @@ tensorDtypeMap = {
 
 
 def parseTrace(
-    in_trace: List, trace_type: str, trace_file_path: str, target_rank: int, total_ranks: int
+    in_trace: List,
+    trace_type: str,
+    trace_file_path: str,
+    target_rank: int,
+    total_ranks: int,
 ) -> List:
     """
     Parse trace files to be compatible with PARAM replay-mode.
@@ -50,8 +55,10 @@ def parseTrace(
             ExecutionTrace(in_trace), target_rank, total_ranks
         )
     else:
-        raise ValueError(f"Specified trace type {trace_type} to {trace_file_path} is not supported. \
-Please check supported types with '--help'")
+        raise ValueError(
+            f"Specified trace type {trace_type} to {trace_file_path} is not supported. \
+Please check supported types with '--help'"
+        )
 
     return parsed_trace
 
@@ -91,17 +98,26 @@ def _parseExecutionTrace(
     Convert the Execution Trace comms metadata to the common trace format for replay.
     """
     ET_PG_NAME_TUPLE = in_trace.schema_pytorch() >= (1, 0, 3)
-    if (in_trace.schema_pytorch() < (1, 0, 3)):
-        raise ValueError(f"Only support trace version >1.0.3, but current trace version is {in_trace.schema.split('-')[0]}")
+    if in_trace.schema_pytorch() < (1, 0, 3):
+        raise ValueError(
+            f"Only support trace version >1.0.3, but current trace version is {in_trace.schema.split('-')[0]}"
+        )
 
-    pg_ranks_map = _parse_proc_group_info(in_trace) # key is pg id, value is global ranks in this pg
-    comms_op_list = _parse_comms_op_node(in_trace, pg_ranks_map, target_rank, total_ranks)
+    pg_ranks_map = _parse_proc_group_info(
+        in_trace
+    )  # key is pg id, value is global ranks in this pg
+    comms_op_list = _parse_comms_op_node(
+        in_trace, pg_ranks_map, target_rank, total_ranks
+    )
 
     return comms_op_list
 
+
 def _parse_proc_group_info(in_trace: ExecutionTrace):
-    pg_ranks_map = {} # {node_id : {process_group_id : [ranks] } }
-    pg_init_nodes = (node for node in in_trace.nodes.values() if "process_group:init" in node.name)
+    pg_ranks_map = {}  # {node_id : {process_group_id : [ranks] } }
+    pg_init_nodes = (
+        node for node in in_trace.nodes.values() if "process_group:init" in node.name
+    )
     for node in pg_init_nodes:
         # info of this node is dumped using torch.distributed.distributed_c10d._world.pg_config_info
         # at the start of profiling, but not not callback to torch.distributed.init_process_group()
@@ -115,9 +131,13 @@ def _parse_proc_group_info(in_trace: ExecutionTrace):
         for pg in pg_objs:
             if not pg["pg_name"].isdecimal():
                 # TODO support local synchronization pg
-                logger.warning(f"Process group name is {pg['pg_name']} in node {node.id}, which is not supported. Skip.")
+                logger.warning(
+                    f"Process group name is {pg['pg_name']} in node {node.id}, which is not supported. Skip."
+                )
                 continue
-            (pg_id, ranks, group_size, group_count) = [pg[k] for k in ["pg_name", "ranks", "group_size", "group_count"]]
+            (pg_id, ranks, group_size, group_count) = [
+                pg[k] for k in ["pg_name", "ranks", "group_size", "group_count"]
+            ]
             pg_id = int(pg_id)
             pg_ranks_map[node.id][pg_id] = (
                 ranks
@@ -128,7 +148,10 @@ def _parse_proc_group_info(in_trace: ExecutionTrace):
         break  # only one process_group init node per trace
     return pg_ranks_map
 
-def _parse_comms_op_node(in_trace: ExecutionTrace, pg_ranks_map: dict, target_rank: int, total_ranks: int):
+
+def _parse_comms_op_node(
+    in_trace: ExecutionTrace, pg_ranks_map: dict, target_rank: int, total_ranks: int
+):
     comms_op_list = []
 
     for node_id in pg_ranks_map:
@@ -137,10 +160,12 @@ def _parse_comms_op_node(in_trace: ExecutionTrace, pg_ranks_map: dict, target_ra
             comms_op_list.append(comm_args)
 
     pg_ranks_map_flatten = {}
-    for k,v in pg_ranks_map.items():
+    for k, v in pg_ranks_map.items():
         pg_ranks_map_flatten.update(v)
 
-    comm_nodes = (node for node in in_trace.nodes.values() if node.name == "record_param_comms")
+    comm_nodes = (
+        node for node in in_trace.nodes.values() if node.name == "record_param_comms"
+    )
     for node in comm_nodes:
         # according to macro RECORD_PARAM_COMMS and RECORD_PARAM_COMMS_DATA in torch/csrc/distributed/c10d/ParamCommsUtils.hpp
         # ["wait", "barrier", "init"] record 1st element as seq, others record starting from input tensor
@@ -150,13 +175,15 @@ def _parse_comms_op_node(in_trace: ExecutionTrace, pg_ranks_map: dict, target_ra
 
         comm_args = commsArgs()
         comm_args.id = node.id
-        comm_args.comms = comms_utils.paramToCommName(node.commArgs.collective_name.lower())
+        comm_args.comms = comms_utils.paramToCommName(
+            node.commArgs.collective_name.lower()
+        )
         if comm_args.comms == "init":
             # init node has been built
             continue
         comm_args.req = req_id
 
-        if (node.commArgs.pg_name and node.commArgs.pg_name.isdecimal()):
+        if node.commArgs.pg_name and node.commArgs.pg_name.isdecimal():
             comm_args.pgId = int(node.commArgs.pg_name)
             comm_args.groupRanks = pg_ranks_map_flatten[comm_args.pgId]
             comm_args.worldSize = len(comm_args.groupRanks)
@@ -171,9 +198,15 @@ def _parse_comms_op_node(in_trace: ExecutionTrace, pg_ranks_map: dict, target_ra
         # https://github.com/pytorch/pytorch/blob/6c4efd4e959017fc758fcc5dc32d8cc6a4b9164d/torch/distributed/distributed_c10d.py#L2404
         if comm_args.comms in supportedP2pOps:
             if "send" in comm_args.comms:
-                (comm_args.src_rank, comm_args.dst_rank) = (target_rank, comm_args.groupRanks[recorded_rank])
+                (comm_args.src_rank, comm_args.dst_rank) = (
+                    target_rank,
+                    comm_args.groupRanks[recorded_rank],
+                )
             elif "recv" in comm_args.comms:
-                (comm_args.src_rank, comm_args.dst_rank) = (comm_args.groupRanks[recorded_rank], target_rank)
+                (comm_args.src_rank, comm_args.dst_rank) = (
+                    comm_args.groupRanks[recorded_rank],
+                    target_rank,
+                )
         elif comm_args.comms in ["reduce", "broadcast", "gather", "scatter"]:
             comm_args.root = comm_args.groupRanks[recorded_rank]
             comm_args.groupRanks = comm_args.groupRanks
@@ -185,16 +218,19 @@ def _parse_comms_op_node(in_trace: ExecutionTrace, pg_ranks_map: dict, target_ra
             comm_args.inSplit = (
                 json.loads(node.commArgs.in_split_size)
                 if json.loads(node.commArgs.in_split_size)
-                else [int(comm_args.inMsgSize / comm_args.worldSize)] * comm_args.worldSize
+                else [int(comm_args.inMsgSize / comm_args.worldSize)]
+                * comm_args.worldSize
             )
             comm_args.outSplit = (
                 json.loads(node.commArgs.out_split_size)
                 if json.loads(node.commArgs.out_split_size)
-                else [int(comm_args.outMsgSize / comm_args.worldSize)] * comm_args.worldSize
+                else [int(comm_args.outMsgSize / comm_args.worldSize)]
+                * comm_args.worldSize
             )
         comms_op_list.append(comm_args)
 
     return comms_op_list
+
 
 def _create_pg_init_node(node_id: int, pg_id: int, ranks: List[int], world_size: int):
     comm_args = commsArgs()

--- a/et_replay/comm/commsTraceParser.py
+++ b/et_replay/comm/commsTraceParser.py
@@ -97,7 +97,7 @@ def _parseExecutionTrace(
     return comms_op_list
 
 def _parse_proc_group_info(in_trace: ExecutionTrace):
-    pg_ranks_map = {}
+    pg_ranks_map = {} # {node_id : {process_group_id : [ranks] } }
     for node in in_trace.nodes.values():
         if "process_group:init" in node.name:
             # info of this node is dumped using torch.distributed.distributed_c10d._world.pg_config_info
@@ -108,13 +108,14 @@ def _parse_proc_group_info(in_trace: ExecutionTrace):
             except json.decoder.JSONDecodeError:  # skip if pg_config_info is truncated
                 break
 
+            pg_ranks_map[node.id] = {}
             for pg in pg_objs:
                 if not pg["pg_name"].isdecimal():
                     # TODO support local synchronization pg
                     raise ValueError(f"Process group name is {pg['pg_name']} in node {node['id']}, which is not supported.")
                 (pg_id, ranks, group_size, group_count) = [pg[k] for k in ["pg_name", "ranks", "group_size", "group_count"]]
                 pg_id = int(pg_id)
-                pg_ranks_map[pg_id] = (
+                pg_ranks_map[node.id][pg_id] = (
                     ranks
                     if len(ranks) > 0
                     else list(range(group_size))
@@ -126,9 +127,14 @@ def _parse_proc_group_info(in_trace: ExecutionTrace):
 def _parse_comms_op_node(in_trace: ExecutionTrace, pg_ranks_map: dict, target_rank: int, total_ranks: int):
     comms_op_list = []
 
-    for pg_id, ranks in pg_ranks_map.items():
-        comm_args = _create_pg_init_node(pg_id, ranks, len(ranks))
-        comms_op_list.append(comm_args)
+    for node_id in pg_ranks_map:
+        for pg_id, ranks in pg_ranks_map[node_id].items():
+            comm_args = _create_pg_init_node(node_id, pg_id, ranks, len(ranks))
+            comms_op_list.append(comm_args)
+
+    pg_ranks_map_flatten = {}
+    for k,v in pg_ranks_map.items():
+        pg_ranks_map_flatten.update(v)
 
     for node in in_trace.nodes.values():
         if node.name == "record_param_comms":
@@ -146,7 +152,7 @@ def _parse_comms_op_node(in_trace: ExecutionTrace, pg_ranks_map: dict, target_ra
 
             if pg_id_pair[0].isdecimal():
                 comm_args.pgId = int(pg_id_pair[0])
-                comm_args.groupRanks = pg_ranks_map[comm_args.pgId]
+                comm_args.groupRanks = pg_ranks_map_flatten[comm_args.pgId]
                 comm_args.worldSize = len(comm_args.groupRanks)
 
             if comm_args.comms not in ("wait", "barrier"):
@@ -186,8 +192,9 @@ def _parse_comms_op_node(in_trace: ExecutionTrace, pg_ranks_map: dict, target_ra
 
     return comms_op_list
 
-def _create_pg_init_node(pg_id: int, ranks: List[int], world_size: int):
+def _create_pg_init_node(node_id: int, pg_id: int, ranks: List[int], world_size: int):
     comm_args = commsArgs()
+    comm_args.id = node_id
     comm_args.comms = "init"
     comm_args.pgId = pg_id
     comm_args.req = -1

--- a/et_replay/comm/commsTraceParser.py
+++ b/et_replay/comm/commsTraceParser.py
@@ -89,7 +89,7 @@ def _parseExecutionTrace(
     """
     ET_PG_NAME_TUPLE = in_trace.schema_pytorch() >= (1, 0, 3)
     if (in_trace.schema_pytorch() < (1, 0, 3)):
-        raise ValueError(f"Only support trace version >1.0.3, but current trace format is {in_trace.schema.split("-")[0]}")
+        raise ValueError(f"Only support trace version >1.0.3, but current trace version is {in_trace.schema.split('-')[0]}")
 
     pg_ranks_map = _parse_proc_group_info(in_trace) # key is pg id, value is global ranks in this pg
     comms_op_list = _parse_comms_op_node(in_trace, pg_ranks_map, target_rank, total_ranks)

--- a/et_replay/comm/commsTraceParser.py
+++ b/et_replay/comm/commsTraceParser.py
@@ -26,155 +26,31 @@ tensorDtypeMap = {
 
 
 def parseTrace(
-    in_trace: List, trace_type: str, target_rank: int, total_ranks: int
+    in_trace: List, trace_type: str, trace_file_path: str, target_rank: int, total_ranks: int
 ) -> List:
     """
     Parse trace files to be compatible with PARAM replay-mode.
-    Currently supports: Basic Trace, Kineto Unitrace, and PyTorch ET trace.
+    Currently supports: Chakra host execution trace.
 
     Args:
         in_trace: Trace file to be parsed.
         trace_type: Trace type to be parsed with
+        trace_file_path: Path of input trace file being loaded.
         target_rank: The current rank of the device.
         total_ranks: Total number of ranks.
     Returns:
         parsed_trace: Parsed trace that is compatible with PARAM replay-mode.
     """
 
-    if trace_type == "basic":  # Basic Trace
-        parsed_trace = _parseBasicTrace(in_trace)
-    elif trace_type == "et":  # Execution Trace (e.g. PyTorch ET, Chakra)
+    if trace_type == "et":  # Execution Trace (e.g. Chakra host execution trace)
         parsed_trace = _parseExecutionTrace(
             ExecutionTrace(in_trace), target_rank, total_ranks
         )
-    elif trace_type == "kineto":  # Kineto Unitrace
-        parsed_trace = _parseKinetoUnitrace(in_trace, target_rank)
     else:
-        raise ValueError("Unrecognized trace format.")
+        raise ValueError(f"Specified trace type {trace_type} to {trace_file_path} is not supported. \
+Please check supported types with '--help'")
 
     return parsed_trace
-
-
-def _parseBasicTrace(in_trace: List):
-    """
-    Convert Basic Trace to comms trace format.
-    """
-    newCommsTrace = []
-    for cnt, curComm in enumerate(in_trace):
-        newComm = commsArgs()
-        newComm.id = cnt
-        newComm.markerStack = curComm.get("markers")
-        if "comms" in curComm:
-            _parseBasicTraceComms(curComm, newComm)
-
-        elif "compute" in curComm:
-            _parseBasicTraceCompute(curComm, newComm)
-
-        if newComm.comms is not None or newComm.compute is not None:
-            newCommsTrace.append(newComm)
-        else:
-            raise ValueError(
-                "Trace file contains an element that is not a supported in PARAM! Please format all elements as comms or compute for replay."
-            )
-
-    return newCommsTrace
-
-
-def _parseBasicTraceComms(curComm, newComm: commsArgs) -> None:
-    newComm.comms = comms_utils.paramToCommName(curComm["comms"].lower())
-    if newComm.markerStack is None:
-        newComm.markerStack = [newComm.comms]
-    newComm.req = curComm.get("req")
-    newComm.startTimeNs = curComm.get("startTime_ns")
-    newComm.worldSize = curComm.get("world_size")
-    newComm.root = curComm.get("root")
-    newComm.pgId = curComm.get("pg_id")
-    newComm.groupRanks = curComm.get("global_ranks")
-
-    if newComm.comms not in ("wait", "barrier", "init", "batch_isend_irecv"):
-        newComm.inMsgSize = curComm["in_msg_size"]
-        newComm.outMsgSize = curComm["out_msg_size"]
-        newComm.dtype = curComm["dtype"].lower()
-
-    if newComm.comms == "all_to_allv":
-        newComm.inSplit = curComm["in_split"]
-        newComm.outSplit = curComm["out_split"]
-
-    if newComm.comms in supportedP2pOps:
-        newComm.src_rank = curComm["src_rank"]
-        newComm.dst_rank = curComm["dst_rank"]
-        newComm.batch_p2p = curComm["use_batch"]
-
-
-def _parseBasicTraceCompute(curComm, newComm: commsArgs) -> None:
-    newComm.compute = curComm["compute"].lower()
-    if newComm.markerStack is None:
-        newComm.markerStack = [newComm.compute]
-    # count = number of times to call the compute kernel
-    if "count" in curComm:
-        newComm.count = curComm["count"]
-    # if no count is specified, assume 1
-    else:
-        newComm.count = 1
-    if newComm.compute == "gemm":
-        if "mm_dim" in curComm:
-            newComm.mm0_dim0 = curComm.get("mm_dim")
-            newComm.mm0_dim1 = curComm.get("mm_dim")
-            newComm.mm1_dim0 = curComm.get("mm_dim")
-            newComm.mm1_dim1 = curComm.get("mm_dim")
-        else:
-            newComm.mm0_dim0 = curComm.get("mm0_dim0")
-            newComm.mm0_dim1 = curComm.get("mm0_dim1")
-            newComm.mm1_dim0 = curComm.get("mm1_dim0")
-            newComm.mm1_dim1 = curComm.get("mm1_dim1")
-        newComm.dtype = curComm.get("dtype").lower()
-    elif newComm.compute == "emb_lookup":
-        if "direction" in curComm:
-            newComm.direction = curComm["direction"]
-        else:
-            newComm.direction = "forward"
-        newComm.emb_dim = curComm.get("emb_dim")
-        newComm.num_embs = curComm.get("num_embs")
-        newComm.batch_size = curComm.get("batch_size")
-        newComm.num_emb_tables_per_device = curComm.get("num_emb_tables")
-        newComm.num_emb_tables_batched = -1
-        newComm.bag_size = curComm.get("bag_size")
-    else:
-        raise ValueError(
-            f"Trace file contains {str(newComm.compute)} compute element that is not supported in PARAM!"
-        )
-
-
-def _parseKinetoUnitrace(in_trace: List, target_rank: int) -> List:
-    """
-    Convert the Kineto unitrace w/ comms metadata to the clean common trace format for replay.
-    """
-    newCommsTrace = []
-    commsCnt = 0
-    for entry in in_trace:
-        # TODO: figure the current marker stack if present
-        marker = "unknown"
-        pass
-
-        if (
-            "name" in entry
-            and entry["name"] == "record_param_comms"
-            and entry["args"]["rank"] == target_rank
-        ):
-            newComm = commsArgs()
-            newComm.comms = comms_utils.paramToCommName(entry["args"]["comms"].lower())
-            newComm.id = commsCnt
-            newComm.inMsgSize = entry["args"]["in_msg_size"]
-            newComm.outMsgSize = entry["args"]["out_msg_size"]
-            newComm.dtype = entry["args"]["dtype"].lower()
-            newComm.inSplit = entry["args"]["in_split"]
-            newComm.outSplit = entry["args"]["out_split"]
-            newComm.markerStack = marker
-
-            newCommsTrace.append(newComm)
-            commsCnt += 1
-
-    return newCommsTrace
 
 
 def _getTensorInfoFromPyTorchETEntry(
@@ -210,7 +86,6 @@ def _parseExecutionTrace(
 ) -> List:
     """
     Convert the Execution Trace comms metadata to the common trace format for replay.
-
     """
     # Execution Trace PG_ID types availability
     ET_PG_NAME_TUPLE = in_trace.schema_pytorch() >= (1, 0, 3)

--- a/et_replay/comm/commsTraceParser.py
+++ b/et_replay/comm/commsTraceParser.py
@@ -136,61 +136,59 @@ def _parse_comms_op_node(in_trace: ExecutionTrace, pg_ranks_map: dict, target_ra
     for k,v in pg_ranks_map.items():
         pg_ranks_map_flatten.update(v)
 
-    for node in in_trace.nodes.values():
-        if node.name == "record_param_comms":
-            # according to macro RECORD_PARAM_COMMS and RECORD_PARAM_COMMS_DATA in torch/csrc/distributed/c10d/ParamCommsUtils.hpp
-            # ["wait", "barrier", "init"] record 1st element as seq, others record starting from input tensor
-            index_base = 0 if isinstance(node.inputs[0], int) else 1
-            (req_id, pg_id_pair, recorded_rank, comm_name) = [node.inputs[index_base + i] for i in range(4)]
-            comm_args = commsArgs()
-            comm_args.id = node.id
-            comm_args.comms = comms_utils.paramToCommName(comm_name.lower())
-            if comm_args.comms == "init":
-                # init node has been built
-                continue
-            comm_args.req = req_id
+    comm_nodes = (node for node in in_trace.nodes.values() if node.name == "record_param_comms")
+    for node in comm_nodes:
+        # according to macro RECORD_PARAM_COMMS and RECORD_PARAM_COMMS_DATA in torch/csrc/distributed/c10d/ParamCommsUtils.hpp
+        # ["wait", "barrier", "init"] record 1st element as seq, others record starting from input tensor
+        index_base = 0 if isinstance(node.inputs[0], int) else 1
+        req_id = node.inputs[index_base]
+        recorded_rank = node.inputs[index_base + 2]
 
-            if pg_id_pair[0].isdecimal():
-                comm_args.pgId = int(pg_id_pair[0])
-                comm_args.groupRanks = pg_ranks_map_flatten[comm_args.pgId]
-                comm_args.worldSize = len(comm_args.groupRanks)
+        comm_args = commsArgs()
+        comm_args.id = node.id
+        comm_args.comms = comms_utils.paramToCommName(node.commArgs.collective_name.lower())
+        if comm_args.comms == "init":
+            # init node has been built
+            continue
+        comm_args.req = req_id
 
-            if comm_args.comms not in ("wait", "barrier"):
-                (comm_args.inMsgSize, in_msg_type) = _getTensorInfoFromPyTorchETEntry(node.inputs, node.input_types[0])
-                (comm_args.outMsgSize, _) = _getTensorInfoFromPyTorchETEntry(node.outputs, node.output_types[0])
-                comm_args.dtype = tensorDtypeMap[in_msg_type]  # 1st value of input_types is the data type for the tensors
+        if (node.commArgs.pg_name and node.commArgs.pg_name.isdecimal()):
+            comm_args.pgId = int(node.commArgs.pg_name)
+            comm_args.groupRanks = pg_ranks_map_flatten[comm_args.pgId]
+            comm_args.worldSize = len(comm_args.groupRanks)
 
-            # the recorded rank id in execution trace is local rank id in the process group
-            # we need to convert it to global rank for replay, check the function broadcast() of pytorch below:
-            # https://github.com/pytorch/pytorch/blob/6c4efd4e959017fc758fcc5dc32d8cc6a4b9164d/torch/distributed/distributed_c10d.py#L2404
-            if comm_args.comms in supportedP2pOps:
-                if "send" in comm_args.comms:
-                    (comm_args.src_rank, comm_args.dst_rank) = (target_rank, comm_args.groupRanks[recorded_rank])
-                elif "recv" in comm_args.comms:
-                    (comm_args.src_rank, comm_args.dst_rank) = (comm_args.groupRanks[recorded_rank], target_rank)
-            elif comm_args.comms in ["reduce", "broadcast", "gather", "scatter"]:
-                comm_args.root = comm_args.groupRanks[recorded_rank]
-                comm_args.groupRanks = comm_args.groupRanks
+        if comm_args.comms not in ("wait", "barrier"):
+            comm_args.inMsgSize = node.commArgs.in_msg_nelems
+            comm_args.outMsgSize = node.commArgs.out_msg_nelems
+            comm_args.dtype = node.commArgs.dtype.lower()
 
-            if comm_args.comms == "all_to_allv":
-                # 6th value of inputs is in_split, split evenly if not provided
-                if not comm_args.worldSize:
-                    # if no pg info provided, use total ranks as world size
-                    comm_args.worldSize = total_ranks
-                comm_args.inSplit = (
-                    node.inputs[5]
-                    if node.inputs[5]
-                    else [int(comm_args.inMsgSize / comm_args.worldSize)]
-                    * comm_args.worldSize
-                )
-                # 7th value of inputs is out_split, split evenly if not provided
-                comm_args.outSplit = (
-                    node.inputs[6]
-                    if node.inputs[6]
-                    else [int(comm_args.outMsgSize / comm_args.worldSize)]
-                    * comm_args.worldSize
-                )
-            comms_op_list.append(comm_args)
+        # the recorded rank id in execution trace is local rank id in the process group
+        # we need to convert it to global rank for replay, check the function broadcast() of pytorch below:
+        # https://github.com/pytorch/pytorch/blob/6c4efd4e959017fc758fcc5dc32d8cc6a4b9164d/torch/distributed/distributed_c10d.py#L2404
+        if comm_args.comms in supportedP2pOps:
+            if "send" in comm_args.comms:
+                (comm_args.src_rank, comm_args.dst_rank) = (target_rank, comm_args.groupRanks[recorded_rank])
+            elif "recv" in comm_args.comms:
+                (comm_args.src_rank, comm_args.dst_rank) = (comm_args.groupRanks[recorded_rank], target_rank)
+        elif comm_args.comms in ["reduce", "broadcast", "gather", "scatter"]:
+            comm_args.root = comm_args.groupRanks[recorded_rank]
+            comm_args.groupRanks = comm_args.groupRanks
+
+        if comm_args.comms == "all_to_allv":
+            if not comm_args.worldSize:
+                # if no pg info provided, use total ranks as world size
+                comm_args.worldSize = total_ranks
+            comm_args.inSplit = (
+                json.loads(node.commArgs.in_split_size)
+                if json.loads(node.commArgs.in_split_size)
+                else [int(comm_args.inMsgSize / comm_args.worldSize)] * comm_args.worldSize
+            )
+            comm_args.outSplit = (
+                json.loads(node.commArgs.out_split_size)
+                if json.loads(node.commArgs.out_split_size)
+                else [int(comm_args.outMsgSize / comm_args.worldSize)] * comm_args.worldSize
+            )
+        comms_op_list.append(comm_args)
 
     return comms_op_list
 

--- a/et_replay/comm/comms_utils.py
+++ b/et_replay/comm/comms_utils.py
@@ -792,7 +792,7 @@ class paramCommsBench(ABC):
             "short": torch.short,
             "char": torch.int8,
             "signed char": torch.int8,
-            "unsigned char": torch.uint8
+            "unsigned char": torch.uint8,
         }
         self.supportedDtype = list(self.dtypeMap.keys())
         self.backendFuncs: BaseBackend

--- a/et_replay/comm/comms_utils.py
+++ b/et_replay/comm/comms_utils.py
@@ -73,49 +73,6 @@ def gracefulExit(args: Any = 0) -> None:
     sys.exit(args)
 
 
-def parsesize(ipValue: str) -> int:
-    """
-    nccl-tests compatible input-size parsing.
-
-    Args:
-        ipValue: Contains size of input.
-    Returns:
-        size: Returns the size of input.
-    """
-    units = 0
-    size = 0.0
-
-    value = ""
-
-    # This function would be invoked in a loop - once for each data-type. For  first iteration, ipValue is of type string but after that,
-    # the type of ipValue equals the returntype of prior iteration ie; int. Hence, type check is moved up as first condition.
-    if isinstance(ipValue, int) or ipValue.isnumeric():
-        units = 1
-        value = ipValue
-
-    elif ipValue.find("G") != -1:
-        units = 1024 * 1024 * 1024
-        unitIdx = ipValue.find("G")
-        value = ipValue[0:unitIdx]
-
-    elif ipValue.find("M") != -1:
-        units = 1024 * 1024
-        unitIdx = ipValue.find("M")
-        value = ipValue[0:unitIdx]
-
-    elif ipValue.find("K") != -1:
-        units = 1024
-        unitIdx = ipValue.find("K")
-        value = ipValue[0:unitIdx]
-
-    else:
-        logger.error(f"Could not parse input size {ipValue}")
-        gracefulExit()
-
-    size = int(value) * units
-    return int(size)
-
-
 def parseRankList(ipStr: str) -> List[int]:
     """
     Parses a string into a rank list.
@@ -140,56 +97,6 @@ def parseRankList(ipStr: str) -> List[int]:
             pos = list(map(int, [r.strip() for r in ipStr.split(":")]))
             rankList = [*range(pos[0], pos[1] + 1)]
     return rankList
-
-
-def getAlgBW(elapsedTimeNS: float, dataSize: int, numIters: int) -> Tuple[float, float]:
-    """
-    Similar to how algorithmic bandwidth is computed in nccl-tests.
-
-    Args:
-        elapsedTimeNS: Total elapsed time for run in ns.
-        dataSize: Size in bytes of the data being ran.
-        numIters: Number of iterations for run.
-    Returns:
-        (avgIterNs, algBW): Returns the average amount of time in ns per iteration, and the algBW (GBps) calculated.
-    """
-    avgIterNS = 0.0
-    if numIters != 0:
-        avgIterNS = elapsedTimeNS / numIters
-
-    algBW = 0.0
-    if avgIterNS != 0:
-        algBW = (dataSize) / (avgIterNS)  # dataSize dividied by ns gives us GBps
-    return (avgIterNS, algBW)
-
-
-def getSizes(
-    beginSize: int, endSize: int, stepFactor: int, stepBytes: int
-) -> List[int]:
-    """
-    Gets the sizes of each iteration.
-
-    Args:
-        beginSize: Size of first iteration.
-        endSize: Size of last iteration.
-        stepFactor: Factor that each iteration increases by.
-    Returns:
-        allSizes: List that contains size of each iteration up to endSize.
-    """
-    curSize = beginSize
-    numIters = 0
-    maxIters = 100
-    allSizes = []
-    while curSize <= endSize:
-        allSizes.append(curSize)
-        curSize = curSize * stepFactor if stepBytes == 0 else curSize + stepBytes
-        numIters = numIters + 1
-        if numIters > 100:
-            logger.error(
-                f"For finding allSizes numIters: {numIters} is greater than maxIters: {maxIters}"
-            )
-            break
-    return allSizes
 
 
 def fixBeginSize(commsParams: commsParamsHolder, world_size: int) -> None:
@@ -799,39 +706,7 @@ class commsParamsHolderBase:
         self.enable_local_report = args.enable_local_report
         self.enable_profiler = args.enable_profiler
         self.use_perf_logger = args.use_perf_logger
-        self.ibv_devices = args.ibv_devices
         self.init_only = args.init_only
-
-
-class commsDlrmParamsHolder(commsParamsHolderBase):
-    """Class holding object for the input parameters of DLRM benchmark."""
-
-    def __init__(
-        self,
-        args,
-        mpi_env_params: Dict[str, int],
-    ) -> None:
-        super().__init__(args)
-
-        # extra DLRM parameters
-        self.numDevices = mpi_env_params["world_size"]
-        self.numBatches = args.num_batches + args.warmup_batches
-        # NOTE: Should ensure that dataSize = int(N) * numDevices * batchSize
-        self.numBatchesPerEpoch = args.mini_batch_size
-        self.dataSize = (
-            mpi_env_params["world_size"] * self.numBatches * self.numBatchesPerEpoch
-        )
-        self.embedLayers = []  # scaledEmbedLayers
-        self.mini_batch_size = args.mini_batch_size
-        self.arch_sparse_feature_size = args.arch_sparse_feature_size
-        self.nw_stack = args.nw_stack
-        self.warmup_batches = args.warmup_batches
-        self.device = args.device
-        self.backend = args.backend
-
-        # additional parameters used in runBench()
-        self.perf_debug = args.perf_debug
-        self.print_comms = args.print_comms
 
 
 class commsParamsHolder(commsParamsHolderBase):
@@ -1627,12 +1502,6 @@ class paramCommsBench(ABC):
             default=None,
             help="add name of custom performer loggers to use them in additional to text output, user is responsible to implement and register the custom performance logger",
         )  # use custom performer logger
-        parser.add_argument(
-            "--ibv-devices",
-            type=str,
-            default="",
-            help="list of ib devices to use for distributed communication",
-        )  # experimental feature
         parser.add_argument(
             "--init-only",
             action="store_true",

--- a/et_replay/comm/comms_utils.py
+++ b/et_replay/comm/comms_utils.py
@@ -791,6 +791,8 @@ class paramCommsBench(ABC):
             "int8": torch.int8,
             "short": torch.short,
             "char": torch.int8,
+            "signed char": torch.int8,
+            "unsigned char": torch.uint8
         }
         self.supportedDtype = list(self.dtypeMap.keys())
         self.backendFuncs: BaseBackend

--- a/et_replay/execution_trace.py
+++ b/et_replay/execution_trace.py
@@ -82,8 +82,10 @@ ways in the PyTorch computation graph.
 
 
 class TensorNode:
-    def __init__(self, id: int, dtype: str):
-        self.id: int = id
+    # one example of id is (8, 9, 0, 64, 4, 'cuda:0') representing
+    # (tensor id, storage id, offset, element number, element size, device)
+    def __init__(self, id: tuple, dtype: str):
+        self.id: tuple = id
         self.dtype = dtype
         self.sources: Set = set()
         self.sinks: Set = set()
@@ -283,12 +285,12 @@ class Node:
 
     def get_tensors(self, param_list: Iterable) -> List[tuple]:
         tensors = []
-        for type, input, shape in param_list:
+        for type, input, shape in param_list:  # TBR: avoid using python key words
             if type.startswith("Tensor"):
                 tensors.append((type, tuple(input), shape))
             # GenericList could have tensor elements
             if type.startswith("GenericList"):
-                elem_type = type[12:-1].split(",")
+                elem_type = type[len("GenericList[") : -1].split(",")
                 tensors.extend(self.get_tensors(zip(elem_type, input, shape)))
         return tensors
 
@@ -305,14 +307,14 @@ class Node:
 class ExecutionTrace:
     def __init__(self, json):
         self.nodes = {}
-        self.clean_nodes = {}  # w/o DataLoader ops
+        self.clean_nodes = {}  # from this node to root, no DataLoader ops in path
         self.tensors = {}
         self.proc_group = {}
         # list of node ids that start an iteration
         self.iteration_ids = []
         self.schema: str = json["schema"]
         pid = json["pid"]
-        self.proc_group = {pid: {}}
+        self.proc_group[pid] = {}
         nodes_list = json["nodes"]
 
         # Depending on schema, call the right method
@@ -351,7 +353,7 @@ class ExecutionTrace:
                 if type(t_id) != tuple:
                     t_id = tuple(t_id)
                 if t_id not in self.tensors:
-                    dtype = t_type[7:-1]
+                    dtype = t_type[len("Tensor(") : -1]
                     self.tensors[t_id] = TensorNode(t_id, dtype)
                 self.tensors[t_id].add_sink(id)
                 self.tensors[t_id].add_shape(shape)
@@ -360,7 +362,7 @@ class ExecutionTrace:
                 if type(t_id) != tuple:
                     t_id = tuple(t_id)
                 if t_id not in self.tensors:
-                    dtype = t_type[7:-1]
+                    dtype = t_type[len("Tensor(") : -1]
                     self.tensors[t_id] = TensorNode(t_id, dtype)
                 self.tensors[t_id].add_source(id)
                 self.tensors[t_id].add_shape(shape)
@@ -401,7 +403,6 @@ class ExecutionTrace:
         "kernel_backend": str,
         "kernel_file": str,
     }
-    OPTIONAL_ATTR = ["kernel_backend", "kernel_file"]
 
     @classmethod
     def _read_attrs(cls, node: Dict[str, Any]) -> Tuple:
@@ -410,13 +411,8 @@ class ExecutionTrace:
             for attr in node["attrs"]
             if attr["name"] in cls.ATTR_TYPES.keys()
         }
-        for opt_key in cls.OPTIONAL_ATTR:
-            if opt_key not in attr_dict:
-                attr_dict[opt_key] = None
 
-        return tuple(
-            attr_dict[key] for key in cls.ATTR_TYPES.keys() if key in attr_dict.keys()
-        )
+        return tuple(attr_dict.get(key, None) for key in cls.ATTR_TYPES.keys())
 
     @staticmethod
     def _create_node_v1_0_1(pid, x: Dict[str, Any]) -> Node:
@@ -442,6 +438,7 @@ class ExecutionTrace:
 
     @staticmethod
     def _create_node_v1_0_2_chakra_0_0_4(pid, x: Dict[str, Any]) -> Node:
+        # TBR: guarantee matching with returned value manually. Easy to incurs bug.
         (
             fw_parent,
             seq_id,
@@ -757,6 +754,7 @@ class ExecutionTrace:
 
         if len(self.clean_nodes.keys()) == 0:  # clean_nodes is empty
             for id, node in self.nodes.items():
+                # TBR: always search from this node to root, incursing repeated searching path, to be optimized
                 if not check_parent(node):  # if the op is not under dataloader
                     self.clean_nodes[id] = node
 

--- a/et_replay/execution_trace.py
+++ b/et_replay/execution_trace.py
@@ -112,7 +112,15 @@ class _CommArgs:
 
     collective_name: str
     dtype: str
-    # .. TODO add more see https://github.com/pytorch/pytorch/issues/124674
+    in_msg_nelems: int
+    out_msg_nelems: int
+    in_split_size: str
+    out_split_size: str
+    global_rank_start: int
+    global_rank_stride: int
+    pg_name: str
+    pg_desc: str
+    pg_size: int
 
 
 """
@@ -414,6 +422,32 @@ class ExecutionTrace:
 
         return tuple(attr_dict.get(key, None) for key in cls.ATTR_TYPES.keys())
 
+    # MUST keep the order the same as members of _CommArgs
+    COMM_ATTR_TYPES = {
+        "collective_name": str,
+        "dtype": str,
+        "in_msg_nelems": int,
+        "out_msg_nelems": int,
+        "in_split_size": str,
+        "out_split_size": str,
+        "global_rank_start": int,
+        "global_rank_stride": int,
+        "pg_name": str,
+        "pg_desc": str,
+        "pg_size": int,
+    }
+
+    @classmethod
+    def _read_comm_attrs(cls, node: Dict[str, Any]) -> _CommArgs:
+        attr_dict = {
+            attr["name"]: cls.COMM_ATTR_TYPES[attr["name"]](attr["value"])
+            for attr in node["attrs"]
+            if attr["name"] in cls.COMM_ATTR_TYPES.keys()
+        }
+
+        params_dict = {k:attr_dict.get(k, None) for k in cls.COMM_ATTR_TYPES.keys()}
+        return _CommArgs(**params_dict)
+
     @staticmethod
     def _create_node_v1_0_1(pid, x: Dict[str, Any]) -> Node:
         return Node(
@@ -451,6 +485,8 @@ class ExecutionTrace:
             kernel_file,
         ) = ExecutionTrace._read_attrs(x)
 
+        comm_attrs = ExecutionTrace._read_comm_attrs(x) if x['name'] == "record_param_comms" else None
+
         return Node(
             x["name"],
             x["id"],
@@ -471,6 +507,7 @@ class ExecutionTrace:
             rf_id,
             kernel_backend,
             kernel_file,
+            comm_attrs
         )
 
     @staticmethod

--- a/et_replay/execution_trace.py
+++ b/et_replay/execution_trace.py
@@ -445,7 +445,7 @@ class ExecutionTrace:
             if attr["name"] in cls.COMM_ATTR_TYPES.keys()
         }
 
-        params_dict = {k:attr_dict.get(k, None) for k in cls.COMM_ATTR_TYPES.keys()}
+        params_dict = {k: attr_dict.get(k, None) for k in cls.COMM_ATTR_TYPES.keys()}
         return _CommArgs(**params_dict)
 
     @staticmethod
@@ -485,7 +485,11 @@ class ExecutionTrace:
             kernel_file,
         ) = ExecutionTrace._read_attrs(x)
 
-        comm_attrs = ExecutionTrace._read_comm_attrs(x) if x['name'] == "record_param_comms" else None
+        comm_attrs = (
+            ExecutionTrace._read_comm_attrs(x)
+            if x["name"] == "record_param_comms"
+            else None
+        )
 
         return Node(
             x["name"],
@@ -507,7 +511,7 @@ class ExecutionTrace:
             rf_id,
             kernel_backend,
             kernel_file,
-            comm_attrs
+            comm_attrs,
         )
 
     @staticmethod

--- a/et_replay/tools/comm_replay.py
+++ b/et_replay/tools/comm_replay.py
@@ -40,7 +40,8 @@ logger = logging.getLogger(__name__)
 # sleep for 20ms to wait for next collective
 LOOP_TIMER_S = 0.02
 
-VALID_TRACE_TYPES = ["basic", "et", "kineto"]
+# index 0 is default value of trace type
+VALID_TRACE_TYPES = ["et"]
 
 
 def writeCommDetails(commsTracePerf: List, rank: int, folder: str = "./") -> None:
@@ -173,8 +174,10 @@ class commsTraceReplayBench(paramCommsBench):
         parser.add_argument(
             "--trace-type",
             type=str,
-            default="basic",
-            help=f"Trace type used for replay. Supported trace types: {str(VALID_TRACE_TYPES)}. By default use basic trace.",
+            choices=VALID_TRACE_TYPES,
+            default=VALID_TRACE_TYPES[0],
+            help=f"Select trace type used for replay. Supported trace types: {VALID_TRACE_TYPES}. \
+                   'et' represents Chakra host execution trace.",
         )
         parser.add_argument(
             "--use-one-trace",
@@ -1589,6 +1592,7 @@ class commsTraceReplayBench(paramCommsBench):
             self.comms_trace = commsTraceParser.parseTrace(
                 self.comms_trace,
                 self.trace_type,
+                (self.trace_file if not os.path.isdir(self.trace_file) else f"{self.trace_file}/{rank}.json"),
                 rank,
                 self.backendFuncs.get_world_size(),
             )

--- a/et_replay/tools/comm_replay.py
+++ b/et_replay/tools/comm_replay.py
@@ -1592,7 +1592,11 @@ class commsTraceReplayBench(paramCommsBench):
             self.comms_trace = commsTraceParser.parseTrace(
                 self.comms_trace,
                 self.trace_type,
-                (self.trace_file if not os.path.isdir(self.trace_file) else f"{self.trace_file}/{rank}.json"),
+                (
+                    self.trace_file
+                    if not os.path.isdir(self.trace_file)
+                    else f"{self.trace_file}/{rank}.json"
+                ),
                 rank,
                 self.backendFuncs.get_world_size(),
             )


### PR DESCRIPTION
## Summary
- Refactored the commsTraceParser to enhance readability and maintainability.
- Removed deprecated support for parsing "basic" and "Kineto" traces; only Chakra host execution traces are now supported.
- Added detailed logging to handle undecimal process group names with warnings instead of exceptions.
- Modified _parse_proc_group_info and _parse_comms_op_node for improved processing of process group info and communication operations.
- Updated comms_utils to support additional data types (signed char, unsigned char).
- Adjusted the command-line interface to reflect the updated trace type options.

This PR relies on https://github.com/facebookresearch/param/pull/146.

## Test Plan
* Note: The following command was executed using https://github.com/facebookresearch/param/pull/148.
```
$ comm_replay --trace-type et --trace-path /home/sanshang/021_debug/000_code/param/trace/traces_megatronlm_gpt_43B_32ranks_pytnightly0703/execution_trace
```
![image](https://github.com/user-attachments/assets/6c9c2c47-1053-4358-b492-0823b1c55909)