### PR TITLE
Refactor backend classes and remove deprecated methods in PyTorch backends

### DIFF
--- a/et_replay/comm/backend/base_backend.py
+++ b/et_replay/comm/backend/base_backend.py
@@ -15,7 +15,7 @@ from torch.distributed import ProcessGroup
 logger = logging.getLogger(__name__)
 
 supportedDevices = ["cpu", "cuda", "rocm", "tpu"]
-supportedC10dBackends = ["nccl", "gloo", "mpi", "ucc", "xla"]
+supportedC10dBackends = ["nccl", "gloo", "mpi", "fairring", "xla"]
 supportedCollectives = [
     "reduce",
     "all_reduce",
@@ -125,7 +125,7 @@ class collectiveArgsHolder:
         self.use_ext_dist = False
 
 
-class backendFunctions(ABC):
+class BaseBackend(ABC):
     """Abstract base class, provides common abstraction for all the backends."""
 
     def __init__(self) -> None:
@@ -151,51 +151,6 @@ class backendFunctions(ABC):
 
         self.computeFunc = {"gemm": self.gemm}
 
-    def getBusBW(
-        self, collective: str, algBW: float, collectiveArgs: collectiveArgsHolder
-    ) -> float:
-        """
-        Calculate bus bandwidth for collective.
-
-        Args:
-            collective: Name of collective.
-            algBW: Algorithmic bandwidth for the collective.
-            collectiveArgs: Contains information about world size.
-        Returns:
-            busBW: Bus bandwidth in GBps
-        """
-        busBW = algBW
-        mulFactor = 1.0
-        if collective == "all_reduce":
-            if collectiveArgs.world_size != 0:
-                mulFactor = (
-                    2 * (collectiveArgs.world_size - 1) / (collectiveArgs.world_size)
-                )
-            busBW = algBW * mulFactor
-        elif collective in (
-            "all_to_all_single",
-            "all_to_all",
-            "all_to_allv",
-            "gather",
-            "all_gather",
-            "reduce_scatter",
-            "reduce_scatter_base",
-            "scatter",
-            "all_gather_base",
-        ):
-            if collectiveArgs.world_size != 0:
-                mulFactor = (collectiveArgs.world_size - 1) / (
-                    collectiveArgs.world_size
-                )
-            busBW = algBW * mulFactor
-        elif collective in ("reduce", "broadcast", "incast", "multicast"):
-            busBW = algBW
-        else:
-            logger.error(
-                f"collective: {collective} is not supported in computing bus BW! "
-            )
-        return busBW
-
     def alloc_ones(
         self,
         sizeArr: int,
@@ -219,6 +174,7 @@ class backendFunctions(ABC):
             ipTensor = ipTensor * scaleFactor
         return ipTensor
 
+    @abstractmethod
     def noop(
         self,
         collectiveArgs: collectiveArgsHolder = None,
@@ -357,12 +313,12 @@ class backendFunctions(ABC):
         pass
 
 
-customized_backend: Dict[str, backendFunctions] = {}
+customized_backend: Dict[str, BaseBackend] = {}
 
 
 def register_customized_backend(
     name: str,
-    func: backendFunctions,
+    func: BaseBackend,
     device: Optional[str] = None,
 ) -> None:
     global customized_backend

--- a/et_replay/comm/backend/pytorch_tpu_backend.py
+++ b/et_replay/comm/backend/pytorch_tpu_backend.py
@@ -7,10 +7,10 @@ import torch.nn as nn
 import torch_xla.core.xla_model as xm  # @manual
 import torch_xla.distributed.xla_multiprocessing as xmp  # @manual
 
-from et_replay.comm.comms_utils import backendFunctions
+from et_replay.comm.backend.base_backend import BaseBackend
 
 
-class PyTorchTPUBackend(backendFunctions):
+class PyTorchTPUBackend(BaseBackend):
     def sayHello(self):
         myhost = os.uname()[1]
         device = self.get_device()

--- a/et_replay/comm/commsTraceParser.py
+++ b/et_replay/comm/commsTraceParser.py
@@ -6,8 +6,8 @@ from typing import List, Tuple
 
 from et_replay import ExecutionTrace
 from et_replay.comm import comms_utils
+from et_replay.comm.backend.base_backend import supportedP2pOps
 from et_replay.comm.comms_utils import commsArgs
-from et_replay.comm.pytorch_backend_utils import supportedP2pOps
 
 tensorDtypeMap = {
     "Tensor(int)": "int",

--- a/et_replay/comm/comms_utils.py
+++ b/et_replay/comm/comms_utils.py
@@ -38,15 +38,15 @@ except ImportError:
 
 import numpy as np
 import torch
-
-from et_replay.comm.param_profile import paramTimer
-from et_replay.comm.pytorch_backend_utils import (
-    backendFunctions,
+from et_replay.comm.backend.base_backend import (
+    BaseBackend,
     collectiveArgsHolder,
     customized_backend,
     supportedC10dBackends,
     supportedDevices,
 )
+
+from et_replay.comm.param_profile import paramTimer
 from torch._C._distributed_c10d import ProcessGroup  # @manual
 
 random.seed()
@@ -233,7 +233,7 @@ def fixBeginSize(commsParams: commsParamsHolder, world_size: int) -> None:
 
 
 def get_rank_details(
-    backendFuncs: backendFunctions,
+    backendFuncs: BaseBackend,
 ) -> Tuple[int, int, int, ProcessGroup, str, str]:
     """
     Returns the details of the rank for the current backendFunction.
@@ -699,7 +699,7 @@ class paramStreamGuard(ContextDecorator):
         self,
         stream: Optional[torch.cuda.Stream],
         curDevice: torch.device,
-        backendFuncs: backendFunctions,
+        backendFuncs: BaseBackend,
         is_blocking: bool = True,
         timer: Optional[paramDeviceTimer] = None,
     ) -> None:
@@ -729,7 +729,7 @@ class paramDeviceTimer(paramTimer):
     Device timer.
     """
 
-    def __init__(self, name: str, backendFuncs: backendFunctions) -> None:
+    def __init__(self, name: str, backendFuncs: BaseBackend) -> None:
         """
         Initialize start and end device events
         """
@@ -918,7 +918,7 @@ class paramCommsBench(ABC):
             "char": torch.int8,
         }
         self.supportedDtype = list(self.dtypeMap.keys())
-        self.backendFuncs: backendFunctions
+        self.backendFuncs: BaseBackend
 
         self.collectiveArgs = collectiveArgsHolder()
         self.comm_size = 1

--- a/et_replay/tools/comm_replay.py
+++ b/et_replay/tools/comm_replay.py
@@ -19,6 +19,7 @@ import numpy as np
 import torch
 
 from et_replay.comm import comms_utils
+from et_replay.comm.backend.base_backend import supportedP2pOps
 from et_replay.comm.comms_utils import (
     bootstrap_info_holder,
     commsArgs,
@@ -28,7 +29,6 @@ from et_replay.comm.comms_utils import (
     paramToCommName,
 )
 from et_replay.comm.param_profile import paramProfile, paramTimer
-from et_replay.comm.pytorch_backend_utils import supportedP2pOps
 
 try:
     from trainer_iteration_wrapper import setTrainingIteration  # @manual
@@ -1382,11 +1382,11 @@ class commsTraceReplayBench(paramCommsBench):
         """
         # init backend and corresponding function pointers
         if commsParams.nw_stack == "pytorch-dist":
-            from et_replay.comm.pytorch_dist_backend import PyTorchDistBackend
+            from et_replay.comm.backend.pytorch_dist_backend import PyTorchDistBackend
 
             self.backendFuncs = PyTorchDistBackend(bootstrap_info, commsParams)
         elif commsParams.nw_stack == "pytorch-xla-tpu":
-            from et_replay.comm.pytorch_tpu_backend import PyTorchTPUBackend
+            from et_replay.comm.backend.pytorch_tpu_backend import PyTorchTPUBackend
 
             self.backendFuncs = PyTorchTPUBackend(bootstrap_info, commsParams)
         else:


### PR DESCRIPTION
## Summary

- Renamed backendFunctions to BaseBackend and refactored associated modules for improved abstraction.
- Removed getBusBW from BaseBackend.
- Removed initialize_tcpstore and UCC plugin support from PyTorchDistBackend.
- Reorganized module structure by relocating files to a backend directory.

## Test Plan
$ comm_replay --trace-type et --trace-path /home/sanshang/021_debug/000_code/param/trace/traces_megatronlm_gpt_43B_32ranks_pytnightly0703/execution_trace
