### PR TITLE
add explicit setting to disable torch nccl timing

### DIFF
--- a/train/comms/pt/comms_utils.py
+++ b/train/comms/pt/comms_utils.py
@@ -1769,6 +1769,12 @@ class ParamCommsBenchBase(ABC):
             default=False,
             help="Toggle to initialize progress group immediately during init_process_group call by passing device_id, see https://pytorch.org/docs/stable/distributed.html#torch.distributed.init_process_group",
         )
+        parser.add_argument(
+            "--enable-torch-nccl-timing",
+            action="store_true",
+            default=False,
+            help="Enable recording start-events for all ProcessGroupNCCL collectives, and compute accurate collective timing per-collective, may have significant performance impact",
+        )
         pass
 
     @abstractmethod
@@ -1830,6 +1836,15 @@ class ParamCommsBenchBase(ABC):
                 )
         else:
             os.environ["MASTER_PORT"] = args.master_port
+
+        # Enabling the "TORCH_NCCL_ENABLE_TIMING" setting can lead to performance regression in benchmark results.
+        # This setting is used to record start-events for all ProcessGroupNCCL collectives, which allows for accurate timing of each collective operation.
+        # However, the it should be used with caution when performance is a critical factor in the benchmark results, since this will add one extra function call
+        # to CUDA kernel start
+        if args.enable_torch_nccl_timing:
+            os.environ["TORCH_NCCL_ENABLE_TIMING"] = "1"
+        else:
+            os.environ["TORCH_NCCL_ENABLE_TIMING"] = "0"
 
 
 class paramCommsBench(ParamCommsBenchMixin, ParamCommsBenchBase):


### PR DESCRIPTION
Summary:
Add a param in the base parser to set `torch_nccl_enable_timing` variable to `False` by default, and only set it to true if user needed.

This value is used only on flight-recorder (for debugging purpose), and significantly affect performance of benchmarking in blocking mode (~30% for small-mid message sizes) if enable

Reviewed By: kingchc

Differential Revision: D72240605


