### PR TITLE
Fix various issues in comm replay including hashing, srcOrDst assignment, and trace file naming

### DIFF
--- a/et_replay/comm/commsTraceParser.py
+++ b/et_replay/comm/commsTraceParser.py
@@ -9,6 +9,9 @@ from et_replay.comm import comms_utils
 from et_replay.comm.backend.base_backend import supportedP2pOps
 from et_replay.comm.comms_utils import commsArgs
 
+import logging
+logger = logging.getLogger(__name__)
+
 tensorDtypeMap = {
     "Tensor(int)": "int",
     "Tensor(float)": "float",
@@ -112,7 +115,8 @@ def _parse_proc_group_info(in_trace: ExecutionTrace):
         for pg in pg_objs:
             if not pg["pg_name"].isdecimal():
                 # TODO support local synchronization pg
-                raise ValueError(f"Process group name is {pg['pg_name']} in node {node['id']}, which is not supported.")
+                logger.warning(f"Process group name is {pg['pg_name']} in node {node.id}, which is not supported. Skip.")
+                continue
             (pg_id, ranks, group_size, group_count) = [pg[k] for k in ["pg_name", "ranks", "group_size", "group_count"]]
             pg_id = int(pg_id)
             pg_ranks_map[node.id][pg_id] = (

--- a/et_replay/comm/commsTraceParser.py
+++ b/et_replay/comm/commsTraceParser.py
@@ -160,14 +160,16 @@ def _parse_comms_op_node(in_trace: ExecutionTrace, pg_ranks_map: dict, target_ra
                 (comm_args.outMsgSize, _) = _getTensorInfoFromPyTorchETEntry(node.outputs, node.output_types[0])
                 comm_args.dtype = tensorDtypeMap[in_msg_type]  # 1st value of input_types is the data type for the tensors
 
+            # the recorded rank id in execution trace is local rank id in the process group
+            # we need to convert it to global rank for replay, check the function broadcast() of pytorch below:
+            # https://github.com/pytorch/pytorch/blob/6c4efd4e959017fc758fcc5dc32d8cc6a4b9164d/torch/distributed/distributed_c10d.py#L2404
             if comm_args.comms in supportedP2pOps:
                 if "send" in comm_args.comms:
-                    (comm_args.src_rank, comm_args.dst_rank) = (target_rank, recorded_rank)
+                    (comm_args.src_rank, comm_args.dst_rank) = (target_rank, comm_args.groupRanks[recorded_rank])
                 elif "recv" in comm_args.comms:
-                    (comm_args.src_rank, comm_args.dst_rank) = (recorded_rank, target_rank)
-
-            if comm_args.comms in ["reduce", "broadcast", "gather", "scatter"]:
-                comm_args.root = recorded_rank
+                    (comm_args.src_rank, comm_args.dst_rank) = (comm_args.groupRanks[recorded_rank], target_rank)
+            elif comm_args.comms in ["reduce", "broadcast", "gather", "scatter"]:
+                comm_args.root = comm_args.groupRanks[recorded_rank]
                 comm_args.groupRanks = comm_args.groupRanks
 
             if comm_args.comms == "all_to_allv":

--- a/et_replay/comm/commsTraceParser.py
+++ b/et_replay/comm/commsTraceParser.py
@@ -97,7 +97,7 @@ def _parseExecutionTrace(
     return comms_op_list
 
 def _parse_proc_group_info(in_trace: ExecutionTrace):
-    pg_ranks_map = {}
+    pg_ranks_map = {} # {node_id : {process_group_id : [ranks] } }
     for node in in_trace.nodes.values():
         if "process_group:init" in node.name:
             # info of this node is dumped using torch.distributed.distributed_c10d._world.pg_config_info
@@ -108,13 +108,14 @@ def _parse_proc_group_info(in_trace: ExecutionTrace):
             except json.decoder.JSONDecodeError:  # skip if pg_config_info is truncated
                 break
 
+            pg_ranks_map[node.id] = {}
             for pg in pg_objs:
                 if not pg["pg_name"].isdecimal():
                     # TODO support local synchronization pg
                     raise ValueError(f"Process group name is {pg['pg_name']} in node {node['id']}, which is not supported.")
                 (pg_id, ranks, group_size, group_count) = [pg[k] for k in ["pg_name", "ranks", "group_size", "group_count"]]
                 pg_id = int(pg_id)
-                pg_ranks_map[pg_id] = (
+                pg_ranks_map[node.id][pg_id] = (
                     ranks
                     if len(ranks) > 0
                     else list(range(group_size))
@@ -126,9 +127,14 @@ def _parse_proc_group_info(in_trace: ExecutionTrace):
 def _parse_comms_op_node(in_trace: ExecutionTrace, pg_ranks_map: dict, target_rank: int, total_ranks: int):
     comms_op_list = []
 
-    for pg_id, ranks in pg_ranks_map.items():
-        comm_args = _create_pg_init_node(pg_id, ranks, len(ranks))
-        comms_op_list.append(comm_args)
+    for node_id in pg_ranks_map:
+        for pg_id, ranks in pg_ranks_map[node_id].items():
+            comm_args = _create_pg_init_node(node_id, pg_id, ranks, len(ranks))
+            comms_op_list.append(comm_args)
+
+    pg_ranks_map_flatten = {}
+    for k,v in pg_ranks_map.items():
+        pg_ranks_map_flatten.update(v)
 
     for node in in_trace.nodes.values():
         if node.name == "record_param_comms":
@@ -146,7 +152,7 @@ def _parse_comms_op_node(in_trace: ExecutionTrace, pg_ranks_map: dict, target_ra
 
             if pg_id_pair[0].isdecimal():
                 comm_args.pgId = int(pg_id_pair[0])
-                comm_args.groupRanks = pg_ranks_map[comm_args.pgId]
+                comm_args.groupRanks = pg_ranks_map_flatten[comm_args.pgId]
                 comm_args.worldSize = len(comm_args.groupRanks)
 
             if comm_args.comms not in ("wait", "barrier"):
@@ -186,8 +192,9 @@ def _parse_comms_op_node(in_trace: ExecutionTrace, pg_ranks_map: dict, target_ra
 
     return comms_op_list
 
-def _create_pg_init_node(pg_id: int, ranks: List[int], world_size: int):
+def _create_pg_init_node(node_id: int, pg_id: int, ranks: List[int], world_size: int):
     comm_args = commsArgs()
+    comm_args.id = node_id
     comm_args.comms = "init"
     comm_args.pgId = pg_id
     comm_args.req = -1

--- a/et_replay/comm/commsTraceParser.py
+++ b/et_replay/comm/commsTraceParser.py
@@ -89,7 +89,7 @@ def _parseExecutionTrace(
     """
     ET_PG_NAME_TUPLE = in_trace.schema_pytorch() >= (1, 0, 3)
     if (in_trace.schema_pytorch() < (1, 0, 3)):
-        raise ValueError(f"Only support trace version >1.0.3, but current trace format is {in_trace.schema.split("-")[0]}")
+        raise ValueError(f"Only support trace version >1.0.3, but current trace version is {in_trace.schema.split('-')[0]}")
 
     pg_ranks_map = _parse_proc_group_info(in_trace) # key is pg id, value is global ranks in this pg
     comms_op_list = _parse_comms_op_node(in_trace, pg_ranks_map, target_rank, total_ranks)

--- a/et_replay/comm/commsTraceParser.py
+++ b/et_replay/comm/commsTraceParser.py
@@ -26,155 +26,31 @@ tensorDtypeMap = {
 
 
 def parseTrace(
-    in_trace: List, trace_type: str, target_rank: int, total_ranks: int
+    in_trace: List, trace_type: str, trace_file_path: str, target_rank: int, total_ranks: int
 ) -> List:
     """
     Parse trace files to be compatible with PARAM replay-mode.
-    Currently supports: Basic Trace, Kineto Unitrace, and PyTorch ET trace.
+    Currently supports: Chakra host execution trace.
 
     Args:
         in_trace: Trace file to be parsed.
         trace_type: Trace type to be parsed with
+        trace_file_path: Path of input trace file being loaded.
         target_rank: The current rank of the device.
         total_ranks: Total number of ranks.
     Returns:
         parsed_trace: Parsed trace that is compatible with PARAM replay-mode.
     """
 
-    if trace_type == "basic":  # Basic Trace
-        parsed_trace = _parseBasicTrace(in_trace)
-    elif trace_type == "et":  # Execution Trace (e.g. PyTorch ET, Chakra)
+    if trace_type == "et":  # Execution Trace (e.g. Chakra host execution trace)
         parsed_trace = _parseExecutionTrace(
             ExecutionTrace(in_trace), target_rank, total_ranks
         )
-    elif trace_type == "kineto":  # Kineto Unitrace
-        parsed_trace = _parseKinetoUnitrace(in_trace, target_rank)
     else:
-        raise ValueError("Unrecognized trace format.")
+        raise ValueError(f"Specified trace type {trace_type} to {trace_file_path} is not supported. \
+Please check supported types with '--help'")
 
     return parsed_trace
-
-
-def _parseBasicTrace(in_trace: List):
-    """
-    Convert Basic Trace to comms trace format.
-    """
-    newCommsTrace = []
-    for cnt, curComm in enumerate(in_trace):
-        newComm = commsArgs()
-        newComm.id = cnt
-        newComm.markerStack = curComm.get("markers")
-        if "comms" in curComm:
-            _parseBasicTraceComms(curComm, newComm)
-
-        elif "compute" in curComm:
-            _parseBasicTraceCompute(curComm, newComm)
-
-        if newComm.comms is not None or newComm.compute is not None:
-            newCommsTrace.append(newComm)
-        else:
-            raise ValueError(
-                "Trace file contains an element that is not a supported in PARAM! Please format all elements as comms or compute for replay."
-            )
-
-    return newCommsTrace
-
-
-def _parseBasicTraceComms(curComm, newComm: commsArgs) -> None:
-    newComm.comms = comms_utils.paramToCommName(curComm["comms"].lower())
-    if newComm.markerStack is None:
-        newComm.markerStack = [newComm.comms]
-    newComm.req = curComm.get("req")
-    newComm.startTimeNs = curComm.get("startTime_ns")
-    newComm.worldSize = curComm.get("world_size")
-    newComm.root = curComm.get("root")
-    newComm.pgId = curComm.get("pg_id")
-    newComm.groupRanks = curComm.get("global_ranks")
-
-    if newComm.comms not in ("wait", "barrier", "init", "batch_isend_irecv"):
-        newComm.inMsgSize = curComm["in_msg_size"]
-        newComm.outMsgSize = curComm["out_msg_size"]
-        newComm.dtype = curComm["dtype"].lower()
-
-    if newComm.comms == "all_to_allv":
-        newComm.inSplit = curComm["in_split"]
-        newComm.outSplit = curComm["out_split"]
-
-    if newComm.comms in supportedP2pOps:
-        newComm.src_rank = curComm["src_rank"]
-        newComm.dst_rank = curComm["dst_rank"]
-        newComm.batch_p2p = curComm["use_batch"]
-
-
-def _parseBasicTraceCompute(curComm, newComm: commsArgs) -> None:
-    newComm.compute = curComm["compute"].lower()
-    if newComm.markerStack is None:
-        newComm.markerStack = [newComm.compute]
-    # count = number of times to call the compute kernel
-    if "count" in curComm:
-        newComm.count = curComm["count"]
-    # if no count is specified, assume 1
-    else:
-        newComm.count = 1
-    if newComm.compute == "gemm":
-        if "mm_dim" in curComm:
-            newComm.mm0_dim0 = curComm.get("mm_dim")
-            newComm.mm0_dim1 = curComm.get("mm_dim")
-            newComm.mm1_dim0 = curComm.get("mm_dim")
-            newComm.mm1_dim1 = curComm.get("mm_dim")
-        else:
-            newComm.mm0_dim0 = curComm.get("mm0_dim0")
-            newComm.mm0_dim1 = curComm.get("mm0_dim1")
-            newComm.mm1_dim0 = curComm.get("mm1_dim0")
-            newComm.mm1_dim1 = curComm.get("mm1_dim1")
-        newComm.dtype = curComm.get("dtype").lower()
-    elif newComm.compute == "emb_lookup":
-        if "direction" in curComm:
-            newComm.direction = curComm["direction"]
-        else:
-            newComm.direction = "forward"
-        newComm.emb_dim = curComm.get("emb_dim")
-        newComm.num_embs = curComm.get("num_embs")
-        newComm.batch_size = curComm.get("batch_size")
-        newComm.num_emb_tables_per_device = curComm.get("num_emb_tables")
-        newComm.num_emb_tables_batched = -1
-        newComm.bag_size = curComm.get("bag_size")
-    else:
-        raise ValueError(
-            f"Trace file contains {str(newComm.compute)} compute element that is not supported in PARAM!"
-        )
-
-
-def _parseKinetoUnitrace(in_trace: List, target_rank: int) -> List:
-    """
-    Convert the Kineto unitrace w/ comms metadata to the clean common trace format for replay.
-    """
-    newCommsTrace = []
-    commsCnt = 0
-    for entry in in_trace:
-        # TODO: figure the current marker stack if present
-        marker = "unknown"
-        pass
-
-        if (
-            "name" in entry
-            and entry["name"] == "record_param_comms"
-            and entry["args"]["rank"] == target_rank
-        ):
-            newComm = commsArgs()
-            newComm.comms = comms_utils.paramToCommName(entry["args"]["comms"].lower())
-            newComm.id = commsCnt
-            newComm.inMsgSize = entry["args"]["in_msg_size"]
-            newComm.outMsgSize = entry["args"]["out_msg_size"]
-            newComm.dtype = entry["args"]["dtype"].lower()
-            newComm.inSplit = entry["args"]["in_split"]
-            newComm.outSplit = entry["args"]["out_split"]
-            newComm.markerStack = marker
-
-            newCommsTrace.append(newComm)
-            commsCnt += 1
-
-    return newCommsTrace
 
 
 def _getTensorInfoFromPyTorchETEntry(
@@ -210,7 +86,6 @@ def _parseExecutionTrace(
 ) -> List:
     """
     Convert the Execution Trace comms metadata to the common trace format for replay.
-
     """
     # Execution Trace PG_ID types availability
     ET_PG_NAME_TUPLE = in_trace.schema_pytorch() >= (1, 0, 3)

--- a/et_replay/comm/commsTraceParser.py
+++ b/et_replay/comm/commsTraceParser.py
@@ -136,61 +136,59 @@ def _parse_comms_op_node(in_trace: ExecutionTrace, pg_ranks_map: dict, target_ra
     for k,v in pg_ranks_map.items():
         pg_ranks_map_flatten.update(v)
 
-    for node in in_trace.nodes.values():
-        if node.name == "record_param_comms":
-            # according to macro RECORD_PARAM_COMMS and RECORD_PARAM_COMMS_DATA in torch/csrc/distributed/c10d/ParamCommsUtils.hpp
-            # ["wait", "barrier", "init"] record 1st element as seq, others record starting from input tensor
-            index_base = 0 if isinstance(node.inputs[0], int) else 1
-            (req_id, pg_id_pair, recorded_rank, comm_name) = [node.inputs[index_base + i] for i in range(4)]
-            comm_args = commsArgs()
-            comm_args.id = node.id
-            comm_args.comms = comms_utils.paramToCommName(comm_name.lower())
-            if comm_args.comms == "init":
-                # init node has been built
-                continue
-            comm_args.req = req_id
+    comm_nodes = (node for node in in_trace.nodes.values() if node.name == "record_param_comms")
+    for node in comm_nodes:
+        # according to macro RECORD_PARAM_COMMS and RECORD_PARAM_COMMS_DATA in torch/csrc/distributed/c10d/ParamCommsUtils.hpp
+        # ["wait", "barrier", "init"] record 1st element as seq, others record starting from input tensor
+        index_base = 0 if isinstance(node.inputs[0], int) else 1
+        req_id = node.inputs[index_base]
+        recorded_rank = node.inputs[index_base + 2]
 
-            if pg_id_pair[0].isdecimal():
-                comm_args.pgId = int(pg_id_pair[0])
-                comm_args.groupRanks = pg_ranks_map_flatten[comm_args.pgId]
-                comm_args.worldSize = len(comm_args.groupRanks)
+        comm_args = commsArgs()
+        comm_args.id = node.id
+        comm_args.comms = comms_utils.paramToCommName(node.commArgs.collective_name.lower())
+        if comm_args.comms == "init":
+            # init node has been built
+            continue
+        comm_args.req = req_id
 
-            if comm_args.comms not in ("wait", "barrier"):
-                (comm_args.inMsgSize, in_msg_type) = _getTensorInfoFromPyTorchETEntry(node.inputs, node.input_types[0])
-                (comm_args.outMsgSize, _) = _getTensorInfoFromPyTorchETEntry(node.outputs, node.output_types[0])
-                comm_args.dtype = tensorDtypeMap[in_msg_type]  # 1st value of input_types is the data type for the tensors
+        if (node.commArgs.pg_name and node.commArgs.pg_name.isdecimal()):
+            comm_args.pgId = int(node.commArgs.pg_name)
+            comm_args.groupRanks = pg_ranks_map_flatten[comm_args.pgId]
+            comm_args.worldSize = len(comm_args.groupRanks)
 
-            # the recorded rank id in execution trace is local rank id in the process group
-            # we need to convert it to global rank for replay, check the function broadcast() of pytorch below:
-            # https://github.com/pytorch/pytorch/blob/6c4efd4e959017fc758fcc5dc32d8cc6a4b9164d/torch/distributed/distributed_c10d.py#L2404
-            if comm_args.comms in supportedP2pOps:
-                if "send" in comm_args.comms:
-                    (comm_args.src_rank, comm_args.dst_rank) = (target_rank, comm_args.groupRanks[recorded_rank])
-                elif "recv" in comm_args.comms:
-                    (comm_args.src_rank, comm_args.dst_rank) = (comm_args.groupRanks[recorded_rank], target_rank)
-            elif comm_args.comms in ["reduce", "broadcast", "gather", "scatter"]:
-                comm_args.root = comm_args.groupRanks[recorded_rank]
-                comm_args.groupRanks = comm_args.groupRanks
+        if comm_args.comms not in ("wait", "barrier"):
+            comm_args.inMsgSize = node.commArgs.in_msg_nelems
+            comm_args.outMsgSize = node.commArgs.out_msg_nelems
+            comm_args.dtype = node.commArgs.dtype.lower()
 
-            if comm_args.comms == "all_to_allv":
-                # 6th value of inputs is in_split, split evenly if not provided
-                if not comm_args.worldSize:
-                    # if no pg info provided, use total ranks as world size
-                    comm_args.worldSize = total_ranks
-                comm_args.inSplit = (
-                    node.inputs[5]
-                    if node.inputs[5]
-                    else [int(comm_args.inMsgSize / comm_args.worldSize)]
-                    * comm_args.worldSize
-                )
-                # 7th value of inputs is out_split, split evenly if not provided
-                comm_args.outSplit = (
-                    node.inputs[6]
-                    if node.inputs[6]
-                    else [int(comm_args.outMsgSize / comm_args.worldSize)]
-                    * comm_args.worldSize
-                )
-            comms_op_list.append(comm_args)
+        # the recorded rank id in execution trace is local rank id in the process group
+        # we need to convert it to global rank for replay, check the function broadcast() of pytorch below:
+        # https://github.com/pytorch/pytorch/blob/6c4efd4e959017fc758fcc5dc32d8cc6a4b9164d/torch/distributed/distributed_c10d.py#L2404
+        if comm_args.comms in supportedP2pOps:
+            if "send" in comm_args.comms:
+                (comm_args.src_rank, comm_args.dst_rank) = (target_rank, comm_args.groupRanks[recorded_rank])
+            elif "recv" in comm_args.comms:
+                (comm_args.src_rank, comm_args.dst_rank) = (comm_args.groupRanks[recorded_rank], target_rank)
+        elif comm_args.comms in ["reduce", "broadcast", "gather", "scatter"]:
+            comm_args.root = comm_args.groupRanks[recorded_rank]
+            comm_args.groupRanks = comm_args.groupRanks
+
+        if comm_args.comms == "all_to_allv":
+            if not comm_args.worldSize:
+                # if no pg info provided, use total ranks as world size
+                comm_args.worldSize = total_ranks
+            comm_args.inSplit = (
+                json.loads(node.commArgs.in_split_size)
+                if json.loads(node.commArgs.in_split_size)
+                else [int(comm_args.inMsgSize / comm_args.worldSize)] * comm_args.worldSize
+            )
+            comm_args.outSplit = (
+                json.loads(node.commArgs.out_split_size)
+                if json.loads(node.commArgs.out_split_size)
+                else [int(comm_args.outMsgSize / comm_args.worldSize)] * comm_args.worldSize
+            )
+        comms_op_list.append(comm_args)
 
     return comms_op_list
 

--- a/et_replay/comm/commsTraceParser.py
+++ b/et_replay/comm/commsTraceParser.py
@@ -12,22 +12,6 @@ from et_replay.comm.comms_utils import commsArgs
 import logging
 logger = logging.getLogger(__name__)
 
-tensorDtypeMap = {
-    "Tensor(int)": "int",
-    "Tensor(float)": "float",
-    "Tensor(bool)": "bool",
-    "Tensor(long)": "long",
-    "Tensor(long int)": "long",
-    "Tensor(double)": "double",
-    "Tensor(half)": "half",
-    "Tensor(byte)": "byte",
-    "Tensor(c10::Half)": "half",
-    "Tensor(c10::BFloat16)": "bfloat16",
-    "Tensor(unsigned char)": "char",
-    "Tensor(signed char)": "char",
-}
-
-
 def parseTrace(
     in_trace: List, trace_type: str, trace_file_path: str, target_rank: int, total_ranks: int
 ) -> List:
@@ -54,34 +38,6 @@ def parseTrace(
 Please check supported types with '--help'")
 
     return parsed_trace
-
-
-def _getTensorInfoFromPyTorchETEntry(
-    tensor_container: List, container_type: str
-) -> Tuple[int, int, str]:
-    """
-    Extract message size, tensor count, type from PyTorch ET entry inputs/outputs field.
-    NOTE: This format can be changed at anytime. TODO: When an extract/parsing tool is available in ATC, switch to it.
-    """
-    list_count = container_type.count("GenericList")
-    tensors = []
-    if list_count == 2:
-        # GenericList[GenericList[Tensor(), Tensor()]]
-        tensors = tensor_container[0][0]
-        dtype = container_type.replace("GenericList[", "").split(",", 1)[0]
-    elif list_count == 1:
-        # GenericList[Tensor()]
-        tensors = tensor_container[0]
-        dtype = container_type.replace("GenericList[", "").replace("]", "")
-    else:
-        tensors.append(tensor_container[0])
-        dtype = container_type
-
-    msg_size = 0
-    for tensor in tensors:
-        msg_size += tensor[3]
-
-    return msg_size, dtype
 
 
 def _parseExecutionTrace(

--- a/et_replay/comm/comms_utils.py
+++ b/et_replay/comm/comms_utils.py
@@ -792,7 +792,7 @@ class paramCommsBench(ABC):
             "short": torch.short,
             "char": torch.int8,
             "signed char": torch.int8,
-            "unsigned char": torch.uint8
+            "unsigned char": torch.uint8,
         }
         self.supportedDtype = list(self.dtypeMap.keys())
         self.backendFuncs: BaseBackend

--- a/et_replay/comm/comms_utils.py
+++ b/et_replay/comm/comms_utils.py
@@ -791,6 +791,8 @@ class paramCommsBench(ABC):
             "int8": torch.int8,
             "short": torch.short,
             "char": torch.int8,
+            "signed char": torch.int8,
+            "unsigned char": torch.uint8
         }
         self.supportedDtype = list(self.dtypeMap.keys())
         self.backendFuncs: BaseBackend

--- a/et_replay/execution_trace.py
+++ b/et_replay/execution_trace.py
@@ -466,7 +466,7 @@ class ExecutionTrace:
             if attr["name"] in cls.COMM_ATTR_TYPES.keys()
         }
 
-        params_dict = {k:attr_dict.get(k, None) for k in cls.COMM_ATTR_TYPES.keys()}
+        params_dict = {k: attr_dict.get(k, None) for k in cls.COMM_ATTR_TYPES.keys()}
         return _CommArgs(**params_dict)
 
     @staticmethod
@@ -506,7 +506,11 @@ class ExecutionTrace:
             kernel_file,
         ) = ExecutionTrace._read_attrs(x)
 
-        comm_attrs = ExecutionTrace._read_comm_attrs(x) if x['name'] == "record_param_comms" else None
+        comm_attrs = (
+            ExecutionTrace._read_comm_attrs(x)
+            if x["name"] == "record_param_comms"
+            else None
+        )
 
         return Node(
             x["name"],
@@ -528,7 +532,7 @@ class ExecutionTrace:
             rf_id,
             kernel_backend,
             kernel_file,
-            comm_attrs
+            comm_attrs,
         )
 
     @staticmethod

--- a/et_replay/tools/comm_replay.py
+++ b/et_replay/tools/comm_replay.py
@@ -623,7 +623,7 @@ class commsTraceReplayBench(paramCommsBench):
         Args:
             curComm: The current communication that we are preparing the correct tensor for.
             commsParams: Holds the comms param arguments that will determine tensor attributes.
-            regenerateTensors: when an id is being replayed multiple times, setting this to false will use temsors from previous runs
+            regenerateTensors: when an id is being replayed multiple times, setting this to false will use tensors from previous runs
         Returns:
             (ipTensor, opTensor) if the current communication requires tensors, None otherwise.
         """

--- a/et_replay/tools/comm_replay.py
+++ b/et_replay/tools/comm_replay.py
@@ -597,8 +597,9 @@ class commsTraceReplayBench(paramCommsBench):
                 commsOp.pgId,
                 commsOp.inMsgSize,
                 commsOp.outMsgSize,
-                commsOp.inSplit,
-                commsOp.outSplit,
+                # inSplit and outSplit are list type, need to be converted for hash
+                tuple(commsOp.inSplit),
+                tuple(commsOp.outSplit),
             )
         else:
             op = (

--- a/et_replay/tools/comm_replay.py
+++ b/et_replay/tools/comm_replay.py
@@ -1595,7 +1595,11 @@ class commsTraceReplayBench(paramCommsBench):
             self.comms_trace = commsTraceParser.parseTrace(
                 self.comms_trace,
                 self.trace_type,
-                (self.trace_file if not os.path.isdir(self.trace_file) else f"{self.trace_file}/{rank}.json"),
+                (
+                    self.trace_file
+                    if not os.path.isdir(self.trace_file)
+                    else f"{self.trace_file}/{rank}.json"
+                ),
                 rank,
                 self.backendFuncs.get_world_size(),
             )

--- a/et_replay/tools/comm_replay.py
+++ b/et_replay/tools/comm_replay.py
@@ -115,7 +115,7 @@ class commsTraceReplayBench(paramCommsBench):
         self.max_msg_cnt = 0  # 0 means no limit
         self.num_msg = 0
         self.is_blocking = True
-        self.do_warm_up = True
+        self.do_warm_up = False
         self.reuse_tensors = False
 
         self.allowList = ""
@@ -217,7 +217,7 @@ class commsTraceReplayBench(paramCommsBench):
             "--do-warm-up",
             action="store_true",
             default=self.do_warm_up,
-            help="Toggle to disable performing extra replaying for warm-up",
+            help="Toggle to enable performing extra replaying for warm-up",
         )
         parser.add_argument(
             "--reuse-tensors",

--- a/et_replay/tools/comm_replay.py
+++ b/et_replay/tools/comm_replay.py
@@ -1546,7 +1546,7 @@ class commsTraceReplayBench(paramCommsBench):
             # Check if self.trace_file is a directory or a single file
             if os.path.isdir(self.trace_file):
                 # Directory mode: construct the path to the rank-specific file
-                trace_file_path = f"{self.trace_file}/{rank}.json"
+                trace_file_path = f"{self.trace_file}/rank{rank}.json"
             else:
                 # Single file mode: use self.trace_file as is
                 trace_file_path = self.trace_file
@@ -1599,7 +1599,7 @@ class commsTraceReplayBench(paramCommsBench):
                 (
                     self.trace_file
                     if not os.path.isdir(self.trace_file)
-                    else f"{self.trace_file}/{rank}.json"
+                    else f"{self.trace_file}/rank{rank}.json"
                 ),
                 rank,
                 self.backendFuncs.get_world_size(),

--- a/et_replay/tools/comm_replay.py
+++ b/et_replay/tools/comm_replay.py
@@ -805,8 +805,8 @@ class commsTraceReplayBench(paramCommsBench):
                         self.collectiveArgs.collective = collName
                         self.backendFuncs.P2POp(self.collectiveArgs, retFlag=True)
 
-                if collName in ["broadcast"]:
-                    self.collectiveArgs.srcOrDst = curComm.srcOrDst
+                if collName in ["reduce", "broadcast", "gather", "scatter"]:
+                    self.collectiveArgs.srcOrDst = curComm.root
 
                 retObj = self.backendFuncs.collectiveFunc[collName](
                     self.collectiveArgs, retFlag=True

--- a/et_replay/tools/comm_replay.py
+++ b/et_replay/tools/comm_replay.py
@@ -41,7 +41,8 @@ logger = logging.getLogger(__name__)
 # sleep for 20ms to wait for next collective
 LOOP_TIMER_S = 0.02
 
-VALID_TRACE_TYPES = ["basic", "et", "kineto"]
+# index 0 is default value of trace type
+VALID_TRACE_TYPES = ["et"]
 
 
 def writeCommDetails(commsTracePerf: List, rank: int, folder: str = "./") -> None:
@@ -176,8 +177,10 @@ class commsTraceReplayBench(paramCommsBench):
         parser.add_argument(
             "--trace-type",
             type=str,
-            default="basic",
-            help=f"Trace type used for replay. Supported trace types: {str(VALID_TRACE_TYPES)}. By default use basic trace.",
+            choices=VALID_TRACE_TYPES,
+            default=VALID_TRACE_TYPES[0],
+            help=f"Select trace type used for replay. Supported trace types: {VALID_TRACE_TYPES}. \
+                   'et' represents Chakra host execution trace.",
         )
         parser.add_argument(
             "--use-one-trace",
@@ -1592,6 +1595,7 @@ class commsTraceReplayBench(paramCommsBench):
             self.comms_trace = commsTraceParser.parseTrace(
                 self.comms_trace,
                 self.trace_type,
+                (self.trace_file if not os.path.isdir(self.trace_file) else f"{self.trace_file}/{rank}.json"),
                 rank,
                 self.backendFuncs.get_world_size(),
             )


### PR DESCRIPTION
## Summary
- Fixed hash function to correctly handle inSplit and outSplit by converting them to tuples.
- Corrected srcOrDst assignment for "reduce", "broadcast", "gather", and "scatter" operations in runComms.
- Updated trace file naming convention to rank{rank}.json when in directory mode.
- Disabled warm-up by default and updated the help text for do_warm_up toggle.
- Corrected a typo in the regenerateTensors description.

This PR relies on https://github.com/facebookresearch/param/pull/147.

## Test Plan
```
$ comm_replay --trace-type et --trace-path /home/sanshang/021_debug/000_code/param/trace/traces_megatronlm_gpt_43B_32ranks_pytnightly0703/execution_trace
```
![image](https://github.com/user-attachments/assets/6c9c2c47-1053-4358-b492-0823b1c55909)