### PR TITLE
Clean up grid in execution trace

### DIFF
--- a/et_replay/tools/et_replay.py
+++ b/et_replay/tools/et_replay.py
@@ -1459,9 +1459,7 @@ class ExgrReplayManager:
                 outputs = []
                 if output_count == 0:
                     if node.kernel_backend == "triton":
-                        exec(
-                            f"func.run(*inputs[:-2], grid={inputs[-2]}, stream={inputs[-1]})"
-                        )
+                        exec(f"func.run(*inputs[:-1], stream={inputs[-1]})")
                     else:
                         func(*inputs)
                 else:


### PR DESCRIPTION
Summary:
X-link: https://github.com/pytorch/pytorch/pull/149159

This DIFF https://www.internalfb.com/diff/D70471332 removed input "grid" when calling triton kernel. PyTorch execution trace need to make the appropriate change. It includes capturing ET and replay ET.

Differential Revision: D71152464


