### PR TITLE
add support to metrics calculation

### DIFF
--- a/et_replay/comm/comms_utils.py
+++ b/et_replay/comm/comms_utils.py
@@ -21,9 +21,6 @@ from typing import Any
 
 try:
     from param_bench.train.comms.pt.fb.internals import (
-        fbInitProfiler,
-        fbSampleProfiler,
-        fbStartProfiler,
         initialize_collectiveArgs_internal,
         remove_quantization_handlers,
     )
@@ -388,48 +385,6 @@ def ensureTensorFlush(tensors: list[torch.Tensor] | torch.Tensor) -> Any:
         x = tensors[-1].item()  # to ensure collective won't be optimized away.
 
     return x
-
-
-def startProfiler(rank: int, device: str, numWarmupIters: int, numIters: int) -> bool:
-    """
-    Starts internal profiler with given parameters.
-
-    Args:
-        rank: Global rank.
-        device: Type of device "cuda", "cpu", etc.
-        numWarmupIters: Number of warmup iterations.
-        numIters: Number of real iterations.
-    Returns:
-        bool: Returns if internal profile was able to start or not.
-    """
-    if has_internal_libs:
-        fbInitProfiler(
-            rank=rank,
-            device=device,
-            warmup=numWarmupIters,
-            iters=numIters,
-        )
-        fbStartProfiler()
-        return True
-    else:
-        logger.debug("Internal profiler is not available, skip...")
-        return False
-
-
-def sampleProfiler(stop: bool = False) -> None:
-    """
-    Starts internal sample profiler.
-
-    Args:
-        stop: Bool to be passed into sample profiler.
-    Returns:
-        None
-    """
-    if has_internal_libs:
-        fbSampleProfiler(stop)
-    else:
-        logger.debug("Internal profiler is not available, skip...")
-
 
 class commsArgs:
     """

--- a/et_replay/comm/profiler_trace_analysis.py
+++ b/et_replay/comm/profiler_trace_analysis.py
@@ -1,0 +1,252 @@
+import logging
+import os
+import json
+import pathlib
+from typing import Dict, Any, Optional, Callable
+from collections import defaultdict
+import ast
+import numpy as np
+from intervaltree import Interval, IntervalTree
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+
+# refer to:
+# https://github.com/pytorch/pytorch/blob/2cc01cc6d3ad2aff47e8460667ba654b2e4c9f21/c10/core/ScalarType.h#L61
+_dtype_size_map: Dict[str, int] = {
+    'Byte'            : 1,
+    'Char'            : 1,
+    'Short'           : 2,
+    'Int'             : 4,
+    'Long'            : 8,
+    'Half'            : 2,
+    'Float'           : 4,
+    'Double'          : 8,
+    'ComplexHalf'     : 4,
+    'ComplexFloat'    : 8,
+    'ComplexDouble'   : 16,
+    'Bool'            : 1,
+    'QInt8'           : 1,
+    'QUInt8'          : 1,
+    'QInt32'          : 4,
+    'BFloat16'        : 2,
+    'QUInt4x2'        : 1,
+    'QUInt2x4'        : 1,
+    'Bits1x8'         : 1,
+    'Bits2x4'         : 1,
+    'Bits4x2'         : 1,
+    'Bits8'           : 1,
+    'Bits16'          : 2,
+    'Float8_e5m2'     : 1,
+    'Float8_e4m3fn'   : 1,
+    'Float8_e5m2fnuz' : 1,
+    'Float8_e4m3fnuz' : 1,
+    'UInt16'          : 2,
+    'UInt32'          : 4,
+    'UInt64'          : 8,
+}
+
+# refer to: https://github.com/NVIDIA/nccl-tests/blob/master/doc/PERFORMANCE.md
+_busbw_correction_factors_tbl: Dict[str, Callable[[int], float]] = {
+    'all_reduce'        : (lambda n: 2 * (n - 1) / n),
+    'all_gather'        : (lambda n: (n - 1) / n),
+    'all_to_all'        : (lambda n: (n - 1) / n),
+    'reduce_scatter'    : (lambda n: (n - 1) / n),
+    'reduce'            : (lambda n: 1),
+    'scatter'           : (lambda n: (n - 1)/n),
+    'gather'            : (lambda n: (n - 1)/n),
+    'broadcast'         : (lambda n: 1),
+    'send'              : (lambda n: 1),
+    'recv'              : (lambda n: 1),
+}
+
+# map collective name of event to key string for bw calculation
+_collname_to_busbw_corr_factor_func: Dict[str, Callable[[int], float]] = {
+    'allreduce'             : _busbw_correction_factors_tbl['all_reduce'],
+    'all_gather'            : _busbw_correction_factors_tbl['all_gather'],
+    '_allgather_base'       : _busbw_correction_factors_tbl['all_gather'],
+    'reduce_scatter'        : _busbw_correction_factors_tbl['reduce_scatter'],
+    '_reduce_scatter_base'  : _busbw_correction_factors_tbl['reduce_scatter'],
+    'all_to_all'            : _busbw_correction_factors_tbl['all_to_all'],
+    'all_to_allv'           : _busbw_correction_factors_tbl['all_to_all'],
+    'broadcast'             : _busbw_correction_factors_tbl['broadcast'],
+    'reduce'                : _busbw_correction_factors_tbl['reduce'],
+    'gather'                : _busbw_correction_factors_tbl['gather'],
+    'scatter'               : _busbw_correction_factors_tbl['scatter'],
+    'send'                  : _busbw_correction_factors_tbl['send'],
+    'recv'                  : _busbw_correction_factors_tbl['recv'],
+}
+
+def _get_dict_value(d, k, err_msg):
+    if k not in d:
+        raise ValueError(err_msg)
+    return d.get(k)
+
+def _calculate_event_data_size(evt):
+    return max(evt['args']['In msg nelems'], evt['args']['Out msg nelems']) * _dtype_size_map[evt['args']['dtype']]
+
+def _calculate_algbw(evt: Dict[str, Any]) -> float:
+    duration_us = _get_dict_value(evt, 'dur', f'Missing "dur" in event: {evt}')
+    total_bytes = _calculate_event_data_size(evt)
+
+    # NCCL tests use 1024^3 to convert B to GB (but not 1e9)
+    # https://github.com/NVIDIA/nccl-tests/blob/8dfeab9eb9bdfdf13503e71e1f33e7f8a208b540/src/common.cu#L102
+    # but it uses 1e9 to convert bw from B/s to GB/s
+    # https://github.com/NVIDIA/nccl-tests/blob/8dfeab9eb9bdfdf13503e71e1f33e7f8a208b540/src/all_gather.cu#L41
+    return round((total_bytes / duration_us) / 1e3, 2)
+
+def _get_event_busbw_factor(evt):
+    coll_name = _get_dict_value(evt['args'], 'Collective name', f'Missing "Collective name" in event: {evt}')
+    
+    # barrier is implemented using AllReduce            
+    if coll_name in ['barrier', ]:
+        return 0
+    
+    group_size = _get_dict_value(evt['args'], 'Group size', f'Missing "Group size" in event: {evt}')
+    correction_factor_func = _get_dict_value(_collname_to_busbw_corr_factor_func,
+                                             coll_name, 
+                                             f'Unsupported collective op for busbw calculation: {coll_name}')
+    
+    return correction_factor_func(group_size)
+
+def calculate_bw_(trace_data):
+    nccl_events = [i for i in trace_data['traceEvents'] if i.get('cat', '') == 'kernel' and i['name'].startswith('ncclDevKernel_')]
+    for evt in nccl_events:
+        try:
+            coll_name = _get_dict_value(evt['args'], 'Collective name', f'Missing "Collective name" in event: {evt}')
+
+            # barrier is implemented using AllReduce            
+            if coll_name in ['barrier', ]:
+                continue
+            
+            algbw = _calculate_algbw(evt)
+            busbw_factor = _get_event_busbw_factor(evt)
+            busbw = round(algbw * busbw_factor, 2)
+
+            evt['args']['algbw (GB/sec)'] = algbw
+            evt['args']['busbw (GB/sec)'] = busbw
+            evt['args']['busbw_factor'] = busbw_factor
+        except ValueError as e:
+            logger.error('Error processing event: %s', e)
+
+def calculate_sbw(trace_data):
+    # calculate shared bw per rank
+    nccl_events = [i for i in trace_data['traceEvents'] if i.get('cat', '') == 'kernel' \
+                   and i['name'].startswith('ncclDevKernel_') \
+                   and 'busbw_factor' in i['args']]
+    
+    if not len(nccl_events):
+        return 0
+    
+    total_data_size = sum([_calculate_event_data_size(evt) * _get_event_busbw_factor(evt) for evt in nccl_events])
+
+    time_range_tree = IntervalTree([Interval(evt['ts'], evt['ts'] + evt['dur']) for evt in nccl_events])
+    time_range_tree.merge_overlaps()
+
+    begin_time_point = min([i.begin for i in time_range_tree])
+    end_time_point = max([i.end for i in time_range_tree])
+
+    sorted_tr = sorted(time_range_tree)
+    total_idle_time = \
+        sum([sorted_tr[i + 1].begin - sorted_tr[i].end for i in range(len(sorted_tr) - 1)]) \
+        if len(sorted_tr) > 1 else 0
+
+    return total_data_size / (end_time_point - begin_time_point - total_idle_time) / 1e3
+
+def pick_iter_e2e_time_(trace_data, tl):
+    tl.extend([evt['dur'] for evt in trace_data['traceEvents'] if evt.get('cat', '') == 'user_annotation' and evt['name'].startswith('ProfilerStep#')])
+    
+def pick_comm_bw_(trace_data, comm_bw_data):
+    rank = trace_data['distributedInfo']['rank']
+    nccl_events = [i for i in trace_data['traceEvents'] if i.get('cat', '') == 'kernel' \
+                   and i['name'].startswith('ncclDevKernel_') \
+                   and 'algbw (GB/sec)' in i['args']]
+    for evt in nccl_events:
+        knl_name = evt['name'][:evt['name'].index('(')]
+        data_size = _calculate_event_data_size(evt)
+        ranks_count = evt['args']['Group size']
+
+        ranks = ast.literal_eval(evt['args']['Process Group Ranks'])
+        pg_id = int(evt['args']['Process Group Name'])
+        pg = tuple([*ranks, pg_id]) if rank == min(ranks) else None
+
+        comm_bw_data[(knl_name, data_size, ranks_count)].append(
+            [evt['dur'], evt['args']['algbw (GB/sec)'], evt['args']['busbw (GB/sec)'], pg]
+        )
+
+def analyze_profiler_trace(trace_dir: str, report_dir: str):
+    '''
+    Analyse input PyTorch profiler trace (i.e. Kineto trace) and generate report.
+
+    Args:
+        trace_dir (str): dir path of input traces, where trace name should be in "rank-n.json" format.
+        report_dir (str): dir path for generated reports 
+    '''
+    logger.info(f'Parse profiler trace from "{trace_dir}" and generate reports to "{report_dir}"')
+
+    processed_trace_dir = os.path.join(report_dir, 'profiler_trace_processed')
+    pathlib.Path(processed_trace_dir).mkdir(parents=True, exist_ok=True)
+
+    # list of iteration time in all ranks
+    iter_e2e_time = []
+
+    # list of shared bw
+    sbw_lst = []
+
+    # key is (kernel_name, data size, ranks number)
+    # value is list of [dur, algbw, busbw, pg]
+    comm_bw_data = defaultdict(list)
+
+    for fpath in os.scandir(trace_dir):
+        if not fpath.is_file():
+            continue
+
+        with open(fpath.path, 'r', encoding='utf-8') as f:
+            trace = json.load(f)
+
+        calculate_bw_(trace)
+        with open(os.path.join(processed_trace_dir, fpath.name), 'w', encoding='utf-8') as f:
+            json.dump(trace, f)
+        
+        sbw_lst.append(calculate_sbw(trace))
+
+        pick_iter_e2e_time_(trace, iter_e2e_time)
+        pick_comm_bw_(trace, comm_bw_data)
+    
+    comm_bw_summary = {}
+    for k,v in comm_bw_data.items():
+        t_lst     = [i[0] for i in v]
+        busbw_lst = [i[2] for i in v]
+        pg_set    = set([i[3] for i in v if i[3]])
+        comm_bw_summary[k] = [len(pg_set),
+                              np.average(t_lst), 
+                              np.average(busbw_lst),
+                              np.percentile(busbw_lst,  1),
+                              np.percentile(busbw_lst, 50),
+                              np.percentile(busbw_lst, 90),
+                              np.percentile(busbw_lst, 99)]
+    comm_bw_summary = dict(sorted(comm_bw_summary.items()))
+
+    # dump summary report
+    with open(os.path.join(report_dir, 'profiler_trace_summary_report.txt'), 'w', encoding='utf-8') as f:
+        f.write(f'avg. E2ETime of iters among all ranks: {sum(iter_e2e_time) / len(iter_e2e_time) / 1e3 :.3f} ms\n')
+        f.write(f'avg. SharedBW (i.e. sum(data_size * busbw_factor) / GPU_comm_busy_time  per rank) among all ranks: {sum(sbw_lst) / len(sbw_lst) :.3f} GB/s\n')
+        
+        f.write(f'\n{" ":>70s}|{" ":>5s}|{"AVG.":^19s}|{"p01":^8s}|{"p50":^8s}|{"p90":^8s}|{"p99":^8s}|\n')
+
+        f.write(f'{"kernel":>50s} {"size":>12s} {"#rks":>6s}|{"#pgs":>5s}|{"  dur":>10s} ')
+        for i in range(5): # average, p01, p50, p90, p99
+            f.write(f'{" busbw":>8s}|')
+        f.write('\n')
+
+        f.write(f'{"      ":>50s} {" (B)":>12s} {"    ":>6s}|{"    ":>5s}|{" (ms)":>10s} ')
+        for i in range(5): # average, p50, p90, p99
+            f.write(f'{"(GB/s)":>8s}|')
+        f.write('\n')
+
+        for k,v in comm_bw_summary.items():
+            f.write(f'{k[0]:>50s} {k[1]:>12d} {k[2]:>6d}|{v[0]:>5d}|{v[1]/1e3:>10.3f} ')
+            for i in range(2, len(v)):
+                f.write(f'{v[i]:>8.2f}|')
+            f.write('\n')
+        

--- a/et_replay/pyproject.toml
+++ b/et_replay/pyproject.toml
@@ -5,6 +5,10 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "et_replay"
 version = "0.5.0"
+dependencies = [
+    "numpy",
+    "intervaltree",
+]
 
 [tool.setuptools.package-dir]
 "et_replay" = "."

--- a/et_replay/tools/comm_replay.py
+++ b/et_replay/tools/comm_replay.py
@@ -643,9 +643,8 @@ class commsTraceReplayBench(paramCommsBench):
             return super().prepComm(curComm, commsParams)
         else:
             commsOpHash = self.hashEtCommsOp(curComm)
+            # Allocate input/output tensors if first time replay, otherwise reuse the previous ones.
             if commsOpHash in self.et_to_tensors:
-                # Allocate input/output tensors if first time replay, otherwise the previous ones.
-                super().prepComm(curComm, commsParams, False)
                 (ipTensor, opTensor) = self.et_to_tensors[commsOpHash]
             else:
                 (ipTensor, opTensor) = super().prepComm(curComm, commsParams, True)

--- a/et_replay/tools/comm_replay.py
+++ b/et_replay/tools/comm_replay.py
@@ -29,12 +29,6 @@ from et_replay.comm.comms_utils import (
 from et_replay.comm.param_profile import paramProfile, paramTimer
 from et_replay.vendor_internal import fb_internal
 
-try:
-    # pyre-ignore[21]:
-    from trainer_iteration_wrapper import setTrainingIteration
-except ImportError:
-    pass
-
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
@@ -1282,12 +1276,6 @@ class commsTraceReplayBench(paramCommsBench):
 
                 if self.collectiveArgs.enable_profiler and fb_internal.has_fb_internal_libs:
                     fb_internal.fbSampleProfiler()
-
-                # set training iteration number in NCCL
-                try:
-                    setTrainingIteration(i + 1)
-                except NameError:
-                    pass
                 
                 # replay comms trace
                 self.replayIter = i

--- a/et_replay/tools/comm_replay.py
+++ b/et_replay/tools/comm_replay.py
@@ -407,9 +407,11 @@ class commsTraceReplayBench(paramCommsBench):
         if not self.is_dry_run:
             print("\n{} Performance of replayed comms {}".format("=" * 20, "=" * 20))
             print(
-                "{}\n Total latency (us) of comms in trace: {}. \n{}".format(
+                "{}\nE2E latency (us): {} for {} iters, {:10.2f} per iter in avg\n{}".format(
                     "-" * 50,
                     self.totalTraceLatency,
+                    self.num_replays,
+                    self.totalTraceLatency / self.num_replays,
                     "-" * 50,
                 )
             )

--- a/et_replay/vendor_internal/fb_internal.py
+++ b/et_replay/vendor_internal/fb_internal.py
@@ -12,42 +12,71 @@ except ImportError:
 import logging
 logger = logging.getLogger(__name__)
 
+class MetaProfiler():
+    def __init__(self, rank, device, profiler_num_replays_start, profiler_num_replays, num_replays):
+        self.rank = rank
+        self.device = device
+        # num of iterations to skip
+        self.num_warmup_iters = self.profiler_num_replays_start
+        # num of iterations to profile, at most num_replays iterations
+        self.num_profile_iters = (
+            profiler_num_replays
+            if profiler_num_replays_start + profiler_num_replays <= num_replays
+            else num_replays - profiler_num_replays_start
+        )
 
-def fbStartProfiler(rank: int, device: str, numWarmupIters: int, numIters: int) -> bool:
-    """
-    Starts internal profiler with given parameters.
+    def __enter__(self):
+        MetaProfiler.start_profiler(
+            rank=self.rank,
+            device=self.device,
+            numWarmupIters=self.num_warmup_iters,
+            numIters=self.num_profile_iters
+        )
 
