### PR TITLE
fix process group init logic and add pg_desc parsing (#186)

### DIFF
--- a/et_replay/comm/backend/base_backend.py
+++ b/et_replay/comm/backend/base_backend.py
@@ -48,7 +48,6 @@ class collectiveArgsHolder:
     def __init__(self) -> None:
         self.group = None
         self.groups = {}  # {pg_id, pg}
-        self.num_pgs = 0
         self.device = {}
         self.world_size = 0
         self.data_type = ""
@@ -289,10 +288,6 @@ class BaseBackend(ABC):
 
     @abstractmethod
     def get_groups(self) -> list[ProcessGroup]:
-        pass
-
-    @abstractmethod
-    def get_num_pgs(self) -> int:
         pass
 
     # Init functions

--- a/et_replay/comm/backend/pytorch_tpu_backend.py
+++ b/et_replay/comm/backend/pytorch_tpu_backend.py
@@ -160,9 +160,6 @@ class PyTorchTPUBackend(BaseBackend):
     def get_groups(self):
         pass
 
-    def get_num_pgs(self):
-        pass
-
     def tensor_list_to_numpy(self, tensorList):
         tensorList = torch.transpose(tensorList.view(-1, 1), 0, 1)[0]
         return tensorList.cpu().detach().numpy()

--- a/et_replay/comm/comms_utils.py
+++ b/et_replay/comm/comms_utils.py
@@ -486,6 +486,7 @@ class commsArgs:
         self.outSplit = kwargs["outSplit"] if "outSplit" in kwargs else None
         self.startTimeNs = kwargs["startTimeNs"] if "startTimeNs" in kwargs else None
         self.pgId = kwargs["pgId"] if "pgId" in kwargs else None
+        self.pgDesc = kwargs["pgDesc"] if "pgDesc" in kwargs else None
         self.groupRanks = kwargs["groupRanks"] if "groupRanks" in kwargs else None
         self.worldSize = kwargs["worldSize"] if "worldSize" in kwargs else None
         self.markerStack = kwargs["markerStack"] if "markerStack" in kwargs else None
@@ -692,6 +693,7 @@ class commsParamsHolderBase:
         self.quant_threshold = args.quant_threshold
         self.dcheck = args.c
         self.groupRanks = {}  # record what ranks each process group will work on {pg_id, ranks}
+        self.pgsDesc = {}  # {pg_id: pg_desc}
         self.use_ext_dist = args.use_ext_dist
         self.size_from_trace = False
         self.init_method = args.init_method

--- a/et_replay/tools/comm_replay.py
+++ b/et_replay/tools/comm_replay.py
@@ -1403,6 +1403,7 @@ class commsTraceReplayBench(paramCommsBench):
             # record process group info
             if curComm.comms == "init":
                 commsParams.groupRanks[curComm.pgId] = curComm.groupRanks
+                commsParams.pgsDesc[curComm.pgId] = curComm.pgDesc
         self.backendFuncs.initialize_groups(commsParams.backend)
 
         # set basic collective info
@@ -1419,7 +1420,6 @@ class commsTraceReplayBench(paramCommsBench):
 
         self.collectiveArgs.group = group  # default group
         self.collectiveArgs.groups = self.backendFuncs.get_groups()
-        self.collectiveArgs.num_pgs = self.backendFuncs.get_num_pgs()
         self.collectiveArgs.device = curDevice
         self.collectiveArgs.world_size = world_size
         self.collectiveArgs.global_rank = global_rank


### PR DESCRIPTION
Summary:
This DIFF include the following changes:
    parse pg description.
    fix pg creation logic.


Test Plan: buck2 run  -c fbcode.nvcc_arch='h100a' mode/opt -c hpc_comms.use_ncclx=2.21.5 param_bench/train/comms/pt:launcher -- --launcher mast --dp networkai_mast_job_identity --cluster MastProdCluster --hw grandteton --nnode 8 --ppn 8 --module commsTraceReplay_v2 --trace-path manifold://pytorch_execution_trace/tree/traces/shengfu/nv/pattern2-64gpu --trace-type et --json_mast_flex_pool_id_override_map ~/flex_pool_long_cable.json --reuse-tensors --warmup-iter 5 --num-replays 10

Differential Revision: D67071961

Pulled By: shengfukevin
