### PR TITLE
Ensure the process id to thread id to node id index is maintained.

### DIFF
--- a/et_replay/execution_trace.py
+++ b/et_replay/execution_trace.py
@@ -357,8 +357,8 @@ class ExecutionTrace:
             input_tensors = self.nodes[id].get_input_tensors()
             output_tensors = self.nodes[id].get_output_tensors()
 
-            # track the various process and threads we have
-            if x["name"] == "__ROOT_THREAD__":
+            # track annonation to get thread ids of root nodes
+            if x["name"] == "[pytorch|profiler|execution_trace|thread]":
                 tid = self.nodes[id].tid
                 self.proc_group[pid][tid] = id
 


### PR DESCRIPTION
Summary: Currently this map is not set since __ROOT_THREAD__ is not a valid node anymore. We can safely read thr pid and tid against a node id and store in this map.

Differential Revision: D71565563


