### PR TITLE
fix found issues of comm replay

### DIFF
--- a/et_replay/comm/backend/base_backend.py
+++ b/et_replay/comm/backend/base_backend.py
@@ -59,7 +59,7 @@ class collectiveArgsHolder:
         self.global_rank = -1
         self.backendFuncs = {}
         self.collective = ""
-        self.collectiveId = 0
+        self.wait_obj_key = (0, 0, False) # (pg_id, req_id, is_p2p)
         self.pt2pt = ""
         self.src_rank = -1
         self.dst_rank = -1
@@ -100,7 +100,7 @@ class collectiveArgsHolder:
         self.dataSize = 0
         self.numElements = 0
         self.waitObj = []
-        self.waitObjIds = {}  # mapping of reqID to future of async collectives
+        self.waitObjIds = {}  # mapping of (pg_id, req_id, is_p2p) to future of async collectives
 
         self.ipTensor_split_pair = []
         self.opTensor_split_pair = []

--- a/et_replay/comm/backend/base_backend.py
+++ b/et_replay/comm/backend/base_backend.py
@@ -28,8 +28,6 @@ supportedCollectives = [
     "reduce_scatter_v",
     "reduce_scatter_base",
     "all_gather_base",
-    "incast",
-    "multicast",
     "gather",
     "scatter",
 ]
@@ -144,8 +142,6 @@ class BaseBackend(ABC):
             "reduce_scatter_base": self.reduce_scatter_base,  # pyre-ignore[16]:
             "scatter": self.scatter,  # pyre-ignore[16]:
             "barrier": self.barrier,
-            "incast": self.incast,  # pyre-ignore[16]:
-            "multicast": self.multicast,  # pyre-ignore[16]:
             "noop": self.noop,
         }
 

