### PR TITLE
add comm part to et_replay

### DIFF
--- a/et_replay/et_replay_utils.py
+++ b/et_replay/et_replay_utils.py
@@ -368,7 +368,7 @@ def build_torchscript_func(n):
     if (
         n.op_schema == ""
         or n.name == "aten::record_stream"
-        or n.name.startswith("aten::_foreach")
+        #or n.name.startswith("aten::_foreach")
     ):
         return None, None
 


### PR DESCRIPTION
## Summary
add comm part to et_replay

## Test Plan
## Test Plan
1. test use 43B megatron trace full replay with storage recycle
slurm script:

```bash
#!/bin/bash
#SBATCH --job-name=full_replay_job
#SBATCH --nodes=4
#SBATCH --ntasks=32
#SBATCH --ntasks-per-node=8
#SBATCH --gpus-per-node=8
#SBATCH --time=01:00:00
#SBATCH --output=%x_%j.out
#SBATCH --error=%x_%j.err


srun -A general_cs_plutus\
     --container-image /lustre/fsw/portfolios/general/users/songyant/docker/songyant+docker-images+ai_develop.sqsh \
     --no-container-mount-home \
     --container-mounts=/lustre/fsw/portfolios/general/users/songyant/workspace_local:/workspace_local \
     zsh -c "
        if [ ! -d /run/sshd ]; then
            mkdir -p /run/sshd
            chmod 0755 /run/sshd
        fi

        source ~/.zshrc
        conda activate full_et_replay

        et_replay --trace_path /workspace_local/full_et_replay/traces_mega_10_new/execution_trace --recycle_storages
     "
```

result:
![image](https://github.com/user-attachments/assets/d2bd9318-b39e-4543-97a6-2e102537a393)


2. test use 8B megatron trace full replay with storage recycle
slurm script:

```bash
#!/bin/bash
#SBATCH --job-name=full_replay_job
#SBATCH --nodes=2
#SBATCH --ntasks=16
#SBATCH --ntasks-per-node=8
#SBATCH --gpus-per-node=8
#SBATCH --time=01:00:00
#SBATCH --output=%x_%j.out
#SBATCH --error=%x_%j.err


srun -A general_cs_plutus\
     --container-image /lustre/fsw/portfolios/general/users/songyant/docker/songyant+docker-images+ai_develop.sqsh \
     --no-container-mount-home \
     --container-mounts=/lustre/fsw/portfolios/general/users/songyant/workspace_local:/workspace_local \
     zsh -c "
        if [ ! -d /run/sshd ]; then
            mkdir -p /run/sshd
            chmod 0755 /run/sshd
        fi

        source ~/.zshrc
        conda activate full_et_replay

        et_replay --trace_path /workspace_local/full_et_replay/traces_mega_8_new/execution_trace --recycle_storages
     "
```

result:
![image](https://github.com/user-attachments/assets/3f07d6d6-4a7e-45c0-883d-d848eff6571f)


3. test use hf_GPT2_et.json compute only replay with storage recycle

command:

```bash
et_replay --input /workspace_local/full_et_replay/traces/hf_GPT2_et.json --compute --recycle_storages
```

result:
![image](https://github.com/user-attachments/assets/75777ce2-5ee3-43e8-82e1-14ea8a6478e6)
