### PR TITLE
replace triton.ops dependencies

### DIFF
--- a/train/comms/pt/pytorch_dist_backend.py
+++ b/train/comms/pt/pytorch_dist_backend.py
@@ -20,7 +20,7 @@ from param_bench.train.comms.pt.pytorch_backend_utils import (
 )
 
 try:
-    from triton.ops.matmul import matmul as triton_matmul
+    from triton_kernels.matmul import matmul as triton_matmul
 
     has_triton = True
 except ImportError:


### PR DESCRIPTION
Summary: `triton.ops` is moved to kernels directory with the 3.2 update. This change updates imports to be through explicit `matmul` and `matmul_perf_model` helper files copied to individual repos.

Differential Revision: D65614265
