### PR TITLE
Share tensors between comp replay and comms replay

### DIFF
--- a/et_replay/tools/comm_replay.py
+++ b/et_replay/tools/comm_replay.py
@@ -1095,7 +1095,7 @@ class commsTraceReplayBench(paramCommsBench):
                     )
 
                 logger.info(
-                    f"{logLable}[Rank {self.collectiveArgs.global_rank:3}] [{cnt+1} / {self.max_msg_cnt}] Replaying {commDesc} with {groupDesc}"
+                    f"{logLable}[Rank {self.collectiveArgs.global_rank:3}] [{cnt+1} / {self.max_msg_cnt}] Replaying {commDesc} with {groupDesc} id = {curComm.id}"
                 )
 
             # read fields and prepare the tensors


### PR DESCRIPTION
Summary:
Share tensors between comp replay and comms replay

When run full replay in et_replay, compute replay and comms replay manage the tensor allocation separately. So some tensors are double allocated, this leads to the full replay of Llama4 70B out of memory.

This DIFF is to fix it by allocating tensors in comp replay and passes them to comms replay.

Reviewed By: sanrise

Differential Revision: D67353163


