### PR TITLE
et_replay refactoring: removed hack code for FBGEMM, introduced skip-node option, MAST launcher update

### DIFF
--- a/et_replay/tests/test_execution_trace.py
+++ b/et_replay/tests/test_execution_trace.py
@@ -30,7 +30,7 @@ class TestTraceLoadAndValidate(unittest.TestCase):
         )
         t, et = self._test_and_validate_trace(et_file)
         self.assertGreater(t.num_ops(), 1000)
-        self.assertEqual(t.num_comm_ops(), 12)
+        self.assertEqual(t.num_comm_ops(), 27)
         self.assertEqual(t.num_triton_ops(), 0)
 
     def test_trace_load_resnet_2gpu_ptorch_1_1_0(self):
@@ -39,7 +39,7 @@ class TestTraceLoadAndValidate(unittest.TestCase):
         )
         t, et = self._test_and_validate_trace(et_file)
         self.assertGreater(t.num_ops(), 1000)
-        self.assertEqual(t.num_comm_ops(), 12)
+        self.assertEqual(t.num_comm_ops(), 27)
         self.assertEqual(t.num_triton_ops(), 0)
 
 

--- a/et_replay/tools/comm_replay.py
+++ b/et_replay/tools/comm_replay.py
@@ -36,6 +36,7 @@ except ImportError:
     pass
 
 logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
 
 # sleep for 20ms to wait for next collective
 LOOP_TIMER_S = 0.02
@@ -640,7 +641,7 @@ class commsTraceReplayBench(paramCommsBench):
         curComm: commsArgs,
         commsParams: commsParamsHolderBase,
         regenerateTensors: bool = True,
-    ) -> Tuple[torch.Tensor, torch.Tensor]:
+    ) -> Tuple[torch.Tensor, Union[List[torch.Tensor], torch.Tensor]]:
         """
         Prepares the appropriate tensors for the current collective communication.
 


### PR DESCRIPTION
Summary:
This DIFF include the following et_replay refactoring:

1. Cleaned up the hack code for FBGEMM
    The current implementation for FBGEMM related ops relied on guessing the parameters of the original FBGEMM module based on its forward and backward function calls. Since FBGEMM keeps involving, most of the code are outdated. It is not a sustainable way to support it.
    The most important reason that these ops can not be replayed is it usually has index input tensors. If random data is used for these integer tensors, it usually runs into illegal memory issue.
    To fix this issue, another DIFF (https://www.internalfb.com/diff/D62889784) is going to capture index tensor based on user's selection. Then in replay, the index tensor is loaded for FBGEMM ops. It has been proved in ICVR model, with the index tensor data, we can replay all of FBGEMM ops.

2. Introduced new options --skip-node-file and --update-skip-node-file:
    If --skip-node-file is available, the json file that defines the nodes to skip will be loaded to skip the ops, --update-skip-node-file is a special run mode, it will go through all compute ops, if an op fails to run, the skip-node-file will be updated to include the failed op.

3. MAST launcher has been updated to create a new FBPKG for et_replay

4. The DFS traverser to collect the ops has been simplified. If a node is an operator, the children of that node will be ignored. The only exception is c10:: related ops since record_param_comms is a child of c10:: op, and comm_replay only uses record_param_comms

5. generate_io_tensor for CommsReplayManager in et_replay.py has been removed temporarily, it does not handle all collectives correctly for creating input/output tensors. The current version uses comms_replay to allocate the tensors. We can put it back when that function is ready.

6. Some other minor fixes, for example, use logger instead of print

Differential Revision: D61055957