--- a/et_replay/comm/commsTraceParser.py
+++ b/et_replay/comm/commsTraceParser.py
@@ -122,10 +122,12 @@ def _parse_comms_op_node(  # noqa: C901
     comm_nodes = (
         node for node in in_trace.nodes.values() if node.name == "record_param_comms"
     )
+    is_seq_id = lambda x: isinstance(x, list) and len(x) == 2 and isinstance(x[0], int) and isinstance(x[1], bool)
     for node in comm_nodes:
         # according to macro RECORD_PARAM_COMMS and RECORD_PARAM_COMMS_DATA in torch/csrc/distributed/c10d/ParamCommsUtils.hpp
-        # ["wait", "barrier", "init"] record 1st element as seq, others record starting from input tensor
-        index_base = 0 if isinstance(node.inputs[0], int) else 1
+        # ["wait", "barrier", "init"] record 1st element as seq_id, whose 1st element is an integer for sequence number, 2nd element is a bool for isP2P
+        # others record starting from input tensor
+        index_base = 0 if is_seq_id(node.inputs[0]) else 1
         req_id = node.inputs[index_base]
         recorded_rank = node.inputs[index_base + 2]
 

--- a/et_replay/comm/comms_utils.py
+++ b/et_replay/comm/comms_utils.py
@@ -313,7 +313,7 @@ def checkQuantArgs(
             logger.warning(
                 f"begin size {beginSize} must be a multiple of --quant-a2a-embedding-dim {quant_a2a_embedding_dim} for all_to_all operation"
             )
-        if blockingFlag != 1:
+        if not blockingFlag:
             raise NotImplementedError("quantized All_to_all must be synchronous.")
     if dtype != torch.float32:
         raise NotImplementedError(
@@ -690,7 +690,7 @@ class commsParamsHolderBase:
         self.dtype = args.dtype
         self.backend = args.backend
         self.device = args.device
-        self.blockingFlag = args.z
+        self.blockingFlag = args.blocking
         # quantization
         self.bitwidth = args.bitwidth
         self.quant_a2a_embedding_dim = args.quant_a2a_embedding_dim
@@ -1435,12 +1435,10 @@ class paramCommsBench(ABC):
             help="The backend to be used in PyTorch distributed process group",
         )  #  backend used for the network stack
         parser.add_argument(
-            "--z",
+            "-b",
             "--blocking",
-            type=int,
-            default=0,
-            help="use blocking/non-blocking mode for collectives",
-            choices=[0, 1],
+            action="store_true",
+            help="use blocking/non-blocking mode for collectives"
         )  # 'sync/blocking' : 1 , 'async/non-blocking' : 0
         parser.add_argument(
             "--bitwidth",

--- a/et_replay/comm/comms_utils.py
+++ b/et_replay/comm/comms_utils.py
@@ -839,18 +839,16 @@ class paramCommsBench(ABC):
             )
 
         if (
-            # Check results for incast only on root
-            commsParams.collective in ("incast", "reduce", "gather")
+            commsParams.collective in ("reduce", "gather")
             and self.backendFuncs.get_global_rank() != commsParams.srcOrDst
         ) or (
-            # Check results of multicast only for dst_ranks
-            commsParams.collective in ("multicast", "pt2pt")
+            commsParams.collective in ("pt2pt", )
             and self.backendFuncs.get_global_rank() not in commsParams.dst_ranks
         ):
             return
 
         if isinstance(tensor, list):
-            # for allgather and incast, it's a list of tensors:
+            # for allgather, it's a list of tensors:
             for rank, t in enumerate(tensor):
                 if not torch.all(torch.eq(t, expRes)):
                     for index, val in enumerate(t):
@@ -884,7 +882,7 @@ class paramCommsBench(ABC):
         if self.collectiveArgs.collective in ("all_reduce", "reduce"):
             # all processes use initVal to have predictable results
             newVal = self.initVal
-        elif self.collectiveArgs.collective in ("broadcast", "multicast"):
+        elif self.collectiveArgs.collective in ("broadcast", ):
             # root process uses initVal and others use random values
             newVal = (
                 self.initVal
@@ -1092,31 +1090,6 @@ class paramCommsBench(ABC):
                 dtype,
                 scaleFactor,
             )
-        return (ipTensor, opTensor)
-
-    def _prep_incast(
-        self,
-        ipTensor: torch.Tensor,
-        curComm: commsArgs,
-        commsParams: commsParamsHolderBase,
-        numElementsIn: int,
-        numElementsOut: int,
-        world_size: int,
-        curDevice: str,
-        dtype: torch.dtype,
-        scaleFactor: float,
-        allocate: bool = True,
-    ) -> Tuple[torch.Tensor, List[torch.Tensor]]:
-        # incast requires a tensor list with length of src_ranks, e.g., List[torch.Tensor]
-        opTensor = []
-
-        if allocate:
-            for _ in self.collectiveArgs.src_ranks:
-                opTensor.append(
-                    self.backendFuncs.alloc_random(
-                        [numElementsOut], curDevice, dtype, scaleFactor
-                    )
-                )
         return (ipTensor, opTensor)
 
     def _prep_reduce_scatter(
@@ -1332,7 +1305,6 @@ class paramCommsBench(ABC):
             "all_gather": self._prep_all_gather,
             "gather": self._prep_all_gather,
             "all_gather_base": self._prep_all_gather_base,
-            "incast": self._prep_incast,
             "reduce_scatter": self._prep_reduce_scatter,
             "reduce_scatter_base": self._prep_reduce_scatter_base,
             "scatter": self._prep_reduce_scatter,

--- a/et_replay/tools/comm_replay.py
+++ b/et_replay/tools/comm_replay.py
@@ -18,6 +18,7 @@ import numpy as np
 import torch
 
 from et_replay.comm import comms_utils
+from et_replay.comm import commsTraceParser
 from et_replay.comm.backend.base_backend import supportedP2pOps
 from et_replay.comm.comms_utils import (
     bootstrap_info_holder,
@@ -1548,69 +1549,17 @@ class commsTraceReplayBench(paramCommsBench):
             self.readRawTrace(remotePath=remotePath, rank=rank)
 
         # Convert trace to comms trace.
-        try:
-            from et_replay.comm import commsTraceParser
-        except ImportError:
-            logger.info("FB internals not present, using base parser.")
-            self.comms_trace = extractCommsInfo(self.comms_trace)
-        else:
-            self.comms_trace = commsTraceParser.parseTrace(
-                self.comms_trace,
-                self.trace_type,
-                (
-                    self.trace_file
-                    if not os.path.isdir(self.trace_file)
-                    else f"{self.trace_file}/rank-{rank}.json"
-                ),
-                rank,
-                self.backendFuncs.get_world_size(),
-            )
-
-
-def extractCommsInfo(in_trace: List[Dict]) -> List[commsArgs]:
-    """
-    Convert Basic Trace to comms trace format.
-    """
-    # print("in extract comms info")
-    # exit(1)
-    newCommsTrace = []
-    for cnt, curComm in enumerate(in_trace):
-        newComm = commsArgs()
-        newComm.comms = paramToCommName(curComm["comms"].lower())
-        logger.info(f"in extract comms info of {newComm.comms}: {curComm}")
-        newComm.id = cnt
-        if "req" in curComm:
-            newComm.req = curComm["req"]
-        if "startTime_ns" in curComm:
-            newComm.startTimeNs = curComm["startTime_ns"]
-        if "markers" in curComm:
-            newComm.markerStack = curComm["markers"]
-        if "world_size" in curComm:
-            newComm.worldSize = curComm["world_size"]
-        if "root" in curComm:
-            newComm.root = curComm["root"]
-        if "pg_id" in curComm:
-            newComm.pgId = curComm["pg_id"]
-        if "global_ranks" in curComm:
-            newComm.groupRanks = curComm["global_ranks"]
-
-        if newComm.comms not in ("wait", "barrier", "init"):
-            newComm.inMsgSize = curComm["in_msg_size"]
-            newComm.outMsgSize = curComm["out_msg_size"]
-            newComm.dtype = curComm["dtype"]
-
-        if newComm.comms in ("all_to_allv"):
-            newComm.inSplit = curComm["in_split"]
-            newComm.outSplit = curComm["out_split"]
-
-        if newComm.comms in supportedP2pOps:
-            newComm.src_rank = curComm["src_rank"]
-            newComm.dst_rank = curComm["dst_rank"]
-            newComm.batch_p2p = curComm["use_batch"]
-
-        newCommsTrace.append(newComm)
-
-    return newCommsTrace
+        self.comms_trace = commsTraceParser.parseTrace(
+            self.comms_trace,
+            self.trace_type,
+            (
+                self.trace_file
+                if not os.path.isdir(self.trace_file)
+                else f"{self.trace_file}/rank-{rank}.json"
+            ),
+            rank,
+            self.backendFuncs.get_world_size(),
+        )
 
 
 def main() -> None:

--- a/et_replay/tools/comm_replay.py
+++ b/et_replay/tools/comm_replay.py
@@ -1438,7 +1438,7 @@ class commsTraceReplayBench(paramCommsBench):
         self.is_dry_run = args.dry_run
         self.shrink = args.auto_shrink
         self.max_msg_cnt = args.max_msg_cnt
-        self.is_blocking = args.z
+        self.is_blocking = args.blocking
         self.do_warm_up = args.do_warm_up
         self.reuse_tensors = args.reuse_tensors
         self.allowList = args.allow_ops


### PR DESCRIPTION
# Depend On
1. [[c10d] fix sequence numbers for coalesced operations #135132](https://github.com/pytorch/pytorch/pull/135132)
2. [fix sequence number for group #134578](https://github.com/pytorch/pytorch/pull/134578)

# Summary
1. fix replay to send/recv
2. fix blocking option
3. fix process group update of barrier
4. Comment out unused function incast and multicast
5. remove function extractCommsInfo() for deprecatd basic trace
6. fix wait comm op for both collective and p2p

# TestPlan
comm_replay --trace-type et --trace-path /home/sanshang/lustre_storage/000_code/chakra/comm_replay_eval_06/training/et_iter_50_51 --num-replays 10
![image](https://github.com/user-attachments/assets/a6d70cac-3c57-4cb8-9b36-cb5ba2fdd639)