-    Args:
-        rank: Global rank.
-        device: Type of device "cuda", "cpu", etc.
-        numWarmupIters: Number of warmup iterations.
-        numIters: Number of real iterations.
-    Returns:
-        bool: Returns if internal profile was able to start or not.
-    """
-    if not has_fb_internal_libs:
-        raise RuntimeError('FB internal libs are not supported')
+        return self
 
-    fbInitProfiler(
-        rank=rank,
-        device=device,
-        warmup=numWarmupIters,
-        iters=numIters,
-    )
-    fbStartProfiler()
-    return True
+    def __exit__(self, exc_type, exc_value, traceback):
+        MetaProfiler.sample_profiler(stop=True)
 
+    def step(self):
+        MetaProfiler.sample_profiler()
 
-def fbSampleProfiler(stop: bool = False) -> None:
-    """
-    Starts internal sample profiler.
+    @classmethod
+    def start_profiler(cls, rank: int, device: str, numWarmupIters: int, numIters: int) -> bool:
+        """
+        Starts internal profiler with given parameters.
 
-    Args:
-        stop: Bool to be passed into sample profiler.
-    Returns:
-        None
-    """
-    if not has_fb_internal_libs:
-        raise RuntimeError('FB internal libs are not supported')
+        Args:
+            rank: Global rank.
+            device: Type of device "cuda", "cpu", etc.
+            numWarmupIters: Number of warmup iterations.
+            numIters: Number of real iterations.
+        Returns:
+            bool: Returns if internal profile was able to start or not.
+        """
+        if not has_fb_internal_libs:
+            raise RuntimeError('FB internal libs are not supported')
 
-    fbSampleProfiler(stop)
+        fbInitProfiler(
+            rank=rank,
+            device=device,
+            warmup=numWarmupIters,
+            iters=numIters,
+        )
+        fbStartProfiler()
+        return True
+
+    @classmethod
+    def sample_profiler(cls, stop: bool = False) -> None:
+        """
+        Starts internal sample profiler.
+
+        Args:
+            stop: Bool to be passed into sample profiler.
+        Returns:
+            None
+        """
+        if not has_fb_internal_libs:
+            raise RuntimeError('FB internal libs are not supported')
+
+        fbSampleProfiler(stop)

--- a/et_replay/vendor_internal/fb_internal.py
+++ b/et_replay/vendor_internal/fb_internal.py
@@ -1,0 +1,53 @@
+try:
+    from param_bench.train.comms.pt.fb.internals import (
+        fbInitProfiler,
+        fbSampleProfiler,
+        fbStartProfiler,
+    )
+
+    has_fb_internal_libs = True
+except ImportError:
+    has_fb_internal_libs = False
+
+import logging
+logger = logging.getLogger(__name__)
+
+
+def fbStartProfiler(rank: int, device: str, numWarmupIters: int, numIters: int) -> bool:
+    """
+    Starts internal profiler with given parameters.
+
+    Args:
+        rank: Global rank.
+        device: Type of device "cuda", "cpu", etc.
+        numWarmupIters: Number of warmup iterations.
+        numIters: Number of real iterations.
+    Returns:
+        bool: Returns if internal profile was able to start or not.
+    """
+    if not has_fb_internal_libs:
+        raise RuntimeError('FB internal libs are not supported')
+
+    fbInitProfiler(
+        rank=rank,
+        device=device,
+        warmup=numWarmupIters,
+        iters=numIters,
+    )
+    fbStartProfiler()
+    return True
+
+
+def fbSampleProfiler(stop: bool = False) -> None:
+    """
+    Starts internal sample profiler.
+
+    Args:
+        stop: Bool to be passed into sample profiler.
+    Returns:
+        None
+    """
+    if not has_fb_internal_libs:
+        raise RuntimeError('FB internal libs are not supported')
+
+    fbSampleProfiler(stop)


### PR DESCRIPTION
# summary
Add support to metrics calculation.
1. Iteration E2E time;
2. bandwidth;

# test plan
```
srun -l -N 8 -n 64 --ntasks-per-node=8 --container-name=sanshang_test \
--container-mounts=/labhome/sanshang:/labhome/sanshang,/swgwork/sanshang:/labhome/sanshang/storage \
bash -c "comm_replay --trace-type et --trace-path ${ROOT_PATH}/et_trace_64gpus \
--output-path ${ROOT_PATH}/output \
--enable-profiler --profiler-num-replays-start 4 --profiler-num-replays 5 \
--do-warm-up --reuse-tensors --num-replays 10"
```
![image](https://github.com/user-attachments/assets/67b97f72-0225-4906-9bf8-f48d40051b24)
![image](https://github.com/user-attachments/assets/0739a372-432d-447d-b5fa-c47ee24d186c)
