### PR TITLE
fix found issues of comm replay

### DIFF
--- a/et_replay/comm/backend/base_backend.py
+++ b/et_replay/comm/backend/base_backend.py
@@ -28,8 +28,6 @@ supportedCollectives = [
     "reduce_scatter_v",
     "reduce_scatter_base",
     "all_gather_base",
-    "incast",
-    "multicast",
     "gather",
     "scatter",
 ]
@@ -61,7 +59,7 @@ class collectiveArgsHolder:
         self.global_rank = -1
         self.backendFuncs = {}
         self.collective = ""
-        self.collectiveId = 0
+        self.wait_obj_key = (0, 0, False)  # (pg_id, req_id, is_p2p)
         self.pt2pt = ""
         self.src_rank = -1
         self.dst_rank = -1
@@ -102,7 +100,9 @@ class collectiveArgsHolder:
         self.dataSize = 0
         self.numElements = 0
         self.waitObj = []
-        self.waitObjIds = {}  # mapping of reqID to future of async collectives
+        self.waitObjIds = (
+            {}
+        )  # mapping of (pg_id, req_id, is_p2p) to future of async collectives
 
         self.ipTensor_split_pair = []
         self.opTensor_split_pair = []
@@ -144,8 +144,6 @@ class BaseBackend(ABC):
             "reduce_scatter_base": self.reduce_scatter_base,  # pyre-ignore[16]:
             "scatter": self.scatter,  # pyre-ignore[16]:
             "barrier": self.barrier,
-            "incast": self.incast,  # pyre-ignore[16]:
-            "multicast": self.multicast,  # pyre-ignore[16]:
             "noop": self.noop,
         }
 

--- a/et_replay/comm/commsTraceParser.py
+++ b/et_replay/comm/commsTraceParser.py
@@ -122,10 +122,17 @@ def _parse_comms_op_node(  # noqa: C901
     comm_nodes = (
         node for node in in_trace.nodes.values() if node.name == "record_param_comms"
     )
+    is_seq_id = (
+        lambda x: isinstance(x, list)
+        and len(x) == 2
+        and isinstance(x[0], int)
+        and isinstance(x[1], bool)
+    )
     for node in comm_nodes:
         # according to macro RECORD_PARAM_COMMS and RECORD_PARAM_COMMS_DATA in torch/csrc/distributed/c10d/ParamCommsUtils.hpp
-        # ["wait", "barrier", "init"] record 1st element as seq, others record starting from input tensor
-        index_base = 0 if isinstance(node.inputs[0], int) else 1
+        # ["wait", "barrier", "init"] record 1st element as seq_id, whose 1st element is an integer for sequence number, 2nd element is a bool for isP2P
+        # others record starting from input tensor
+        index_base = 0 if is_seq_id(node.inputs[0]) else 1
         req_id = node.inputs[index_base]
         recorded_rank = node.inputs[index_base + 2]
 


### PR DESCRIPTION
## Summary
fix replay to send/recv
fix blocking option
fix process group update of barrier
Comment out unused function incast and multicast
remove function extractCommsInfo() for deprecatd basic trace
fix wait comm op for both collective and p2p

## Test Plan
comm_replay --trace-type et --trace-path /home/sanshang/lustre_storage/000_code/chakra/comm_replay_eval_06/training/et_iter_50_51 --num-replays 10

## additional notes
This is copied from https://github.com/facebookresearch/param/pull/180. 
